### PR TITLE
L-Butt joint: re-introduce cut of the cross-beam

### DIFF
--- a/src/compas_timber/connections/l_butt.py
+++ b/src/compas_timber/connections/l_butt.py
@@ -76,8 +76,10 @@ class LButtJoint(Joint):
         main_extend = BeamExtensionFeature(*self.main_beam.extension_to_plane(self.cutting_plane_main))
         main_trim = BeamTrimmingFeature(self.cutting_plane_main)
         cross_extend = BeamExtensionFeature(*self.cross_beam.extension_to_plane(self.cutting_plane_cross))
+        cross_trim = BeamTrimmingFeature(self.cutting_plane_cross)
 
         self.main_beam.add_feature(main_extend)
         self.main_beam.add_feature(main_trim)
         self.cross_beam.add_feature(cross_extend)
-        self.features.extend([main_extend, main_trim, cross_extend])
+        self.cross_beam.add_feature(cross_trim)
+        self.features.extend([main_extend, main_trim, cross_extend, cross_trim])


### PR DESCRIPTION
Resolving #85 

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
