### PR TITLE
Feature priorities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added new `FeaturePriority` enumeration.
+* Added attribute `priority` to `Feature`.
+
 ### Changed
 
 ### Removed

--- a/src/compas_timber/consumers/geometry.py
+++ b/src/compas_timber/consumers/geometry.py
@@ -272,7 +272,7 @@ class BrepGeometryConsumer(object):
 
     def _apply_features(self, geometry, features):
         debug_info = []
-        for feature in features:
+        for feature in sorted(features, key=lambda f: f.PRIORITY):
             cls = self.FEATURE_MAP.get(type(feature), None)
             if not cls:
                 raise ValueError("No applicator found for feature type: {}".format(type(feature)))

--- a/src/compas_timber/parts/__init__.py
+++ b/src/compas_timber/parts/__init__.py
@@ -3,6 +3,7 @@ from .features import CutFeature
 from .features import DrillFeature
 from .features import MillVolume
 from .features import BrepSubtraction
+from .features import FeaturePriority
 
 __all__ = [
     "Beam",
@@ -10,4 +11,5 @@ __all__ = [
     "DrillFeature",
     "MillVolume",
     "BrepSubtraction",
+    "FeaturePriority",
 ]

--- a/src/compas_timber/parts/beam.py
+++ b/src/compas_timber/parts/beam.py
@@ -88,6 +88,8 @@ class Beam(Part):
         self.height = height
         self.length = length
         self.features = []
+        self.attributes = {}
+        self.attributes.update(kwargs)
         self._blank_extensions = {}
 
     @property
@@ -98,6 +100,9 @@ class Beam(Part):
             "width": self.width,
             "height": self.height,
             "length": self.length,
+            # joinery features are readded when deserializing via the assembly
+            "features": [feature for feature in self.features if not feature.is_joinery],
+            "attributes": self.attributes,
         }
         return data
 
@@ -105,6 +110,8 @@ class Beam(Part):
     def __from_data__(cls, data):
         instance = cls(Frame.__from_data__(data["frame"]), data["length"], data["width"], data["height"])
         instance.key = data["key"]
+        instance.features = data["features"]
+        instance.attributes.update(data.get("attributes", {}))
         return instance
 
     @property

--- a/src/compas_timber/parts/features.py
+++ b/src/compas_timber/parts/features.py
@@ -15,6 +15,7 @@ class Feature(Data):
         Indicates whether this feature is a result of joinery.
 
     """
+
     PRIORITY = FeaturePriority.EARLY
 
     def __init__(self, name=None, is_joinery=True):
@@ -64,6 +65,7 @@ class DrillFeature(Feature):
         The length (depth?) of the drill hole.
 
     """
+
     PRIORITY = FeaturePriority.LATER
 
     def __init__(self, line, diameter, length, **kwargs):

--- a/src/compas_timber/parts/features.py
+++ b/src/compas_timber/parts/features.py
@@ -1,6 +1,11 @@
 from compas.data import Data
 
 
+class FeaturePriority(object):
+    EARLY = 0
+    LATER = 1
+
+
 class Feature(Data):
     """
 
@@ -10,8 +15,9 @@ class Feature(Data):
         Indicates whether this feature is a result of joinery.
 
     """
+    PRIORITY = FeaturePriority.EARLY
 
-    def __init__(self, name=None, is_joinery=False):
+    def __init__(self, name=None, is_joinery=True):
         super(Feature, self).__init__(name)
         self._is_joiney = is_joinery
 
@@ -58,6 +64,7 @@ class DrillFeature(Feature):
         The length (depth?) of the drill hole.
 
     """
+    PRIORITY = FeaturePriority.LATER
 
     def __init__(self, line, diameter, length, **kwargs):
         super(DrillFeature, self).__init__(**kwargs)


### PR DESCRIPTION
* Features have now priorities (workaround for nasty issue applying certain brep subtractions before trimming)
* `Beam.attributes` now gets serialized.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [x] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
