### PR TITLE
added center_of_mass and volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+* Added `center_of_mass` property to Assembly class.
+* Added `volume` property to Assembly class.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+
 * Added `center_of_mass` property to Assembly class.
 * Added `volume` property to Assembly class.
 

--- a/src/compas_timber/assembly/assembly.py
+++ b/src/compas_timber/assembly/assembly.py
@@ -208,7 +208,7 @@ class TimberAssembly(Assembly):
 
         Returns
         -------
-        list
+        compas.geometry.Point
             The center of mass of the assembly.
 
         """
@@ -226,12 +226,12 @@ class TimberAssembly(Assembly):
 
     @property
     def volume(self):
-        """Returns the center of mass of the assembly.
+        """Returns the volume of the assembly.
 
         Returns
         -------
-        list
-            The center of mass of the assembly.
+        float
+            The sum of the volumes of all beam.blank's in the assembly.
 
         """
         return sum([beam.blank.volume for beam in self._beams])

--- a/src/compas_timber/assembly/assembly.py
+++ b/src/compas_timber/assembly/assembly.py
@@ -218,12 +218,12 @@ class TimberAssembly(Assembly):
         for beam in self._beams:
             vol = beam.blank.volume
             point = beam.blank_frame.point
-            point += beam.blank_frame.xaxis * (beam.blank_length / 2) 
-            total_vol += vol 
+            point += beam.blank_frame.xaxis * (beam.blank_length / 2)
+            total_vol += vol
             total_position += point * vol
 
         return Point(*total_position) * (1.0 / total_vol)
-    
+
     @property
     def volume(self):
         """Returns the center of mass of the assembly.

--- a/src/compas_timber/assembly/assembly.py
+++ b/src/compas_timber/assembly/assembly.py
@@ -1,6 +1,6 @@
 from compas.datastructures import Assembly
 from compas.datastructures import AssemblyError
-
+from compas.geometry import Point
 from compas_timber.connections import Joint
 from compas_timber.connections import BeamJoinningError
 from compas_timber.parts import Beam
@@ -201,3 +201,37 @@ class TimberAssembly(Assembly):
     @property
     def topologies(self):
         return self._topologies
+
+    @property
+    def center_of_mass(self):
+        """Returns the center of mass of the assembly.
+
+        Returns
+        -------
+        list
+            The center of mass of the assembly.
+
+        """
+        total_vol = 0
+        total_position = Point(0, 0, 0)
+
+        for beam in self._beams:
+            vol = beam.blank.volume
+            point = beam.blank_frame.point
+            point += beam.blank_frame.xaxis * (beam.blank_length / 2) 
+            total_vol += vol 
+            total_position += point * vol
+
+        return Point(*total_position) * (1.0 / total_vol)
+    
+    @property
+    def volume(self):
+        """Returns the center of mass of the assembly.
+
+        Returns
+        -------
+        list
+            The center of mass of the assembly.
+
+        """
+        return sum([beam.blank.volume for beam in self._beams])


### PR DESCRIPTION
this adds center of mass and volume to the `Assembly` class. These properties are useful for planning assembly with cranes or helicopters. 

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
