### PR TITLE
Baking freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `FindBeamByGuid` component.
 * Bumped required COMPAS version to `2.0.0beta.2`.
 * Changed docs theme to the new `sphinx_compas2_theme`.
+* Re-worked component `BakeBoxMap` to advanced mode.
+* Removed call to `rs.Redraw()` in `BakeBoxMap` which was causing GH document to lock (cannot drag).
 
 ### Removed
 

--- a/src/compas_timber/ghpython/components/CT_Bake_BoxMap/code.py
+++ b/src/compas_timber/ghpython/components/CT_Bake_BoxMap/code.py
@@ -53,7 +53,6 @@ class BakeBoxMap(component):
                     ActiveDoc.Objects.ModifyTextureMapping(guid, 1, boxmap)
         finally:
             rs.EnableRedraw(True)
-            rs.Redraw()
 
     @staticmethod
     def create_box_map(pln, sx, sy, sz):

--- a/src/compas_timber/ghpython/components/CT_Bake_BoxMap/metadata.json
+++ b/src/compas_timber/ghpython/components/CT_Bake_BoxMap/metadata.json
@@ -6,7 +6,7 @@
     "description": "Bakes Beam objects with a BoxMapping (by default the material is applied 'by layer' and has to be defined in the layer the objects are baked to).",
     "exposure": 4,
     "ghpython": {
-        "isAdvancedMode": false,
+        "isAdvancedMode": true,
         "iconDisplay": 0,
         "inputParameters": [
             {


### PR DESCRIPTION
Isolated the call to `rs.Redraw()` as the cause of the GH document locking when using a button to trigger back and clicking really fast. Baking seems to work without call to redraw but need further testing to make sure it's really not needed - @jonashaldemann could you help out?

Also reworked the component to be written in advanced mode (class based).

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
