### PR TITLE
GH error components get default index 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Fixed `ValueErrorException` in `as_dict()` method of `BTLxProcessingParams` class by ensuring precision specifiers are used with floats.
+* Changed `index` input of `ShowFeatureErrors` and `ShowJoiningErrors` do have default value of 0.
 
 ### Removed
 

--- a/src/compas_timber/ghpython/components/CT_ShowFeatureErrors/code.py
+++ b/src/compas_timber/ghpython/components/CT_ShowFeatureErrors/code.py
@@ -8,7 +8,7 @@ class ShowFeatureErrors(component):
     def RunScript(self, debug_info, index):
         if index is None:
             self.AddRuntimeMessage(Warning, "Input parameter 'i' failed to collect data")
-            return
+            index = 0
         if not debug_info:
             self.AddRuntimeMessage(Warning, "Input parameter 'DebugInfo' failed to collect data")
             return

--- a/src/compas_timber/ghpython/components/CT_ShowJoiningErrors/code.py
+++ b/src/compas_timber/ghpython/components/CT_ShowJoiningErrors/code.py
@@ -8,7 +8,7 @@ class ShowJoiningErrors(component):
     def RunScript(self, debug_info, index):
         if index is None:
             self.AddRuntimeMessage(Warning, "Input parameter 'i' failed to collect data")
-            return
+            index = 0
         if not debug_info:
             self.AddRuntimeMessage(Warning, "Input parameter 'DebugInfo' failed to collect data")
             return


### PR DESCRIPTION
this changes the GH components to have a default `index` value of 0.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
