### PR TITLE
key is back, back again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `SurfaceModelJointOverride` GH Component
 * Added `ShowSurfaceModelBeamType` GH Component
 * Re-introduced attribute `key` in `Beam`.
+* Added attribute `key` to `Plate`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added attribute `plates` to `TimberModel`.
 * Added `SurfaceModelJointOverride` GH Component
 * Added `ShowSurfaceModelBeamType` GH Component
+* Re-introduced attribute `key` in `Beam`.
 
 ### Changed
 

--- a/src/compas_timber/elements/beam.py
+++ b/src/compas_timber/elements/beam.py
@@ -80,7 +80,7 @@ class Beam(Element):
     midpoint : :class:`~compas.geometry.Point`
         The point at the middle of the centerline of this beam.
     key : int, optional
-        Once beam is added to a model, it will have this model-unique integer key.
+        Once beam is added to a model, it will have this model-wide-unique integer key.
 
     """
 
@@ -238,7 +238,7 @@ class Beam(Element):
 
     @property
     def has_features(self):
-        # TODO: move to compas_future... Part
+        # TODO: consider removing, this is not used anywhere
         return len(self.features) > 0
 
     @property

--- a/src/compas_timber/elements/beam.py
+++ b/src/compas_timber/elements/beam.py
@@ -79,6 +79,8 @@ class Beam(Element):
         A list containing the 4 lines along the long axis of this beam.
     midpoint : :class:`~compas.geometry.Point`
         The point at the middle of the centerline of this beam.
+    key : int, optional
+        Once beam is added to a model, it will have this model-unique integer key.
 
     """
 
@@ -238,6 +240,11 @@ class Beam(Element):
     def has_features(self):
         # TODO: move to compas_future... Part
         return len(self.features) > 0
+
+    @property
+    def key(self):
+        # type: () -> int | None
+        return self.graph_node
 
     def __str__(self):
         return "Beam {:.3f} x {:.3f} x {:.3f} at {}".format(

--- a/src/compas_timber/elements/plate.py
+++ b/src/compas_timber/elements/plate.py
@@ -37,7 +37,8 @@ class Plate(Element):
         Thickness of the plate material.
     aabb : tuple(float, float, float, float, float, float)
         An axis-aligned bounding box of this plate as a 6 valued tuple of (xmin, ymin, zmin, xmax, ymax, zmax).
-
+    key : int, optional
+        Once plate is added to a model, it will have this model-wide-unique integer key.
 
     """
 
@@ -91,8 +92,13 @@ class Plate(Element):
 
     @property
     def has_features(self):
-        # TODO: move to compas_future... Part
+        # TODO: consider removing, this is not used anywhere
         return len(self.features) > 0
+
+    @property
+    def key(self):
+        # type: () -> int | None
+        return self.graph_node
 
     # ==========================================================================
     # Implementations of abstract methods


### PR DESCRIPTION
* Re-added the `key` attribute (which has been renamed `graph_node` in the new model),
* Added `key` to the new `Plate` element. 

Reason is: while only `guid` should be used to uniquely identify an element. `key` is a practical, human readable, way of identifying a beam once added to a model.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)