### PR TITLE
choose explicitly GH artist in show assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Adapted the `Data` interface of `Beam` and `Assembly` according to the changes in COMPAS core.
 * Beam geometry is created on demand.
 * Adapted the `Data` interface of `Joint` and its implementations according to the changes in COMPAS core.
+* Explicitly choosing `Grasshopper` context for the `Artist` in `ShowAssembly` component.
 
 ### Removed
 

--- a/src/compas_timber/ghpython/components/CT_ShowAssembly/code.py
+++ b/src/compas_timber/ghpython/components/CT_ShowAssembly/code.py
@@ -11,6 +11,6 @@ class ShowAssembly(component):
 
         Brep = []
         for beam in Assembly.beams:
-            Brep.append(Artist(beam.geometry).draw())
+            Brep.append(Artist(beam.geometry, context="Grasshopper").draw())
 
         return Brep


### PR DESCRIPTION
Explicitly selecting a GH Artist in the ShowAssembly component.

Occasionally (e.g. when playing with the `sc.doc` assignment) the COMPAS might insist on using the `RhinoArtist` which produces weird behavior in GH. When running GH components we're anyways always in GH.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
