### PR TITLE
joints support multiple topologies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `FindBeamByGuid` component.
 * Bumped required COMPAS version to `2.0.0beta.2`.
 * Changed docs theme to the new `sphinx_compas2_theme`.
+* Joints now support a list of topologies instead of just their native topology.
 
 ### Removed
 

--- a/src/compas_timber/connections/french_ridge_lap.py
+++ b/src/compas_timber/connections/french_ridge_lap.py
@@ -37,7 +37,7 @@ class FrenchRidgeLapJoint(Joint):
 
     """
 
-    SUPPORTED_TOPOLOGY = JointTopology.TOPO_L
+    SUPPORTED_TOPOLOGY = [JointTopology.TOPO_L]
 
     def __init__(self, beam_a=None, beam_b=None, gap=0.0, frame=None, key=None):
         super(FrenchRidgeLapJoint, self).__init__(frame=frame, key=key)

--- a/src/compas_timber/connections/joint.py
+++ b/src/compas_timber/connections/joint.py
@@ -61,7 +61,7 @@ class Joint(Data):
 
     """
 
-    SUPPORTED_TOPOLOGY = JointTopology.TOPO_UNKNOWN
+    SUPPORTED_TOPOLOGY = [JointTopology.TOPO_UNKNOWN]
 
     def __init__(self, frame=None, key=None):
         super(Joint, self).__init__()

--- a/src/compas_timber/connections/l_butt.py
+++ b/src/compas_timber/connections/l_butt.py
@@ -37,7 +37,7 @@ class LButtJoint(Joint):
 
     """
 
-    SUPPORTED_TOPOLOGY = JointTopology.TOPO_L
+    SUPPORTED_TOPOLOGY = [JointTopology.TOPO_L, JointTopology.TOPO_T, JointTopology.TOPO_X]
 
     def __init__(self, main_beam=None, cross_beam=None, gap=0.0, frame=None, key=None):
         super(LButtJoint, self).__init__(frame=frame, key=key)

--- a/src/compas_timber/connections/l_miter.py
+++ b/src/compas_timber/connections/l_miter.py
@@ -39,7 +39,7 @@ class LMiterJoint(Joint):
 
     """
 
-    SUPPORTED_TOPOLOGY = JointTopology.TOPO_L
+    SUPPORTED_TOPOLOGY = [JointTopology.TOPO_L, JointTopology.TOPO_T, JointTopology.TOPO_X]
 
     def __init__(self, beam_a=None, beam_b=None, cutoff=None, frame=None, key=None):
         super(LMiterJoint, self).__init__(frame, key)

--- a/src/compas_timber/connections/t_butt.py
+++ b/src/compas_timber/connections/t_butt.py
@@ -37,7 +37,7 @@ class TButtJoint(Joint):
 
     """
 
-    SUPPORTED_TOPOLOGY = JointTopology.TOPO_T
+    SUPPORTED_TOPOLOGY = [JointTopology.TOPO_T, JointTopology.TOPO_L, JointTopology.TOPO_X]
 
     def __init__(self, main_beam=None, cross_beam=None, gap=None, frame=None, key=None):
         super(TButtJoint, self).__init__(frame, key)

--- a/src/compas_timber/connections/x_halflap.py
+++ b/src/compas_timber/connections/x_halflap.py
@@ -18,7 +18,7 @@ from .solver import JointTopology
 
 
 class XHalfLapJoint(Joint):
-    SUPPORTED_TOPOLOGY = JointTopology.TOPO_X
+    SUPPORTED_TOPOLOGY = [JointTopology.TOPO_X, JointTopology.TOPO_T, JointTopology.TOPO_L]
 
     def __init__(self, beam_a=None, beam_b=None, cut_plane_choice=None, frame=None, key=None):
         super(XHalfLapJoint, self).__init__(frame, key)

--- a/src/compas_timber/ghpython/components/CT_AutomaticJoints/code.py
+++ b/src/compas_timber/ghpython/components/CT_AutomaticJoints/code.py
@@ -34,10 +34,15 @@ class AutotomaticJoints(component):
             for rule in rules:
                 if not rule.comply(pair):
                     continue
-                if rule.joint_type.SUPPORTED_TOPOLOGY != detected_topo:
-                    msg = "Conflict detected! Beams: {}, {} meet with topology: {} but rule assigns: {}"
+                if detected_topo not in rule.joint_type.SUPPORTED_TOPOLOGY:
+                    msg = "Conflict detected! Beams: {}, {} meet with topology: {} but rule assigns: {} which supports: {}"
                     Info.append(
-                        msg.format(beam_a, beam_b, JointTopology.get_name(detected_topo), rule.joint_type.__name__)
+                        msg.format(
+                            beam_a,
+                            beam_b,
+                            JointTopology.get_name(detected_topo), rule.joint_type.__name__,
+                            [JointTopology.get_name(t) for t in rule.joint_type.SUPPORTED_TOPOLOGY],
+                        )
                     )
                     continue
                 # sort by category to allow beam role by order (main beam first, cross beam second)

--- a/src/compas_timber/ghpython/components/CT_AutomaticJoints/code.py
+++ b/src/compas_timber/ghpython/components/CT_AutomaticJoints/code.py
@@ -40,7 +40,8 @@ class AutotomaticJoints(component):
                         msg.format(
                             beam_a,
                             beam_b,
-                            JointTopology.get_name(detected_topo), rule.joint_type.__name__,
+                            JointTopology.get_name(detected_topo),
+                            rule.joint_type.__name__,
                             [JointTopology.get_name(t) for t in rule.joint_type.SUPPORTED_TOPOLOGY],
                         )
                     )

--- a/src/compas_timber/ghpython/components/CT_JointDef_FrenchRidgeLap/code.py
+++ b/src/compas_timber/ghpython/components/CT_JointDef_FrenchRidgeLap/code.py
@@ -27,7 +27,7 @@ class FrenchRidgeLapDefinition(component):
         Joint = []
         for main, cross in zip(MainBeam, CrossBeam):
             topology, _, _ = ConnectionSolver().find_topology(main, cross)
-            if topology != FrenchRidgeLapJoint.SUPPORTED_TOPOLOGY:
+            if topology not in FrenchRidgeLapJoint.SUPPORTED_TOPOLOGY:
                 self.AddRuntimeMessage(
                     Warning,
                     "Beams meet with topology: {} which does not agree with joint of type: {}".format(

--- a/src/compas_timber/ghpython/components/CT_JointDef_LButt/code.py
+++ b/src/compas_timber/ghpython/components/CT_JointDef_LButt/code.py
@@ -27,7 +27,7 @@ class LButtDefinition(component):
         Joint = []
         for main, cross in zip(MainBeam, CrossBeam):
             topology, _, _ = ConnectionSolver().find_topology(main, cross)
-            if topology != LButtJoint.SUPPORTED_TOPOLOGY:
+            if topology not in LButtJoint.SUPPORTED_TOPOLOGY:
                 self.AddRuntimeMessage(
                     Warning,
                     "Beams meet with topology: {} which does not agree with joint of type: {}".format(

--- a/src/compas_timber/ghpython/components/CT_JointDef_LMiter/code.py
+++ b/src/compas_timber/ghpython/components/CT_JointDef_LMiter/code.py
@@ -27,7 +27,7 @@ class LMiterDefinition(component):
         Joint = []
         for beam_a, beam_b in zip(BeamA, BeamB):
             topology, _, _ = ConnectionSolver().find_topology(beam_a, beam_b)
-            if topology != LMiterJoint.SUPPORTED_TOPOLOGY:
+            if topology not in LMiterJoint.SUPPORTED_TOPOLOGY:
                 self.AddRuntimeMessage(
                     Warning,
                     "Beams meet with topology: {} which does not agree with joint of type: {}".format(

--- a/src/compas_timber/ghpython/components/CT_JointDef_TButt/code.py
+++ b/src/compas_timber/ghpython/components/CT_JointDef_TButt/code.py
@@ -27,7 +27,7 @@ class LMiterDefinition(component):
         Joint = []
         for main, cross in zip(MainBeam, CrossBeam):
             topology, _, _ = ConnectionSolver().find_topology(main, cross)
-            if topology != TButtJoint.SUPPORTED_TOPOLOGY:
+            if topology not in TButtJoint.SUPPORTED_TOPOLOGY:
                 self.AddRuntimeMessage(
                     Warning,
                     "Beams meet with topology: {} which does not agree with joint of type: {}".format(

--- a/src/compas_timber/ghpython/components/CT_JointDef_XHalfLap/code.py
+++ b/src/compas_timber/ghpython/components/CT_JointDef_XHalfLap/code.py
@@ -27,7 +27,7 @@ class XHalfLapDefinition(component):
         for main, cross in zip(MainBeam, CrossBeam):
             max_distance_from_beams = max([main.width, main.height, cross.width, cross.height])
             topology, _, _ = ConnectionSolver().find_topology(main, cross, max_distance=max_distance_from_beams)
-            if topology != XHalfLapJoint.SUPPORTED_TOPOLOGY:
+            if topology not in XHalfLapJoint.SUPPORTED_TOPOLOGY:
                 self.AddRuntimeMessage(
                     Warning,
                     "Beams meet with topology: {} which does not agree with joint of type: {}".format(


### PR DESCRIPTION
solves https://github.com/gramaziokohler/compas_timber/issues/151

Joints support a list of topologies instead of just their assumed native topology. This lets the user assign e.g. Half-lap even when the detected topology is `JointTopology.TOPO_T`.

![image](https://github.com/gramaziokohler/compas_timber/assets/3398309/76f649a0-4620-46e3-9c19-f19dcc1b692b)
![image](https://github.com/gramaziokohler/compas_timber/assets/3398309/f56cc52b-4c94-4dc1-ae43-ed852f1da7e0)

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
