### PR TITLE
explicit key serialization in Beam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Explicitly added attribute `key` to (de)serialization of `Beam`.
+
 ### Removed
 
 

--- a/src/compas_timber/parts/beam.py
+++ b/src/compas_timber/parts/beam.py
@@ -124,17 +124,19 @@ class Beam(Part):
     def data(self):
         data = {
             "frame": self.frame,
+            "key": self.key,
             "width": self.width,
             "height": self.height,
             "length": self.length,
             "geometry_type": self.geometry_type,
         }
-        data.update(self.attributes)
         return data
 
     @classmethod
     def from_data(cls, data):
-        return cls(**data)
+        instance = cls(**data)
+        instance.key = data["key"]
+        return instance
 
     @property
     def tolerance(self):

--- a/tests/compas_timber/test_assembly.py
+++ b/tests/compas_timber/test_assembly.py
@@ -1,5 +1,7 @@
 from copy import deepcopy
 
+from compas.data import json_dumps
+from compas.data import json_loads
 from compas.geometry import Frame
 from compas.geometry import Point
 from compas.geometry import Vector
@@ -117,6 +119,21 @@ def test_parts_joined(mocker):
 
     assert A.are_parts_joined([B1, B2])
     assert not A.are_parts_joined([B1, B3])
+
+
+def test_beams_have_keys_after_serialization():
+    A = TimberAssembly()
+    B1 = Beam(Frame.worldXY(), length=1.0, width=0.1, height=0.1, geometry_type="mesh")
+    B2 = Beam(Frame.worldYZ(), length=1.0, width=0.1, height=0.1, geometry_type="mesh")
+    B3 = Beam(Frame.worldZX(), length=1.0, width=0.1, height=0.1, geometry_type="mesh")
+    A.add_beam(B1)
+    A.add_beam(B2)
+    A.add_beam(B3)
+    keys = [beam.key for beam in A.beams]
+
+    A = json_loads(json_dumps(A))
+
+    assert keys == [beam.key for beam in A.beams]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Somewhat illegally fixed issue with beams not having keys after (de)serializing.

As `key` is an attribute of `Beam`s parent class, it would be more ideal to fix this in `Part` but due to the mismatch between the two and also to the fact that `Assembly` will get reworked soon, I think it'd be better this way.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
