### PR TITLE
Reference frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `ref_frame` attribute to `Beam`.
+* Added `ref_sides` attribute to `Beam`.
+
 ### Changed
 
 * Fixed error in BakeWithBoxMap component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `ref_frame` attribute to `Beam`.
 * Added `ref_sides` attribute to `Beam`.
+* Added `ref_edges` attribute to `Beam`.
 
 ### Changed
 

--- a/src/compas_timber/elements/beam.py
+++ b/src/compas_timber/elements/beam.py
@@ -57,6 +57,8 @@ class Beam(Element):
         Reference frame for machining processes according to BTLx standard.
     ref_sides : tuple(:class:`~compas.geometry.Frame`)
         A tuple containing the 6 frames representing the sides of the beam according to BTLx standard.
+    ref_edges : tuple(:class:`~compas.geometry.Line`)
+        A tuple containing the 4 lines representing the long edges of the beam according to BTLx standard.
     faces : list(:class:`~compas.geometry.Frame`)
         A list of frames representing the 6 faces of this beam.
         0: +y (side's frame normal is equal to the beam's Y positive direction)
@@ -188,6 +190,17 @@ class Beam(Element):
             Frame(rs4_point, self.ref_frame.xaxis, self.ref_frame.yaxis, name="RS_4"),
             Frame(rs5_point, self.ref_frame.zaxis, self.ref_frame.yaxis, name="RS_5"),
             Frame(rs6_point, self.ref_frame.zaxis, -self.ref_frame.yaxis, name="RS_6"),
+        )
+
+    @property
+    def ref_edges(self):
+        # so tuple is not created every time
+        ref_sides = self.ref_sides
+        return (
+            Line(ref_sides[0].point, ref_sides[0].point + ref_sides[0].xaxis * self.blank_length, name="RE_1"),
+            Line(ref_sides[1].point, ref_sides[1].point + ref_sides[1].xaxis * self.blank_length, name="RE_2"),
+            Line(ref_sides[2].point, ref_sides[2].point + ref_sides[2].xaxis * self.blank_length, name="RE_3"),
+            Line(ref_sides[3].point, ref_sides[3].point + ref_sides[3].xaxis * self.blank_length, name="RE_4"),
         )
 
     @property

--- a/src/compas_timber/elements/beam.py
+++ b/src/compas_timber/elements/beam.py
@@ -94,6 +94,7 @@ class Beam(Element):
         self.attributes.update(kwargs)
         self._blank_extensions = {}
         self.debug_info = []
+        self.ref_frame = self._calculate_ref_frame()
 
     def __repr__(self):
         # type: () -> str
@@ -354,6 +355,20 @@ class Beam(Element):
         depth_offset = boxframe.xaxis * xsize * 0.5
         boxframe.point += depth_offset
         return Box(xsize, ysize, zsize, frame=boxframe)
+
+    def _calculate_ref_frame(self):
+        """Calculate the reference frame of the beam.
+
+        Returns
+        -------
+        :class:`~compas.geometry.Frame`
+
+        """
+        assert self.frame
+        ref_point = self.frame.point.copy()
+        ref_point += self.frame.yaxis * self.width * 0.5
+        ref_point -= self.frame.zaxis * self.height * 0.5
+        return Frame(ref_point, self.frame.xaxis, self.frame.zaxis)
 
     # ==========================================================================
     # Featrues

--- a/src/compas_timber/elements/beam.py
+++ b/src/compas_timber/elements/beam.py
@@ -53,6 +53,10 @@ class Beam(Element):
         A feature-less box representing the parametric geometry of this beam.
     blank : :class:`~compas.geometry.Box`
         A feature-less box representing the material stock geometry to produce this beam.
+    ref_frame : :class:`~compas.geometry.Frame`
+        Reference frame for machining processes according to BTLx standard.
+    ref_sides : tuple(:class:`~compas.geometry.Frame`)
+        A tuple containing the 6 frames representing the sides of the beam according to BTLx standard.
     faces : list(:class:`~compas.geometry.Frame`)
         A list of frames representing the 6 faces of this beam.
         0: +y (side's frame normal is equal to the beam's Y positive direction)
@@ -169,6 +173,7 @@ class Beam(Element):
     @property
     def ref_sides(self):
         # type: () -> tuple[Frame, Frame, Frame, Frame, Frame, Frame]
+        # See: https://design2machine.com/btlx/BTLx_2_2_0.pdf
         # TODO: cache these
         rs1_point = self.ref_frame.point
         rs2_point = rs1_point + self.ref_frame.yaxis * self.height

--- a/src/compas_timber/elements/beam.py
+++ b/src/compas_timber/elements/beam.py
@@ -177,12 +177,12 @@ class Beam(Element):
         rs5_point = rs1_point
         rs6_point = rs1_point + self.ref_frame.xaxis * self.blank_length + self.ref_frame.yaxis * self.height
         return (
-            Frame(rs1_point, self.ref_frame.xaxis, self.ref_frame.zaxis),
-            Frame(rs2_point, self.ref_frame.xaxis, -self.ref_frame.yaxis),
-            Frame(rs3_point, self.ref_frame.xaxis, -self.ref_frame.zaxis),
-            Frame(rs4_point, self.ref_frame.xaxis, self.ref_frame.yaxis),
-            Frame(rs5_point, self.ref_frame.zaxis, self.ref_frame.yaxis),
-            Frame(rs6_point, self.ref_frame.zaxis, -self.ref_frame.yaxis),
+            Frame(rs1_point, self.ref_frame.xaxis, self.ref_frame.zaxis, name="RS_1"),
+            Frame(rs2_point, self.ref_frame.xaxis, -self.ref_frame.yaxis, name="RS_2"),
+            Frame(rs3_point, self.ref_frame.xaxis, -self.ref_frame.zaxis, name="RS_3"),
+            Frame(rs4_point, self.ref_frame.xaxis, self.ref_frame.yaxis, name="RS_4"),
+            Frame(rs5_point, self.ref_frame.zaxis, self.ref_frame.yaxis, name="RS_5"),
+            Frame(rs6_point, self.ref_frame.zaxis, -self.ref_frame.yaxis, name="RS_6"),
         )
 
     @property

--- a/tests/compas_timber/test_btlx.py
+++ b/tests/compas_timber/test_btlx.py
@@ -2,6 +2,8 @@ import pytest
 
 from compas.geometry import Line
 from compas.geometry import Point
+from compas.geometry import Frame
+from compas.geometry import Vector
 
 from compas_timber.elements import Beam
 from compas_timber.fabrication import BTLxPart
@@ -23,3 +25,43 @@ def test_beam_ref_faces(mock_beam):
     assert btlx_part.ref_side_from_face(mock_beam.faces[3]) == 4
     assert btlx_part.ref_side_from_face(mock_beam.faces[4]) == 5
     assert btlx_part.ref_side_from_face(mock_beam.faces[5]) == 6
+
+
+def test_beam_ref_faces_attribute(mock_beam):
+    ref_side_frames_expected = (
+        Frame(
+            point=Point(x=-48.67193560518159, y=20.35704602012424, z=0.0005429194857271558),
+            xaxis=Vector(x=0.9374000278319115, y=0.3451241645032913, z=0.04658861337963174),
+            yaxis=Vector(x=0.3454993211307862, y=-0.9384189997533969, z=-1.734723475976807e-18),
+        ),
+        Frame(
+            point=Point(x=-48.7156552451492, y=20.340949685829152, z=0.9994570805142728),
+            xaxis=Vector(x=0.9374000278319115, y=0.3451241645032913, z=0.04658861337963174),
+            yaxis=Vector(x=0.04371963996761174, y=0.016096334295087427, z=-0.9989141610285457),
+        ),
+        Frame(
+            point=Point(x=-48.37015592401841, y=19.402530686075757, z=0.9994570805142728),
+            xaxis=Vector(x=0.9374000278319115, y=0.3451241645032913, z=0.04658861337963174),
+            yaxis=Vector(x=-0.3454993211307862, y=0.9384189997533969, z=1.734723475976807e-18),
+        ),
+        Frame(
+            point=Point(x=-48.3264362840508, y=19.41862702037084, z=0.000542919485727154),
+            xaxis=Vector(x=0.9374000278319115, y=0.3451241645032913, z=0.04658861337963174),
+            yaxis=Vector(x=-0.04371963996761174, y=-0.016096334295087427, z=0.9989141610285457),
+        ),
+        Frame(
+            point=Point(x=-48.67193560518159, y=20.35704602012424, z=0.0005429194857271558),
+            xaxis=Vector(x=0.3454993211307862, y=-0.9384189997533969, z=-1.734723475976807e-18),
+            yaxis=Vector(x=-0.04371963996761173, y=-0.016096334295087424, z=0.9989141610285456),
+        ),
+        Frame(
+            point=Point(x=-38.6552567933492, y=24.04490371522915, z=1.499457080514273),
+            xaxis=Vector(x=0.3454993211307862, y=-0.9384189997533969, z=-1.734723475976807e-18),
+            yaxis=Vector(x=0.04371963996761173, y=0.016096334295087424, z=-0.9989141610285456),
+        ),
+    )
+
+    for index in range(6):
+        ref_side = mock_beam.ref_sides[index]
+        assert ref_side_frames_expected[index] == ref_side
+        assert ref_side.name == "RS_{}".format(index + 1)

--- a/tests/compas_timber/test_btlx.py
+++ b/tests/compas_timber/test_btlx.py
@@ -65,3 +65,31 @@ def test_beam_ref_faces_attribute(mock_beam):
         ref_side = mock_beam.ref_sides[index]
         assert ref_side_frames_expected[index] == ref_side
         assert ref_side.name == "RS_{}".format(index + 1)
+
+
+def test_beam_ref_edges(mock_beam):
+
+    ref_edges_expected = (
+        Line(
+            Point(x=-48.67193560518159, y=20.35704602012424, z=0.0005429194857271558),
+            Point(x=-38.61153715338159, y=24.06100004952424, z=0.5005429194857273),
+        ),
+        Line(
+            Point(x=-48.7156552451492, y=20.340949685829152, z=0.9994570805142728),
+            Point(x=-38.6552567933492, y=24.04490371522915, z=1.499457080514273),
+        ),
+        Line(
+            Point(x=-48.37015592401841, y=19.402530686075757, z=0.9994570805142728),
+            Point(x=-38.309757472218415, y=23.106484715475755, z=1.499457080514273),
+        ),
+        Line(
+            Point(x=-48.3264362840508, y=19.41862702037084, z=0.000542919485727154),
+            Point(x=-38.2660378322508, y=23.12258104977084, z=0.5005429194857273),
+        ),
+    )
+    assert len(mock_beam.ref_edges) == 4
+
+    for index in range(4):
+        ref_edge = mock_beam.ref_edges[index]
+        assert ref_edges_expected[index] == ref_edge
+        assert ref_edge.name == "RE_{}".format(index + 1)


### PR DESCRIPTION
This is a first in a series of PRs meant to align (merge) the Feature with the machining processes (BTLx).
It is broken down into multiple parts to keep PRs small and review-able.

- This PR deals with introducing a BTLx compatible coordinate system to each beam along with the collection of standard reference sides as specified in https://design2machine.com/btlx/BTLx_2_2_0.pdf.
- This are currently added alongside the existing frame and faces and may or may not replace them in the future.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
