### PR TITLE
Fix joint init data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Renamed `intersection_line_line_3D` to `intersection_line_line_param`.
 * Adjusted functions in `compas_timber._fabrication.DovetailMortise` and `compas_timber.connections.TDovetailJoint`.
 * Fixed `**kwargs` inheritance in `__init__` for joint modules: `LMiterJoint`, `TStepJoint`, `TDovetailJoint`, `TBirdsmouthJoint`.
-* Standardized `__data__` structure to store beams directly instead of GUIDs for joint modules: `LMiterJoint`, `TStepJoint`, `TDovetailJoint`, `TBirdsmouthJoint`.
+* Fixed GUID assignment logic from `**kwargs` to ensure correct fallback behavior for joint modules: `LMiterJoint`, `TStepJoint`, `TDovetailJoint`, `TBirdsmouthJoint`.
 * Changed `model.element_by_guid()` instead of direct `elementsdict[]` access for beam retrieval in joint modules: `LMiterJoint`, `TStepJoint`, `TDovetailJoint`, `TBirdsmouthJoint`.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Renamed `intersection_line_plane` to `intersection_line_plane_param`.
 * Renamed `intersection_line_line_3D` to `intersection_line_line_param`.
 * Adjusted functions in `compas_timber._fabrication.DovetailMortise` and `compas_timber.connections.TDovetailJoint`.
+* Fixed `**kwargs` inheritance in `__init__` for joint modules: `LMiterJoint`, `TStepJoint`, `TDovetailJoint`, `TBirdsmouthJoint`.
+* Standardized `__data__` structure to store beams directly instead of GUIDs for joint modules: `LMiterJoint`, `TStepJoint`, `TDovetailJoint`, `TBirdsmouthJoint`.
+* Changed `model.element_by_guid()` instead of direct `elementsdict[]` access for beam retrieval in joint modules: `LMiterJoint`, `TStepJoint`, `TDovetailJoint`, `TBirdsmouthJoint`.
+
 
 ### Removed
 

--- a/src/compas_timber/connections/l_miter.py
+++ b/src/compas_timber/connections/l_miter.py
@@ -41,13 +41,13 @@ class LMiterJoint(Joint):
     @property
     def __data__(self):
         data = super(LMiterJoint, self).__data__
-        data["beam_a"] = self.beam_a_guid
-        data["beam_b"] = self.beam_b_guid
+        data["beam_a"] = self.beam_a
+        data["beam_b"] = self.beam_b
         data["cutoff"] = self.cutoff
         return data
 
-    def __init__(self, beam_a=None, beam_b=None, cutoff=None):
-        super(LMiterJoint, self).__init__()
+    def __init__(self, beam_a=None, beam_b=None, cutoff=None, **kwargs):
+        super(LMiterJoint, self).__init__(**kwargs)
         self.beam_a = beam_a
         self.beam_b = beam_b
         self.beam_a_guid = str(beam_a.guid) if beam_a else None
@@ -148,5 +148,5 @@ class LMiterJoint(Joint):
 
     def restore_beams_from_keys(self, model):
         """After de-serialization, restores references to the main and cross beams saved in the model."""
-        self.beam_a = model.elementdict[self.beam_a_guid]
-        self.beam_b = model.elementdict[self.beam_b_guid]
+        self.beam_a = model.element_by_guid(self.beam_a_guid)
+        self.beam_b = model.element_by_guid(self.beam_b_guid)

--- a/src/compas_timber/connections/l_miter.py
+++ b/src/compas_timber/connections/l_miter.py
@@ -41,8 +41,8 @@ class LMiterJoint(Joint):
     @property
     def __data__(self):
         data = super(LMiterJoint, self).__data__
-        data["beam_a"] = self.beam_a
-        data["beam_b"] = self.beam_b
+        data["beam_a"] = self.beam_a_guid
+        data["beam_b"] = self.beam_b_guid
         data["cutoff"] = self.cutoff
         return data
 
@@ -50,8 +50,8 @@ class LMiterJoint(Joint):
         super(LMiterJoint, self).__init__(**kwargs)
         self.beam_a = beam_a
         self.beam_b = beam_b
-        self.beam_a_guid = str(beam_a.guid) if beam_a else None
-        self.beam_b_guid = str(beam_b.guid) if beam_b else None
+        self.beam_a_guid = kwargs.get("beam_a_guid", None) or str(beam_a.guid)
+        self.beam_b_guid = kwargs.get("beam_b_guid", None) or str(beam_b.guid)
         self.cutoff = cutoff  # for very acute angles, limit the extension of the tip/beak of the joint
         self.features = []
 

--- a/src/compas_timber/connections/t_birdsmouth.py
+++ b/src/compas_timber/connections/t_birdsmouth.py
@@ -40,12 +40,12 @@ class TBirdsmouthJoint(Joint):
     @property
     def __data__(self):
         data = super(TBirdsmouthJoint, self).__data__
-        data["main_beam"] = self.main_beam_guid
-        data["cross_beam"] = self.cross_beam_guid
+        data["main_beam"] = self.main_beam
+        data["cross_beam"] = self.cross_beam
         return data
 
-    def __init__(self, main_beam, cross_beam):
-        super(TBirdsmouthJoint, self).__init__()
+    def __init__(self, main_beam, cross_beam, **kwargs):
+        super(TBirdsmouthJoint, self).__init__(**kwargs)
         self.main_beam = main_beam
         self.cross_beam = cross_beam
         self.main_beam_guid = str(main_beam.guid) if main_beam else None
@@ -124,5 +124,5 @@ class TBirdsmouthJoint(Joint):
 
     def restore_beams_from_keys(self, model):
         """After de-serialization, restores references to the main and cross beams saved in the model."""
-        self.main_beam = model.elementdict[self.main_beam_guid]
-        self.cross_beam = model.elementdict[self.cross_beam_guid]
+        self.main_beam = model.element_by_guid(self.main_beam_guid)
+        self.cross_beam = model.element_by_guid(self.cross_beam_guid)

--- a/src/compas_timber/connections/t_birdsmouth.py
+++ b/src/compas_timber/connections/t_birdsmouth.py
@@ -40,16 +40,16 @@ class TBirdsmouthJoint(Joint):
     @property
     def __data__(self):
         data = super(TBirdsmouthJoint, self).__data__
-        data["main_beam"] = self.main_beam
-        data["cross_beam"] = self.cross_beam
+        data["main_beam"] = self.main_beam_guid
+        data["cross_beam"] = self.cross_beam_guid
         return data
 
     def __init__(self, main_beam, cross_beam, **kwargs):
         super(TBirdsmouthJoint, self).__init__(**kwargs)
         self.main_beam = main_beam
         self.cross_beam = cross_beam
-        self.main_beam_guid = str(main_beam.guid) if main_beam else None
-        self.cross_beam_guid = str(cross_beam.guid) if cross_beam else None
+        self.main_beam_guid = kwargs.get("main_beam_guid", None) or str(main_beam.guid)
+        self.cross_beam_guid = kwargs.get("cross_beam_guid", None) or str(cross_beam.guid)
 
         self.features = []
 

--- a/src/compas_timber/connections/t_dovetail.py
+++ b/src/compas_timber/connections/t_dovetail.py
@@ -89,8 +89,8 @@ class TDovetailJoint(Joint):
     @property
     def __data__(self):
         data = super(TDovetailJoint, self).__data__
-        data["main_beam"] = self.main_beam_guid
-        data["cross_beam"] = self.cross_beam_guid
+        data["main_beam"] = self.main_beam
+        data["cross_beam"] = self.cross_beam
         data["start_y"] = self.start_y
         data["start_depth"] = self.start_depth
         data["rotation"] = self.rotation
@@ -103,6 +103,7 @@ class TDovetailJoint(Joint):
         data["tool_height"] = self.tool_height
         return data
 
+    # fmt: off
     def __init__(
         self,
         main_beam,
@@ -117,8 +118,9 @@ class TDovetailJoint(Joint):
         tool_angle=None,
         tool_diameter=None,
         tool_height=None,
+        **kwargs
     ):
-        super(TDovetailJoint, self).__init__()
+        super(TDovetailJoint, self).__init__(**kwargs)
         self.main_beam = main_beam
         self.cross_beam = cross_beam
         self.main_beam_guid = str(main_beam.guid) if main_beam else None
@@ -285,5 +287,5 @@ class TDovetailJoint(Joint):
 
     def restore_beams_from_keys(self, model):
         """After de-serialization, restores references to the main and cross beams saved in the model."""
-        self.main_beam = model.elementdict[self.main_beam_guid]
-        self.cross_beam = model.elementdict[self.cross_beam_guid]
+        self.main_beam = model.element_by_guid(self.main_beam_guid)
+        self.cross_beam = model.element_by_guid(self.cross_beam_guid)

--- a/src/compas_timber/connections/t_dovetail.py
+++ b/src/compas_timber/connections/t_dovetail.py
@@ -89,8 +89,8 @@ class TDovetailJoint(Joint):
     @property
     def __data__(self):
         data = super(TDovetailJoint, self).__data__
-        data["main_beam"] = self.main_beam
-        data["cross_beam"] = self.cross_beam
+        data["main_beam"] = self.main_beam_guid
+        data["cross_beam"] = self.cross_beam_guid
         data["start_y"] = self.start_y
         data["start_depth"] = self.start_depth
         data["rotation"] = self.rotation
@@ -123,8 +123,8 @@ class TDovetailJoint(Joint):
         super(TDovetailJoint, self).__init__(**kwargs)
         self.main_beam = main_beam
         self.cross_beam = cross_beam
-        self.main_beam_guid = str(main_beam.guid) if main_beam else None
-        self.cross_beam_guid = str(cross_beam.guid) if cross_beam else None
+        self.main_beam_guid = kwargs.get("main_beam_guid", None) or str(main_beam.guid)
+        self.cross_beam_guid = kwargs.get("cross_beam_guid", None) or str(cross_beam.guid)
 
         # Default values if not provided
         self.start_y = start_y if start_y is not None else 0.0

--- a/src/compas_timber/connections/t_step_joint.py
+++ b/src/compas_timber/connections/t_step_joint.py
@@ -58,8 +58,8 @@ class TStepJoint(Joint):
     @property
     def __data__(self):
         data = super(TStepJoint, self).__data__
-        data["main_beam"] = self.main_beam
-        data["cross_beam"] = self.cross_beam
+        data["main_beam"] = self.main_beam_guid
+        data["cross_beam"] = self.cross_beam_guid
         data["step_shape"] = self.step_shape
         data["step_depth"] = self.step_depth
         data["heel_depth"] = self.heel_depth
@@ -82,8 +82,8 @@ class TStepJoint(Joint):
         super(TStepJoint, self).__init__(**kwargs)
         self.main_beam = main_beam
         self.cross_beam = cross_beam
-        self.main_beam_guid = str(main_beam.guid) if main_beam else None
-        self.cross_beam_guid = str(cross_beam.guid) if cross_beam else None
+        self.main_beam_guid = kwargs.get("main_beam_guid", None) or str(main_beam.guid)
+        self.cross_beam_guid = kwargs.get("cross_beam_guid", None) or str(cross_beam.guid)
 
         self.step_shape = 0 if step_shape is None else step_shape
         self.step_depth, self.heel_depth = self.set_step_depths(step_depth, heel_depth)

--- a/src/compas_timber/connections/t_step_joint.py
+++ b/src/compas_timber/connections/t_step_joint.py
@@ -58,8 +58,8 @@ class TStepJoint(Joint):
     @property
     def __data__(self):
         data = super(TStepJoint, self).__data__
-        data["main_beam"] = self.main_beam_guid
-        data["cross_beam"] = self.cross_beam_guid
+        data["main_beam"] = self.main_beam
+        data["cross_beam"] = self.cross_beam
         data["step_shape"] = self.step_shape
         data["step_depth"] = self.step_depth
         data["heel_depth"] = self.heel_depth
@@ -67,6 +67,7 @@ class TStepJoint(Joint):
         data["tenon_mortise_height"] = self.tenon_mortise_height
         return data
 
+    # fmt: off
     def __init__(
         self,
         main_beam,
@@ -76,8 +77,9 @@ class TStepJoint(Joint):
         heel_depth=None,
         tapered_heel=None,
         tenon_mortise_height=None,
+        **kwargs
     ):
-        super(TStepJoint, self).__init__()
+        super(TStepJoint, self).__init__(**kwargs)
         self.main_beam = main_beam
         self.cross_beam = cross_beam
         self.main_beam_guid = str(main_beam.guid) if main_beam else None
@@ -195,5 +197,5 @@ class TStepJoint(Joint):
 
     def restore_beams_from_keys(self, model):
         """After de-serialization, restores references to the main and cross beams saved in the model."""
-        self.main_beam = model.elementdict[self.main_beam_guid]
-        self.cross_beam = model.elementdict[self.cross_beam_guid]
+        self.main_beam = model.element_by_guid(self.main_beam_guid)
+        self.cross_beam = model.element_by_guid(self.cross_beam_guid)


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This bug fix includes changes to modules: `l_miter`, `t_step_joint`, `t_birdsmouth`, `t_dovetail`.

1.     Update __init__ to pass **kwargs to the superclass
2.     Update __data__ to include beams directly (rather than their GUIDs).
3.     Update restore_beams_from_keys to use model.element_by_guid() instead of model.elementsdict[]

### What type of change is this?

- [X] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [X] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [X] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
