### PR TITLE
fix for missed intersection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `JointRuleFromList` GH component.
 * Changed `TButtJoint` to take an optional `PlateFastener`.
 * Moved `FeatureApplicationError`, `BeamJoinningError`, and `FastenerApplicationError` to `errors.__init__.py`.
+* Fixed a bug that occured when parallel beams are joined in the BallNodeJoint.
 
 ### Removed
 

--- a/src/compas_timber/_fabrication/slot.py
+++ b/src/compas_timber/_fabrication/slot.py
@@ -13,7 +13,6 @@ from .btlx_process import OrientationType
 
 
 class Slot(BTLxProcess):
-
     PROCESS_NAME = "Slot"  # type: ignore
 
     def __init__(
@@ -31,7 +30,7 @@ class Slot(BTLxProcess):
         angle_opp_point=90.0,
         add_angle_opp_point=0.0,
         machining_limits=None,
-        **kwargs
+        **kwargs,
     ):
         super(Slot, self).__init__(**kwargs)
         self._orientation = None

--- a/src/compas_timber/connections/ball_node.py
+++ b/src/compas_timber/connections/ball_node.py
@@ -115,13 +115,15 @@ class BallNodeJoint(Joint):
         if not self._node_point:
             beams = list(self.beams)
             cpt = Point(0, 0, 0)
+            count = 0
             for i, beam in enumerate(beams):
                 points = intersection_line_line_param(
                     beams[i - 1].centerline, beam.centerline
                 )  # TODO: include Tolerance check here.
                 if points[0][0] is not None and points[1][0] is not None:
                     cpt += points[1][0]
-            self._node_point = cpt * (1.0 / len(beams))
+                    count+=1
+            self._node_point = cpt * (1.0 / count)
         return self._node_point
 
     def add_features(self):
@@ -134,6 +136,11 @@ class BallNodeJoint(Joint):
         for beam in self.beams:
             interface = self.fastener.base_interface.copy()
             pt = beam.centerline.closest_point(self._node_point)
+            print("joint point", self.node_point)
+            print("beam.key", beam.key)
+            print("pt", pt)
+            print("beam.midpoint", beam.midpoint)
+            print("beam.frame.zaxis", beam.frame.zaxis)
             interface.frame = Frame(pt, Vector.from_start_end(pt, beam.midpoint), beam.frame.zaxis)
             self.fastener.interfaces.append(interface)
             beam.add_features(interface.get_features(beam))

--- a/src/compas_timber/connections/ball_node.py
+++ b/src/compas_timber/connections/ball_node.py
@@ -122,7 +122,7 @@ class BallNodeJoint(Joint):
                 )  # TODO: include Tolerance check here.
                 if points[0][0] is not None and points[1][0] is not None:
                     cpt += points[1][0]
-                    count+=1
+                    count += 1
             self._node_point = cpt * (1.0 / count)
         return self._node_point
 


### PR DESCRIPTION
This fixes a bug that occured when parallel beams are joined in the BallNodeJoint

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
