### PR TITLE
JointRule_comply_fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `JointRuleFromList` GH component.
 * Changed `TButtJoint` to take an optional `PlateFastener`.
 * Moved `FeatureApplicationError`, `BeamJoinningError`, and `FastenerApplicationError` to `errors.__init__.py`.
+* Fixed bug in `JointRule.joints_from_beams_and_rules()` that caused failures when topology was not recognized.
+* Implemented `max_distance` parameter in `JointRule.joints_from_beams_and_rules()` and `JointRule.comply` methods.
 
 ### Removed
 

--- a/src/compas_timber/_fabrication/slot.py
+++ b/src/compas_timber/_fabrication/slot.py
@@ -13,7 +13,6 @@ from .btlx_process import OrientationType
 
 
 class Slot(BTLxProcess):
-
     PROCESS_NAME = "Slot"  # type: ignore
 
     def __init__(
@@ -31,7 +30,7 @@ class Slot(BTLxProcess):
         angle_opp_point=90.0,
         add_angle_opp_point=0.0,
         machining_limits=None,
-        **kwargs
+        **kwargs,
     ):
         super(Slot, self).__init__(**kwargs)
         self._orientation = None

--- a/src/compas_timber/design/workflow.py
+++ b/src/compas_timber/design/workflow.py
@@ -93,23 +93,23 @@ class JointRule(object):
             pair = element_pairs.pop()
             match_found = False
             for rule in direct_rules:  # see if pair is used in a direct rule
-                if rule.comply(pair):
+                if rule.comply(pair, max_distance=max_distance):
                     match_found = True
                     break
 
             if not match_found:
                 for rule in JointRule.get_category_rules(rules):  # see if pair is used in a category rule
-                    if rule.comply(pair):
+                    if rule.comply(pair, max_distance=max_distance):
                         match_found = True
                         joint_defs.append(JointDefinition(rule.joint_type, rule.reorder(pair), **rule.kwargs))
                         break
 
             if not match_found:
                 for rule in JointRule.get_topology_rules(rules):  # see if pair is used in a topology rule
-                    comply, pair = rule.comply(pair)
+                    comply, ordered_pair = rule.comply(pair, max_distance=max_distance)
                     if comply:
                         match_found = True
-                        joint_defs.append(JointDefinition(rule.joint_type, pair, **rule.kwargs))
+                        joint_defs.append(JointDefinition(rule.joint_type, ordered_pair, **rule.kwargs))
                         break
             if not match_found:
                 unmatched_pairs.append(pair)

--- a/src/compas_timber/ghpython/components/CT_Model/code.py
+++ b/src/compas_timber/ghpython/components/CT_Model/code.py
@@ -42,7 +42,7 @@ class ModelComponent(component):
             element.reset()
             Model.add_element(element)
 
-        joints, unmatched_pairs = JointRule.joints_from_beams_and_rules(Model.beams, JointRules)
+        joints, unmatched_pairs = JointRule.joints_from_beams_and_rules(Model.beams, JointRules, MaxDistance)
 
         if unmatched_pairs:
             for pair in unmatched_pairs:


### PR DESCRIPTION
This fixes a bug that caused the` JointRule.joints_from_beams_and_rules()` method to fail when topology was not recognized by `ConnectionSolver`. it also passes `max_distance` parameter into the `JointRule.comply` methods.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
