### PR TITLE
added pluggables for puzzle checker

### DIFF
--- a/src/compas_timber/solvers/__init__.py
+++ b/src/compas_timber/solvers/__init__.py
@@ -1,0 +1,77 @@
+"""
+********************************************************************************
+solvers
+********************************************************************************
+
+.. currentmodule:: compas_timber.solvers
+
+.. rst-class:: lead
+
+This module contains pluggable functions for the sequence generating puzzle checker extensions.
+
+Pluggables
+==========
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    next_removable_part
+    create_dissassembly_sequence
+
+"""
+from compas.plugins import pluggable
+from compas.plugins import PluginNotInstalledError
+
+
+@pluggable(category="solvers")
+def next_removable_part(assembly, removed_part_ids, part_ids_to_remove, number_of_parts_to_remove, **kwargs):
+    """Returns the next part to remove from the assembly.
+
+    One or more parts of the assembly are choosen to be removed next based on the particular solver implementation.
+
+    Parameters
+    ----------
+    assembly : `compas.datastructures.Assembly`
+        The assembly to remove parts from.
+    removed_part_ids : list
+        The list of part ids that have already been removed.
+    part_ids_to_remove : list
+        The list of part ids that are to be removed.
+    number_of_parts_to_remove : int
+        The number of parts to remove from the assembly.
+
+    Returns
+    -------
+    :class:`compas_monosashi.sequencer.Step`
+        A step which contains one or more Instructions which specify
+        the parts to remove from the assembly and the corresponding removal direction.
+
+    """
+    raise PluginNotInstalledError
+
+
+@pluggable(category="solvers")
+def create_dissassembly_sequence(assembly, **kwargs):
+    """Returns a sequence of steps to disassemble the assembly.
+
+    This function's implementation decides on the strategy used to generate the collection of
+    steps to disassemble the assembly and determines their order.
+
+    The order of steps can be revered in order to generate a sequence of steps to assemble the assembly.
+
+    Parameters
+    ----------
+    assembly : `compas.datastructures.Assembly`
+        The assembly to disassemble.
+
+    Returns
+    -------
+    :class:`compas_monosashi.sequencer.BuildingPlan`
+        A sequence of steps to disassemble the assembly.
+
+    See Also
+    --------
+    :func:`~compas_timber.solvers.next_removable_part`
+
+    """
+    raise PluginNotInstalledError


### PR DESCRIPTION
Added pluggables for sequencing the assembly of a `TimberAssembly` following initial design [here](https://miro.com/app/board/uXjVM7RqN-Y=/).

The plugins will go into a separate package to be published soon.

Expected output types can be checked out [here](https://github.com/gramaziokohler/monosashi/blob/main/src/compas_monosashi/sequencer.py).

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
