### PR TITLE
set proper tolerance in model component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Implemented a workaround for https://github.com/gramaziokohler/compas_timber/issues/280.
+
 ### Removed
 
 

--- a/src/compas_timber/ghpython/components/CT_Model/code.py
+++ b/src/compas_timber/ghpython/components/CT_Model/code.py
@@ -23,6 +23,10 @@ JOINT_DEFAULTS = {
 }
 
 
+# workaround for https://github.com/gramaziokohler/compas_timber/issues/280
+TOL.absolute = 1e-6
+
+
 class ModelComponent(component):
     def get_joints_from_rules(self, beams, rules, topologies):
         if not isinstance(rules, list):


### PR DESCRIPTION
This is to address https://github.com/gramaziokohler/compas_timber/issues/280.

This is a workaround.
A more proper solution might include allowing passing an explicit tolerance to the `from_boolean_difference` method in `RhinoBrep`.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
