### PR TITLE
Fix `BTLxWriter` handling of Dictionary Params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Updated the API documentation for `connections`, `elements`, `fabrication`, `ghpython`, `planning` packages.
 * Refactored all btlx `process` references to `processing`, including base classes, properties, variables, and docstrings.
 * Refactored `BTLx` to `BTLxWriter` in the `compas_timber.Fabrication` package.
+* Removed model argument from `BTLxWriter` in the GH component and updated it to always return the BTLx string.
 
 ### Removed
 

--- a/src/compas_timber/fabrication/btlx.py
+++ b/src/compas_timber/fabrication/btlx.py
@@ -217,7 +217,11 @@ class BTLxWriter(object):
         for key, value in processing.params_dict.items():
             if key not in processing.header_attributes:
                 child = ET.SubElement(processing_element, key)
-                child.text = str(value)
+                if isinstance(value, dict):
+                    for sub_key, sub_value in value.items():
+                        child.set(sub_key, sub_value)
+                else:
+                    child.text = str(value)
         # create subprocessing elements
         if processing.subprocessings:
             for subprocessing in processing.subprocessings:

--- a/src/compas_timber/ghpython/components/CT_BTLx/code.py
+++ b/src/compas_timber/ghpython/components/CT_BTLx/code.py
@@ -11,11 +11,14 @@ class WriteBTLx(component):
             self.AddRuntimeMessage(Warning, "Input parameter Model failed to collect data")
             return
 
-        btlx = BTLxWriter(model, file_name=str(Rhino.RhinoDoc.ActiveDoc.Name))
+        btlx = BTLxWriter(file_name=str(Rhino.RhinoDoc.ActiveDoc.Name))
 
         if write:
             if not path:
                 self.AddRuntimeMessage(Warning, "Input parameter Path failed to collect data")
                 return
             XML = btlx.write(model, path)
-            return XML
+        else:
+            XML = btlx.model_to_xml(model)
+
+        return XML

--- a/tests/compas_timber/test_btlx.py
+++ b/tests/compas_timber/test_btlx.py
@@ -165,3 +165,31 @@ def test_btlx_should_skip_feature():
         result = writer.model_to_xml(model)
 
     assert result is not None
+
+
+def test_create_processing_with_dict_params():
+    class MockProcessing:
+        PROCESSING_NAME = "MockProcessing"
+        header_attributes = {"Name": "MockProcessing", "Priority": "1", "Process": "yes", "ProcessID": "1", "ReferencePlaneID": "1"}
+        params_dict = {"Param1": "Value1", "Param2": {"SubParam1": "SubValue1", "SubParam2": "SubValue2"}, "Param3": "Value3"}
+        subprocessings = []
+
+    writer = BTLxWriter()
+    processing = MockProcessing()
+    processing_element = writer._create_processing(processing)
+
+    assert processing_element.tag == "MockProcessing"
+    assert processing_element.attrib == processing.header_attributes
+
+    param1 = processing_element.find("Param1")
+    assert param1 is not None
+    assert param1.text == "Value1"
+
+    param2 = processing_element.find("Param2")
+    assert param2 is not None
+    assert param2.get("SubParam1") == "SubValue1"
+    assert param2.get("SubParam2") == "SubValue2"
+
+    param3 = processing_element.find("Param3")
+    assert param3 is not None
+    assert param3.text == "Value3"


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Updated `_create_processing` to correctly handle dictionary values in `params_dict` by adding them as XML attributes. 
For example, `MachiningLimits` params now pass through properly as a dictionary. 

Also fixed a bug in the `BTLxWriter` GH component and updated it to always return the BTLx string.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
