### PR TITLE
frame.data instead of live frame in Beam.data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Installing dependencies
         run: |
-          curl -o compas.tar.gz -LJO https://pypi.debian.net/compas/COMPAS-2.0.0a1.tar.gz
+          curl -o compas.tar.gz -LJO https://pypi.debian.net/compas/COMPAS-2.0.0a2.tar.gz
           curl -o ironpython-pytest.tar.gz -LJO https://pypi.debian.net/ironpython-pytest/latest
           choco install ironpython --version=2.7.8.1
           ipy -X:Frames -m ensurepip

--- a/.github/workflows/ironpython.yml
+++ b/.github/workflows/ironpython.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          curl -o compas.tar.gz -LJO https://pypi.debian.net/compas/COMPAS-2.0.0a1.tar.gz
+          curl -o compas.tar.gz -LJO https://pypi.debian.net/compas/COMPAS-2.0.0a2.tar.gz
           curl -o ironpython-pytest.tar.gz -LJO https://pypi.debian.net/ironpython-pytest/latest
           choco install ironpython --version=2.7.8.1
           ipy -X:Frames -m ensurepip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 rtree
-compas==2.0.0a1
+compas==2.0.0a2

--- a/src/compas_timber/connections/t_butt.py
+++ b/src/compas_timber/connections/t_butt.py
@@ -1,4 +1,4 @@
-from compas.geometry import BrepTrimmingError
+from compas.brep import BrepTrimmingError
 from compas.geometry import Frame
 
 from compas_timber.parts import BeamTrimmingFeature

--- a/src/compas_timber/connections/x_halflap.py
+++ b/src/compas_timber/connections/x_halflap.py
@@ -1,4 +1,4 @@
-from compas.geometry import Brep
+from compas.brep import Brep
 from compas.geometry import Frame
 from compas.geometry import Line
 from compas.geometry import Plane

--- a/src/compas_timber/parts/beam.py
+++ b/src/compas_timber/parts/beam.py
@@ -123,7 +123,7 @@ class Beam(Part):
     @property
     def data(self):
         data = {
-            "frame": self.frame,
+            "frame": self.frame.data,
             "key": self.key,
             "width": self.width,
             "height": self.height,
@@ -134,7 +134,9 @@ class Beam(Part):
 
     @classmethod
     def from_data(cls, data):
-        instance = cls(**data)
+        instance = cls(
+            Frame.from_data(data["frame"]), data["length"], data["width"], data["height"], data["geometry_type"]
+        )
         instance.key = data["key"]
         return instance
 

--- a/src/compas_timber/parts/beam.py
+++ b/src/compas_timber/parts/beam.py
@@ -1,8 +1,8 @@
 import math
 
+from compas.brep import Brep
 from compas.datastructures import Mesh
 from compas.geometry import Box
-from compas.geometry import Brep
 from compas.geometry import Frame
 from compas.geometry import Line
 from compas.geometry import Plane

--- a/src/compas_timber/parts/features.py
+++ b/src/compas_timber/parts/features.py
@@ -1,5 +1,5 @@
-from compas.geometry import Brep
-from compas.geometry import BrepTrimmingError
+from compas.brep import Brep
+from compas.brep import BrepTrimmingError
 from compas.geometry import Frame
 from compas.datastructures import GeometricFeature
 from compas.datastructures import ParametricFeature


### PR DESCRIPTION
* Bumped COMPAS dependency to `2.0.0a2`.
* Matched serialization of `Beam` to `Part` so that both could be interchangeably used when deserializing.