### PR TITLE
Fix_surface_model_tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Fixed error in BakeWithBoxMap component.
+* Fixed error with tolerances for `SurfaceModel`s modeled in meters.
 
 ### Removed
 

--- a/src/compas_timber/design/wall_from_surface.py
+++ b/src/compas_timber/design/wall_from_surface.py
@@ -311,7 +311,6 @@ class SurfaceModel(object):
                     angle_vectors(segment.direction, self.z_axis, deg=True) < 1
                     or angle_vectors(segment.direction, self.z_axis, deg=True) > 179
                 ):
-
                     if self.lintel_posts:
                         element.type = "jack_stud"
                     else:
@@ -370,14 +369,20 @@ class SurfaceModel(object):
                 if element.type != "plate":
                     element_before = offset_loop[i - 1]
                     element_after = offset_loop[(i + 1) % len(offset_loop)]
-                    start_point = intersection_line_line(element.centerline, element_before.centerline, self.dist_tolerance)[0]
-                    end_point = intersection_line_line(element.centerline, element_after.centerline, self.dist_tolerance)[0]
+                    start_point = intersection_line_line(
+                        element.centerline, element_before.centerline, self.dist_tolerance
+                    )[0]
+                    end_point = intersection_line_line(
+                        element.centerline, element_after.centerline, self.dist_tolerance
+                    )[0]
                     if start_point and end_point:
                         element.centerline = Line(start_point, end_point)
             else:
                 element_before = offset_loop[i - 1]
                 element_after = offset_loop[(i + 1) % len(offset_loop)]
-                start_point = intersection_line_line(element.centerline, element_before.centerline, self.dist_tolerance)[0]
+                start_point = intersection_line_line(
+                    element.centerline, element_before.centerline, self.dist_tolerance
+                )[0]
                 end_point = intersection_line_line(element.centerline, element_after.centerline, self.dist_tolerance)[0]
                 if start_point and end_point:
                     element.centerline = Line(start_point, end_point)

--- a/src/compas_timber/design/wall_from_surface.py
+++ b/src/compas_timber/design/wall_from_surface.py
@@ -114,6 +114,7 @@ class SurfaceModel(object):
         self.windows = []
         self.beam_dimensions = {}
         self.joint_overrides = joint_overrides
+        self.dist_tolerance = 0.01
 
         for key in self.BEAM_CATEGORY_NAMES:
             self.beam_dimensions[key] = [self.beam_width, self.frame_depth]
@@ -180,10 +181,10 @@ class SurfaceModel(object):
             model.add_beam(beam)
         topologies = []
         solver = ConnectionSolver()
-        found_pairs = solver.find_intersecting_pairs(model.beams, rtree=True, max_distance=0.1)
+        found_pairs = solver.find_intersecting_pairs(model.beams, rtree=True, max_distance=self.dist_tolerance)
         for pair in found_pairs:
             beam_a, beam_b = pair
-            detected_topo, beam_a, beam_b = solver.find_topology(beam_a, beam_b, max_distance=0.1)
+            detected_topo, beam_a, beam_b = solver.find_topology(beam_a, beam_b, max_distance=self.dist_tolerance)
             if not detected_topo == JointTopology.TOPO_UNKNOWN:
                 topologies.append({"detected_topo": detected_topo, "beam_a": beam_a, "beam_b": beam_b})
                 for rule in self.rules:
@@ -275,6 +276,7 @@ class SurfaceModel(object):
     def parse_loops(self):
         for loop in self.surface.loops:
             polyline_points = []
+            length = 0.0
             for i, edge in enumerate(loop.edges):
                 if not edge.is_line:
                     raise ValueError("function only supprorts polyline edges")
@@ -285,17 +287,20 @@ class SurfaceModel(object):
                     polyline_points.append(edge.start_vertex.point)
                 else:
                     polyline_points.append(edge.end_vertex.point)
+                length += edge.length
             polyline_points.append(polyline_points[0])
+            offset_dist = length * 0.001
             if loop.is_outer:
-                offset_loop = Polyline(offset_polyline(Polyline(polyline_points), 10, self.normal))
+                offset_loop = Polyline(offset_polyline(Polyline(polyline_points), offset_dist, self.normal))
                 if offset_loop.length > Polyline(polyline_points).length:
                     polyline_points.reverse()
                 self.outer_polyline = Polyline(polyline_points)
             else:
-                offset_loop = Polyline(offset_polyline(Polyline(polyline_points), 10, self.normal))
+                offset_loop = Polyline(offset_polyline(Polyline(polyline_points), offset_dist, self.normal))
                 if offset_loop.length < Polyline(polyline_points).length:
                     polyline_points.reverse()
                 self.inner_polylines.append(Polyline(polyline_points))
+        self.dist_tolerance = self.outer_polyline.length * 0.00001
 
     def generate_perimeter_elements(self):
         interior_indices = self.get_interior_segment_indices(self.outer_polyline)
@@ -359,20 +364,21 @@ class SurfaceModel(object):
                 element.offset(self.edge_stud_offset)
             offset_loop.append(element)
             # self.edges.append(Line(element.centerline[0], element.centerline[1]))
+
         for i, element in enumerate(offset_loop):
             if self.edge_stud_offset > 0:
                 if element.type != "plate":
                     element_before = offset_loop[i - 1]
                     element_after = offset_loop[(i + 1) % len(offset_loop)]
-                    start_point = intersection_line_line(element.centerline, element_before.centerline, 0.01)[0]
-                    end_point = intersection_line_line(element.centerline, element_after.centerline, 0.01)[0]
+                    start_point = intersection_line_line(element.centerline, element_before.centerline, self.dist_tolerance)[0]
+                    end_point = intersection_line_line(element.centerline, element_after.centerline, self.dist_tolerance)[0]
                     if start_point and end_point:
                         element.centerline = Line(start_point, end_point)
             else:
                 element_before = offset_loop[i - 1]
                 element_after = offset_loop[(i + 1) % len(offset_loop)]
-                start_point = intersection_line_line(element.centerline, element_before.centerline, 0.01)[0]
-                end_point = intersection_line_line(element.centerline, element_after.centerline, 0.01)[0]
+                start_point = intersection_line_line(element.centerline, element_before.centerline, self.dist_tolerance)[0]
+                end_point = intersection_line_line(element.centerline, element_after.centerline, self.dist_tolerance)[0]
                 if start_point and end_point:
                     element.centerline = Line(start_point, end_point)
         return offset_loop
@@ -589,7 +595,7 @@ class SurfaceModel(object):
                     pts = []
                     for seg in self.outline.lines:
                         if seg != segment:
-                            pt = intersection_line_segment(ray, seg, 0.01)[0]
+                            pt = intersection_line_segment(ray, seg, self.dist_tolerance)[0]
                             if pt:
                                 pts.append(Point(*pt))
                     if len(pts) > 1:

--- a/src/compas_timber/ghpython/components/CT_SurfaceModelOptions/code.py
+++ b/src/compas_timber/ghpython/components/CT_SurfaceModelOptions/code.py
@@ -2,11 +2,9 @@ from ghpythonlib.componentbase import executingcomponent as component
 
 
 class SurfaceModelOptions(component):
-
     def RunScript(
         self, sheeting_outside, sheeting_inside, lintel_posts, edge_stud_offset, custom_dimensions, joint_overrides
     ):
-
         if sheeting_outside is not None and not isinstance(sheeting_outside, float):
             raise TypeError("sheeting_outside expected a float, got: {}".format(type(sheeting_outside)))
         if sheeting_inside is not None and not isinstance(sheeting_inside, float):

--- a/tests/compas_timber/test_btlx.py
+++ b/tests/compas_timber/test_btlx.py
@@ -68,7 +68,6 @@ def test_beam_ref_faces_attribute(mock_beam):
 
 
 def test_beam_ref_edges(mock_beam):
-
     ref_edges_expected = (
         Line(
             Point(x=-48.67193560518159, y=20.35704602012424, z=0.0005429194857271558),


### PR DESCRIPTION
Bug fix for `SurfaceModel`s modeled in meters or otherwise very small. Made the relevant tolerances proportional to the outline length.

### What type of change is this?

- [ x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
