### PR TITLE
fixed invalid exposure setting in components

### DIFF
--- a/src/compas_timber/ghpython/components/CT_ShowJointTypes/metadata.json
+++ b/src/compas_timber/ghpython/components/CT_ShowJointTypes/metadata.json
@@ -4,7 +4,7 @@
     "category": "COMPAS Timber",
     "subcategory": "Show",
     "description": "Shows the names of the defined Joints.",
-    "exposure": 6,
+    "exposure": 8,
     "ghpython": {
         "isAdvancedMode": true,
         "iconDisplay": 0,

--- a/src/compas_timber/ghpython/components/CT_ShowTopologyTypes/metadata.json
+++ b/src/compas_timber/ghpython/components/CT_ShowTopologyTypes/metadata.json
@@ -4,7 +4,7 @@
     "category": "COMPAS Timber",
     "subcategory": "Show",
     "description": "Shows the names of the connection topology types.",
-    "exposure": 6,
+    "exposure": 8,
     "ghpython": {
         "isAdvancedMode": true,
         "iconDisplay": 0,


### PR DESCRIPTION
Fixed an invalid exposure setting in some components.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
