### PR TITLE
these fixes are needed  for the hangar model to work

### DIFF
--- a/src/compas_timber/connections/butt_joint.py
+++ b/src/compas_timber/connections/butt_joint.py
@@ -115,7 +115,7 @@ class ButtJoint(Joint):
         self.reference_side_index_cross, _ = self.get_face_most_towards_beam(
             self.main_beam, self.cross_beam, ignore_ends=False
         )
-        if self.reject_i and self.reference_side_index in [4, 5]:
+        if self.reject_i and self.reference_side_index_cross in [4, 5]:
             raise BeamJoinningError(
                 beams=self.beams, joint=self, debug_info="Beams are in I topology and reject_i flag is True"
             )

--- a/src/compas_timber/connections/l_butt.py
+++ b/src/compas_timber/connections/l_butt.py
@@ -121,10 +121,9 @@ class LButtJoint(ButtJoint):
         if self.features:
             self.main_beam.remove_features(self.features)
         start_main, start_cross = None, None
-
+        main_cutting_plane = self.get_main_cutting_plane()[0]
+        cross_cutting_plane = self.get_cross_cutting_plane()
         try:
-            main_cutting_plane = self.get_main_cutting_plane()[0]
-            cross_cutting_plane = self.get_cross_cutting_plane()
             start_main, end_main = self.main_beam.extension_to_plane(main_cutting_plane)
             start_cross, end_cross = self.cross_beam.extension_to_plane(cross_cutting_plane)
         except BeamJoinningError as be:


### PR DESCRIPTION
These allow the hangar model to work. the one in butt_joint was a variable I forgot to change.

the changes in the L-butt joint should not pose any problem. the functions that I moved to outside the `try` should not fail.

### What type of change is this?

- [`x`] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
