### PR TITLE
componentizing components and uploading wheel as artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
           prefix: "(COMPAS_TIMBER)"
       - name: Copy manual components
         run: |
-          cp src/compas_timber/ghpython/components/ghuser_manual/* src/compas_timber/ghpython/components/ghuser/
+          cp src/compas_timber/ghpython/ghuser_manual/* src/compas_timber/ghpython/components/ghuser/
       - name: Build
         run: |
           python setup.py clean --all sdist bdist_wheel


### PR DESCRIPTION
Added a github action to componentize the components and upload the wheel containing the user-objects as an artifact.

I'm aware of `prefix` not being currently supported by https://github.com/compas-dev/compas-actions.ghpython_components but it fails so gracefully that I just left it. Opened https://github.com/compas-dev/compas-actions.ghpython_components/pull/10 though.