### PR TITLE
removed replacing sc.doc with RhinoDoc

### DIFF
--- a/src/compas_timber/ghpython/components/CT_Bake_BoxMap/code.py
+++ b/src/compas_timber/ghpython/components/CT_Bake_BoxMap/code.py
@@ -5,13 +5,10 @@ import random
 import Rhino
 import Rhino.Geometry as rg
 import rhinoscriptsyntax as rs
-import scriptcontext as sc
 from compas.artists import Artist
 from compas_rhino.conversions import frame_to_rhino
 from Grasshopper.Kernel.GH_RuntimeMessageLevel import Error
 from Grasshopper.Kernel.GH_RuntimeMessageLevel import Warning
-
-from compas_timber.ghpython.ghcomponent_helpers import list_input_valid
 
 
 def create_box_map(pln, sx, sy, sz):
@@ -70,24 +67,20 @@ if not Beams:
 else:
     _inputok = True
 
-if _inputok and Bake:
-    frames = [frame_to_rhino(b.frame) for b in Beam]
-    breps = [Artist(b.get_geometry(True)).draw() for b in Beam]
+try:
+    if _inputok and Bake:
+        frames = [frame_to_rhino(b.frame) for b in Beam]
+        breps = [Artist(b.get_geometry(True)).draw() for b in Beam]
 
-    if frames and breps:
-        rs.EnableRedraw(False)
-        sc.doc = Rhino.RhinoDoc.ActiveDoc
+        if frames and breps:
+            rs.EnableRedraw(False)
+            rhino_doc = Rhino.RhinoDoc.ActiveDoc
 
-        for brep, frame in zip(breps, frames):
-            attributes = None
-            guid = sc.doc.Objects.Add(brep, attributes)
-            boxmap, map_pln = create_box_map(frame, dimx, dimy, dimz)
-            sc.doc.Objects.ModifyTextureMapping(guid, 1, boxmap)
-
-        sc.doc = ghdoc
-        rs.EnableRedraw(True)
-        rs.Redraw()
-else:
-    sc.doc = ghdoc
+            for brep, frame in zip(breps, frames):
+                attributes = None
+                guid = rhino_doc.Objects.Add(brep, attributes)
+                boxmap, map_pln = create_box_map(frame, dimx, dimy, dimz)
+                rhino_doc.Objects.ModifyTextureMapping(guid, 1, boxmap)
+finally:
     rs.EnableRedraw(True)
     rs.Redraw()


### PR DESCRIPTION
Removed the setting of `sc.doc` to `Rhino.RhinoDoc.ActiveDoc` in the baking component.

While this component directly wasn't the cause for the [weird Artist behavior](https://github.com/orgs/gramaziokohler/projects/5/views/1?pane=issue&itemId=20791286), it seems dangerous and unnecessary to touch such global state. However, if this is definitely required, feel free to comment.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
