### PR TITLE
updated GH component categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `BeamFromCurve` GH component accepts now referenced Rhino curves, referenced Rhino object IDs and internalized lines. 
 * Fixed `FeatureError` when L-Butt applies the cutting plane.
 * Fixed T-Butt doesn't get extended to cross beam's plane.
+* Changed GH Categories for joint rules
 
 ### Removed
 

--- a/src/compas_timber/ghpython/components/CT_Assembly/metadata.json
+++ b/src/compas_timber/ghpython/components/CT_Assembly/metadata.json
@@ -4,7 +4,7 @@
     "category": "COMPAS Timber",
     "subcategory": "Assembly",
     "description": "Creates an Assembly",
-    "exposure": 4,
+    "exposure": 2,
     "ghpython": {
         "isAdvancedMode": true,
         "iconDisplay": 0,

--- a/src/compas_timber/ghpython/components/CT_Attributes_Set/metadata.json
+++ b/src/compas_timber/ghpython/components/CT_Attributes_Set/metadata.json
@@ -38,14 +38,14 @@
                 "description": "Category.",
                 "typeHintID": "str",
                 "scriptParamAccess": 1
-            },         
+            },
             {
                 "name": "update",
                 "description": "Set to True to apply. Nothing happens if None or False.",
                 "typeHintID": "bool",
                 "scriptParamAccess": 0
             }
-            
+
         ],
         "outputParameters": [
 

--- a/src/compas_timber/ghpython/components/CT_BTLx/metadata.json
+++ b/src/compas_timber/ghpython/components/CT_BTLx/metadata.json
@@ -2,7 +2,7 @@
     "name": "WriteBTLx",
     "nickname": "WriteBTLx",
     "category": "COMPAS Timber",
-    "subcategory": "Utils",
+    "subcategory": "Fabrication",
     "description": "Writes a BTLx file for machining of assembly parts.",
     "exposure": 4,
     "ghpython": {

--- a/src/compas_timber/ghpython/components/CT_Joint_Rule_Category/metadata.json
+++ b/src/compas_timber/ghpython/components/CT_Joint_Rule_Category/metadata.json
@@ -2,7 +2,7 @@
     "name": "Category Joints Rules ",
     "nickname": "JointsByCategory",
     "category": "COMPAS Timber",
-    "subcategory": "Joints",
+    "subcategory": "Joint Rules",
     "description": "Defines which Joint type will be applied in the Automatic Joints component for connecting Beams with the given Category attributes. This overrides Topological Joint rules and is overriden by Direct joint rules",
     "exposure": 2,
     "ghpython": {

--- a/src/compas_timber/ghpython/components/CT_Joint_Rule_Direct/metadata.json
+++ b/src/compas_timber/ghpython/components/CT_Joint_Rule_Direct/metadata.json
@@ -2,9 +2,9 @@
     "name": "Direct Joint Rules",
     "nickname": "DirectJoints",
     "category": "COMPAS Timber",
-    "subcategory": "Joints",
+    "subcategory": "Joint Rules",
     "description": "Generates a direct joint between two beams. This overrides other joint rules.",
-    "exposure": 4,
+    "exposure": 2,
     "ghpython": {
         "isAdvancedMode": true,
         "iconDisplay": 0,

--- a/src/compas_timber/ghpython/components/CT_Joint_Rule_Topology/metadata.json
+++ b/src/compas_timber/ghpython/components/CT_Joint_Rule_Topology/metadata.json
@@ -2,7 +2,7 @@
     "name": "Topological Joint Rules",
     "nickname": "JointsByTopo",
     "category": "COMPAS Timber",
-    "subcategory": "Joints",
+    "subcategory": "Joint Rules",
     "description": "makes rules to apply joint types for each topology type.",
     "exposure": 2,
     "ghpython": {


### PR DESCRIPTION
updated the categories and exposure level for GH components.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
