### PR TITLE
Slot comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed comma incompatible with py27 in `Slot` module.
+
 ### Removed
 
 

--- a/src/compas_timber/_fabrication/slot.py
+++ b/src/compas_timber/_fabrication/slot.py
@@ -15,6 +15,7 @@ from .btlx_process import OrientationType
 class Slot(BTLxProcess):
     PROCESS_NAME = "Slot"  # type: ignore
 
+    # fmt: off
     def __init__(
         self,
         orientation,
@@ -30,7 +31,7 @@ class Slot(BTLxProcess):
         angle_opp_point=90.0,
         add_angle_opp_point=0.0,
         machining_limits=None,
-        **kwargs,
+        **kwargs
     ):
         super(Slot, self).__init__(**kwargs)
         self._orientation = None
@@ -76,9 +77,7 @@ class Slot(BTLxProcess):
     @orientation.setter
     def orientation(self, orientation):
         if orientation not in [OrientationType.START, OrientationType.END]:
-            raise ValueError(
-                "Orientation must be either OrientationType.START or OrientationType.END. Got: {}".format(orientation)
-            )
+            raise ValueError("Orientation must be either OrientationType.START or OrientationType.END. Got: {}".format(orientation))
         self._orientation = orientation
 
     @property
@@ -188,9 +187,7 @@ class Slot(BTLxProcess):
     @add_angle_opp_point.setter
     def add_angle_opp_point(self, add_angle_opp_point):
         if add_angle_opp_point < -179.9 or add_angle_opp_point > 179.9:
-            raise ValueError(
-                "Add Angle Opp Point must be between -179.9 and 179.9. Got: {}".format(add_angle_opp_point)
-            )
+            raise ValueError("Add Angle Opp Point must be between -179.9 and 179.9. Got: {}".format(add_angle_opp_point))
         self._add_angle_opp_point = add_angle_opp_point
 
     @property


### PR DESCRIPTION
Small syntax fix to support python27.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
