### PR TITLE
fixed intersection check in solver

### DIFF
--- a/src/compas_timber/connections/solver.py
+++ b/src/compas_timber/connections/solver.py
@@ -33,11 +33,11 @@ class ConnectionSolver(object):
 
     @staticmethod
     def _intersect_with_tolerance(line_a, line_b, tolerance=TOLERANCE):
-            p1, p2 = intersection_segment_segment(line_a, line_b)
-            if p1 is None or p2 is None:
-                return False
-            distance = distance_point_point(p1, p2)
-            return close(distance, tolerance)
+        p1, p2 = intersection_segment_segment(line_a, line_b)
+        if p1 is None or p2 is None:
+            return False
+        distance = distance_point_point(p1, p2)
+        return close(distance, tolerance)
 
     def find_topology(self, beam_a, beam_b, tol=TOLERANCE, max_distance=None):
         if max_distance is None:


### PR DESCRIPTION
Intersection points are found by `intersection_segment_segment` even when line segments don't actually intersect. 
Added check if distance between the intersection points is within a tolerance.

Added `NO_INSTERSECTION` value to the `JointTopology` type so that asking for topology of two beams that don't intersect will not result in an exception.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
