### PR TITLE
fixed spelling on `BeamJoinningError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Fixed `ValueErrorException` in `as_dict()` method of `BTLxProcessingParams` class by ensuring precision specifiers are used with floats.
+* Fixed spelling of `BeamJoinningError` to `BeamJoiningError`.
 
 ### Removed
 
@@ -121,7 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed incorrect data keys for `beam_guid` in the `__data__` property for joint modules: `LMiterJoint`, `TStepJoint`, `TDovetailJoint`, `TBirdsmouthJoint`, `LFrenchRidgeLapJoint`.
 * Fixed `JointRuleFromList` GH component.
 * Changed `TButtJoint` to take an optional `PlateFastener`.
-* Moved `FeatureApplicationError`, `BeamJoinningError`, and `FastenerApplicationError` to `errors.__init__.py`.
+* Moved `FeatureApplicationError`, `BeamJoiningError`, and `FastenerApplicationError` to `errors.__init__.py`.
 * Fixed a bug that occured when parallel beams are joined in the BallNodeJoint.
 * Fixed `L_TopoJointRule`, `T_TopoJointRule` and `X_TopoJointRule` for cases where `Joint.SUPPORTED_TOPOLOGY` is a single value or a list.
 * Fixed bug in `JointRule.joints_from_beams_and_rules()` that caused failures when topology was not recognized.

--- a/docs/api/compas_timber.connections.rst
+++ b/docs/api/compas_timber.connections.rst
@@ -43,6 +43,6 @@ Exceptions
 
 The following exceptions may be raised by this module. See the :mod:`compas_timber.errors` module for details.
 
-- :class:`compas_timber.errors.BeamJoinningError`
+- :class:`compas_timber.errors.BeamJoiningError`
 - :class:`compas_timber.errors.FeatureApplicationError`
 - :class:`compas_timber.errors.FastenerApplicationError`

--- a/docs/api/compas_timber.errors.rst
+++ b/docs/api/compas_timber.errors.rst
@@ -11,6 +11,6 @@ Classes
     :toctree: generated/
     :nosignatures:
 
-    BeamJoinningError
+    BeamJoiningError
     FeatureApplicationError
     FastenerApplicationError

--- a/examples/Grasshopper/tests/test_double_cut.ghx
+++ b/examples/Grasshopper/tests/test_double_cut.ghx
@@ -745,7 +745,7 @@ from compas.tolerance import TOL
 from ghpythonlib.componentbase import executingcomponent as component
 from Grasshopper.Kernel.GH_RuntimeMessageLevel import Warning
 
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 from compas_timber.connections import ConnectionSolver
 from compas_timber.connections import JointTopology
 from compas_timber.connections import LMiterJoint
@@ -903,7 +903,7 @@ class ModelComponent(component):
                     continue
                 try:
                     joint.joint_type.create(Model, *beams_to_pair, **joint.kwargs)
-                except BeamJoinningError as bje:
+                except BeamJoiningError as bje:
                     debug_info.add_joint_error(bje)
                 else:
                     handled_beams.append(beam_pair_ids)

--- a/examples/Grasshopper/tests/test_dovetail_joint.ghx
+++ b/examples/Grasshopper/tests/test_dovetail_joint.ghx
@@ -1921,17 +1921,17 @@ ref_side_cross = frame_to_rhino(cross_beam.ref_sides[cross_ref_side_index])
 #create dovetail_tenon
 DovetailTenon.define_dovetail_tool(15.0, 60.034, 28.0)
 dovetail_tenon = DovetailTenon.from_plane_and_beam(
-            cross_beam.ref_sides[cross_ref_side_index], 
-            main_beam, 
-            start_y=start_y, 
-            rotation=rotation, 
-            start_depth=start_depth, 
-            width=width, 
-            length=length, 
-            cone_angle=cone_angle, 
+            cross_beam.ref_sides[cross_ref_side_index],
+            main_beam,
+            start_y=start_y,
+            rotation=rotation,
+            start_depth=start_depth,
+            width=width,
+            length=length,
+            cone_angle=cone_angle,
             ref_side_index=main_ref_side_index,
         )
-        
+
 #cutting_frame
 cutting_plane_tenon= dovetail_tenon.frame_from_params_and_beam(main_beam)
 #tenon cutting planes
@@ -4115,7 +4115,7 @@ from compas.tolerance import TOL
 from ghpythonlib.componentbase import executingcomponent as component
 from Grasshopper.Kernel.GH_RuntimeMessageLevel import Warning
 
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 from compas_timber.connections import ConnectionSolver
 from compas_timber.connections import JointTopology
 from compas_timber.connections import LMiterJoint
@@ -4273,7 +4273,7 @@ class ModelComponent(component):
                     continue
                 try:
                     joint.joint_type.create(Model, *beams_to_pair, **joint.kwargs)
-                except BeamJoinningError as bje:
+                except BeamJoiningError as bje:
                     debug_info.add_joint_error(bje)
                 else:
                     handled_beams.append(beam_pair_ids)

--- a/examples/Grasshopper/tests/test_frl.ghx
+++ b/examples/Grasshopper/tests/test_frl.ghx
@@ -1133,7 +1133,7 @@ cross_vector = main_beam.centerline.direction.cross(cross_beam.centerline.direct
 #cross
 cross_ref_side_dict = beam_ref_side_incidence_with_vector(cross_beam, cross_vector, ignore_ends=True)
 cross_ref_side_index = max(cross_ref_side_dict, key=cross_ref_side_dict.get)
-# main 
+# main
 main_ref_side_dict = beam_ref_side_incidence_with_vector(main_beam, cross_vector, ignore_ends=True)
 main_ref_side_index = min(main_ref_side_dict, key=main_ref_side_dict.get)
 
@@ -1463,7 +1463,7 @@ from compas.tolerance import TOL
 from ghpythonlib.componentbase import executingcomponent as component
 from Grasshopper.Kernel.GH_RuntimeMessageLevel import Warning
 
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 from compas_timber.connections import ConnectionSolver
 from compas_timber.connections import JointTopology
 from compas_timber.connections import LMiterJoint
@@ -1621,7 +1621,7 @@ class ModelComponent(component):
                     continue
                 try:
                     joint.joint_type.create(Model, *beams_to_pair, **joint.kwargs)
-                except BeamJoinningError as bje:
+                except BeamJoiningError as bje:
                     debug_info.add_joint_error(bje)
                 else:
                     handled_beams.append(beam_pair_ids)

--- a/examples/Grasshopper/tests/test_lap.ghx
+++ b/examples/Grasshopper/tests/test_lap.ghx
@@ -1301,7 +1301,7 @@ unload_modules('compas_timber')
 #cross
 cross_ref_side_dict = beam_ref_side_incidence(main_beam, cross_beam, ignore_ends=True)
 cross_ref_side_index = min(cross_ref_side_dict, key=cross_ref_side_dict.get)
-# main 
+# main
 main_ref_side_dict = beam_ref_side_incidence(cross_beam, main_beam, ignore_ends=True)
 main_ref_side_index = min(main_ref_side_dict, key=main_ref_side_dict.get)
 main_ref_side_indices = main_ref_side_index, (main_ref_side_index+2)%4
@@ -1716,7 +1716,7 @@ from compas.tolerance import TOL
 from ghpythonlib.componentbase import executingcomponent as component
 from Grasshopper.Kernel.GH_RuntimeMessageLevel import Warning
 
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 from compas_timber.connections import ConnectionSolver
 from compas_timber.connections import JointTopology
 from compas_timber.connections import LMiterJoint
@@ -1874,7 +1874,7 @@ class ModelComponent(component):
                     continue
                 try:
                     joint.joint_type.create(Model, *beams_to_pair, **joint.kwargs)
-                except BeamJoinningError as bje:
+                except BeamJoiningError as bje:
                     debug_info.add_joint_error(bje)
                 else:
                     handled_beams.append(beam_pair_ids)

--- a/examples/Grasshopper/tests/test_step_joint.ghx
+++ b/examples/Grasshopper/tests/test_step_joint.ghx
@@ -5818,7 +5818,7 @@ from compas.tolerance import TOL
 from ghpythonlib.componentbase import executingcomponent as component
 from Grasshopper.Kernel.GH_RuntimeMessageLevel import Warning
 
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 from compas_timber.connections import ConnectionSolver
 from compas_timber.connections import JointTopology
 from compas_timber.connections import LMiterJoint
@@ -5976,7 +5976,7 @@ class ModelComponent(component):
                     continue
                 try:
                     joint.joint_type.create(Model, *beams_to_pair, **joint.kwargs)
-                except BeamJoinningError as bje:
+                except BeamJoiningError as bje:
                     debug_info.add_joint_error(bje)
                 else:
                     handled_beams.append(beam_pair_ids)

--- a/examples/Grasshopper/tests/test_tenon_mortise_joint.ghx
+++ b/examples/Grasshopper/tests/test_tenon_mortise_joint.ghx
@@ -1709,19 +1709,19 @@ ref_side_cross = frame_to_rhino(cross_beam.ref_sides[cross_ref_side_index])
 
 #create dovetail_tenon
 tenon = Tenon.from_plane_and_beam(
-            cross_beam.ref_sides[cross_ref_side_index], 
-            main_beam, 
-            start_y=start_y, 
-            rotation=rotation, 
-            start_depth=start_depth, 
-            width=width, 
+            cross_beam.ref_sides[cross_ref_side_index],
+            main_beam,
+            start_y=start_y,
+            rotation=rotation,
+            start_depth=start_depth,
+            width=width,
             length=length,
             height=height,
             shape = shape,
             shape_radius = shape_radius,
             ref_side_index=main_ref_side_index,
         )
-        
+
 print(tenon.ref_side_index)
 house = House.from_tenon(tenon, length, width, height)
 print(house.subprocessings)
@@ -1732,7 +1732,7 @@ house_params = house.params_dict
 main_beam.add_features(house)
 #model = TimberModel()
 #model.add_elements(main_beam)
-#        
+#
 ##cutting_frame
 cutting_plane_tenon= tenon.frame_from_params_and_beam(main_beam)
 ##tenon volume
@@ -3264,7 +3264,7 @@ from compas.tolerance import TOL
 from ghpythonlib.componentbase import executingcomponent as component
 from Grasshopper.Kernel.GH_RuntimeMessageLevel import Warning
 
-from compas_timber.connections import BeamJoinningError
+from compas_timber.connections import BeamJoiningError
 from compas_timber.connections import ConnectionSolver
 from compas_timber.connections import JointTopology
 from compas_timber.connections import LMiterJoint
@@ -3422,7 +3422,7 @@ class ModelComponent(component):
                     continue
                 try:
                     joint.joint_type.create(Model, *beams_to_pair, **joint.kwargs)
-                except BeamJoinningError as bje:
+                except BeamJoiningError as bje:
                     debug_info.add_joint_error(bje)
                 else:
                     handled_beams.append(beam_pair_ids)

--- a/src/compas_timber/connections/joint.py
+++ b/src/compas_timber/connections/joint.py
@@ -59,7 +59,7 @@ class Joint(Interaction):
 
         Raises
         ------
-        :class:`~compas_timber.connections.BeamJoinningError`
+        :class:`~compas_timber.connections.BeamJoiningError`
             Should be raised whenever the joint was not able to calculate the features to be applied to the beams.
 
         """
@@ -75,7 +75,7 @@ class Joint(Interaction):
 
         Raises
         ------
-        :class:`~compas_timber.connections.BeamJoinningError`
+        :class:`~compas_timber.connections.BeamJoiningError`
             Should be raised whenever the joint was not able to calculate the extensions to be applied to the beams.
 
         """
@@ -87,7 +87,7 @@ class Joint(Interaction):
 
         Raises
         ------
-        :class:`~compas_timber.connections.BeamJoinningError`
+        :class:`~compas_timber.connections.BeamJoiningError`
             Should be raised whenever the elements did not comply with the requirements of the joint.
 
         """

--- a/src/compas_timber/connections/l_butt.py
+++ b/src/compas_timber/connections/l_butt.py
@@ -1,5 +1,5 @@
 from compas_timber.connections.utilities import beam_ref_side_incidence
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 from compas_timber.fabrication import JackRafterCut
 from compas_timber.fabrication import Lap
 
@@ -90,7 +90,7 @@ class LButtJoint(Joint):
         ref_side_index = min(ref_side_dict, key=ref_side_dict.get)
 
         if self.reject_i and ref_side_index in [4, 5]:
-            raise BeamJoinningError(beams=self.elements, joint=self, debug_info="Beams are in I topology and reject_i flag is True")
+            raise BeamJoiningError(beams=self.elements, joint=self, debug_info="Beams are in I topology and reject_i flag is True")
         return ref_side_index
 
     @property
@@ -113,7 +113,7 @@ class LButtJoint(Joint):
 
         Raises
         ------
-        BeamJoinningError
+        BeamJoiningError
             If the extension could not be calculated.
 
         """
@@ -127,9 +127,9 @@ class LButtJoint(Joint):
                     cutting_plane_main.translate(-cutting_plane_main.normal * self.mill_depth)
                 start_main, end_main = self.main_beam.extension_to_plane(cutting_plane_main)
             except AttributeError as ae:
-                raise BeamJoinningError(beams=self.elements, joint=self, debug_info=str(ae), debug_geometries=[cutting_plane_main])
+                raise BeamJoiningError(beams=self.elements, joint=self, debug_info=str(ae), debug_geometries=[cutting_plane_main])
             except Exception as ex:
-                raise BeamJoinningError(beams=self.elements, joint=self, debug_info=str(ex))
+                raise BeamJoiningError(beams=self.elements, joint=self, debug_info=str(ex))
             extension_tolerance = 0.01  # TODO: this should be proportional to the unit used
             self.main_beam.add_blank_extension(
                 start_main + extension_tolerance,
@@ -141,7 +141,7 @@ class LButtJoint(Joint):
             cutting_plane_cross = self.main_beam.ref_sides[self.main_beam_opposing_side_index]
             start_cross, end_cross = self.cross_beam.extension_to_plane(cutting_plane_cross)
         except AttributeError as ae:
-            raise BeamJoinningError(beams=self.elements, joint=self, debug_info=str(ae), debug_geometries=[cutting_plane_cross])
+            raise BeamJoiningError(beams=self.elements, joint=self, debug_info=str(ae), debug_geometries=[cutting_plane_cross])
         extension_tolerance = 0.01  # TODO: this should be proportional to the unit used
         self.cross_beam.add_blank_extension(
             start_cross + extension_tolerance,

--- a/src/compas_timber/connections/l_french_ridge_lap.py
+++ b/src/compas_timber/connections/l_french_ridge_lap.py
@@ -2,7 +2,7 @@ from compas.tolerance import TOL
 
 from compas_timber.connections.utilities import beam_ref_side_incidence
 from compas_timber.connections.utilities import beam_ref_side_incidence_with_vector
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 from compas_timber.fabrication import FrenchRidgeLap
 
 from .joint import Joint
@@ -105,7 +105,7 @@ class LFrenchRidgeLapJoint(Joint):
 
         Raises
         ------
-        BeamJoinningError
+        BeamJoiningError
             If the extension could not be calculated.
 
         """
@@ -118,9 +118,9 @@ class LFrenchRidgeLapJoint(Joint):
         except AttributeError as ae:
             # I want here just the plane that caused the error
             geometries = [self.cutting_plane_a] if start_a is not None else [self.cutting_plane_b]
-            raise BeamJoinningError(self.elements, self, debug_info=str(ae), debug_geometries=geometries)
+            raise BeamJoiningError(self.elements, self, debug_info=str(ae), debug_geometries=geometries)
         except Exception as ex:
-            raise BeamJoinningError(self.elements, self, debug_info=str(ex))
+            raise BeamJoiningError(self.elements, self, debug_info=str(ex))
         self.beam_a.add_blank_extension(start_a, end_a, self.guid)
         self.beam_b.add_blank_extension(start_b, end_b, self.guid)
 
@@ -149,7 +149,7 @@ class LFrenchRidgeLapJoint(Joint):
 
         Raises
         ------
-        BeamJoinningError
+        BeamJoiningError
             If the elements are not compatible for the creation of the joint.
 
         """
@@ -159,7 +159,7 @@ class LFrenchRidgeLapJoint(Joint):
             beam_normal = beam.frame.normal.unitized()
             dot = abs(beam_normal.dot(cross_vect.unitized()))
             if not (TOL.is_zero(dot) or TOL.is_close(dot, 1)):
-                raise BeamJoinningError(
+                raise BeamJoiningError(
                     self.beam_a,
                     self.beam_b,
                     debug_info="The the two beams are not aligned to create a French Ridge Lap joint.",
@@ -173,7 +173,7 @@ class LFrenchRidgeLapJoint(Joint):
             dimensions.append((width, height))
         # check if the dimensions of both beams match
         if dimensions[0] != dimensions[1]:
-            raise BeamJoinningError(self.beam_a, self.beam_b, debug_info="The beams have different dimensions.")
+            raise BeamJoiningError(self.beam_a, self.beam_b, debug_info="The beams have different dimensions.")
 
     def restore_beams_from_keys(self, model):
         """After de-serialization, restores references to the main and cross beams saved in the model."""

--- a/src/compas_timber/connections/l_halflap.py
+++ b/src/compas_timber/connections/l_halflap.py
@@ -2,7 +2,7 @@ from compas.geometry import Frame
 
 from compas_timber.elements import CutFeature
 from compas_timber.elements import MillVolume
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 
 from .lap_joint import LapJoint
 from .solver import JointTopology
@@ -58,7 +58,7 @@ class LHalfLapJoint(LapJoint):
 
         Raises
         ------
-        BeamJoinningError
+        BeamJoiningError
             If the extension could not be calculated.
 
         """
@@ -67,7 +67,7 @@ class LHalfLapJoint(LapJoint):
             main_cutting_frame = self.get_main_cutting_frame()
             cross_cutting_frame = self.get_cross_cutting_frame()
         except Exception as ex:
-            raise BeamJoinningError(beams=self.elements, joint=self, debug_info=str(ex))
+            raise BeamJoiningError(beams=self.elements, joint=self, debug_info=str(ex))
 
         start_main, end_main = self.main_beam.extension_to_plane(main_cutting_frame)
         start_cross, end_cross = self.cross_beam.extension_to_plane(cross_cutting_frame)
@@ -84,7 +84,7 @@ class LHalfLapJoint(LapJoint):
             cross_cutting_frame = self.get_cross_cutting_frame()
             negative_brep_main_beam, negative_brep_cross_beam = self._create_negative_volumes()
         except Exception as ex:
-            raise BeamJoinningError(beams=self.elements, joint=self, debug_info=str(ex))
+            raise BeamJoiningError(beams=self.elements, joint=self, debug_info=str(ex))
 
         main_volume = MillVolume(negative_brep_main_beam)
         cross_volume = MillVolume(negative_brep_cross_beam)

--- a/src/compas_timber/connections/l_miter.py
+++ b/src/compas_timber/connections/l_miter.py
@@ -4,7 +4,7 @@ from compas.geometry import Point
 from compas.geometry import Vector
 from compas.geometry import cross_vectors
 
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 from compas_timber.fabrication import JackRafterCut
 from compas_timber.utils import intersection_line_line_param
 
@@ -104,7 +104,7 @@ class LMiterJoint(Joint):
 
         Raises
         ------
-        BeamJoinningError
+        BeamJoiningError
             If the extension could not be calculated.
 
         """
@@ -117,9 +117,9 @@ class LMiterJoint(Joint):
         except AttributeError as ae:
             # I want here just the plane that caused the error
             geometries = [plane_b] if start_a is not None else [plane_a]
-            raise BeamJoinningError(self.elements, self, debug_info=str(ae), debug_geometries=geometries)
+            raise BeamJoiningError(self.elements, self, debug_info=str(ae), debug_geometries=geometries)
         except Exception as ex:
-            raise BeamJoinningError(self.elements, self, debug_info=str(ex))
+            raise BeamJoiningError(self.elements, self, debug_info=str(ex))
         self.beam_a.add_blank_extension(start_a, end_a, self.guid)
         self.beam_b.add_blank_extension(start_b, end_b, self.guid)
 
@@ -138,7 +138,7 @@ class LMiterJoint(Joint):
         try:
             plane_a, plane_b = self.get_cutting_planes()
         except Exception as ex:
-            raise BeamJoinningError(self.elements, self, debug_info=str(ex))
+            raise BeamJoiningError(self.elements, self, debug_info=str(ex))
 
         cut1 = JackRafterCut.from_plane_and_beam(plane_a, self.beam_a)
         cut2 = JackRafterCut.from_plane_and_beam(plane_b, self.beam_b)

--- a/src/compas_timber/connections/t_birdsmouth.py
+++ b/src/compas_timber/connections/t_birdsmouth.py
@@ -3,7 +3,7 @@ from compas.geometry import distance_point_line
 from compas.geometry import intersection_plane_plane_plane
 
 from compas_timber.connections.utilities import beam_ref_side_incidence
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 from compas_timber.fabrication import DoubleCut
 
 from .joint import Joint
@@ -79,7 +79,7 @@ class TBirdsmouthJoint(Joint):
 
         Raises
         ------
-        BeamJoinningError
+        BeamJoiningError
             If the extension could not be calculated.
 
         """
@@ -92,7 +92,7 @@ class TBirdsmouthJoint(Joint):
         try:
             start_a, end_a = self.main_beam.extension_to_plane(plane)
         except Exception as ex:
-            raise BeamJoinningError(self.elements, self, debug_info=str(ex))
+            raise BeamJoiningError(self.elements, self, debug_info=str(ex))
         self.main_beam.add_blank_extension(start_a, end_a, self.guid)
 
     def add_features(self):

--- a/src/compas_timber/connections/t_butt.py
+++ b/src/compas_timber/connections/t_butt.py
@@ -1,7 +1,7 @@
 from compas_timber.connections import Joint
 from compas_timber.connections import JointTopology
 from compas_timber.connections.utilities import beam_ref_side_incidence
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 from compas_timber.fabrication import JackRafterCut
 from compas_timber.fabrication import Lap
 
@@ -107,7 +107,7 @@ class TButtJoint(Joint):
 
         Raises
         ------
-        BeamJoinningError
+        BeamJoiningError
             If the extension could not be calculated.
 
         """
@@ -118,9 +118,9 @@ class TButtJoint(Joint):
                 cutting_plane.translate(-cutting_plane.normal * self.mill_depth)
             start_main, end_main = self.main_beam.extension_to_plane(cutting_plane)
         except AttributeError as ae:
-            raise BeamJoinningError(beams=self.elements, joint=self, debug_info=str(ae), debug_geometries=[cutting_plane])
+            raise BeamJoiningError(beams=self.elements, joint=self, debug_info=str(ae), debug_geometries=[cutting_plane])
         except Exception as ex:
-            raise BeamJoinningError(beams=self.elements, joint=self, debug_info=str(ex))
+            raise BeamJoiningError(beams=self.elements, joint=self, debug_info=str(ex))
         extension_tolerance = 0.01  # TODO: this should be proportional to the unit used
         self.main_beam.add_blank_extension(
             start_main + extension_tolerance,

--- a/src/compas_timber/connections/t_dovetail.py
+++ b/src/compas_timber/connections/t_dovetail.py
@@ -3,7 +3,7 @@ import math
 from compas_timber.connections.utilities import beam_ref_side_incidence
 from compas_timber.connections.utilities import beam_ref_side_incidence_with_vector
 from compas_timber.connections.utilities import point_centerline_towards_joint
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 from compas_timber.fabrication import DovetailMortise
 from compas_timber.fabrication import DovetailTenon
 from compas_timber.fabrication import TenonShapeType
@@ -190,7 +190,7 @@ class TDovetailJoint(Joint):
 
         Raises
         ------
-        BeamJoinningError
+        BeamJoiningError
             If the extension could not be calculated.
 
         """
@@ -200,9 +200,9 @@ class TDovetailJoint(Joint):
             cutting_plane.translate(-cutting_plane.normal * self.tool_height)
             start_main, end_main = self.main_beam.extension_to_plane(cutting_plane)
         except AttributeError as ae:
-            raise BeamJoinningError(beams=self.elements, joint=self, debug_info=str(ae), debug_geometries=[cutting_plane])
+            raise BeamJoiningError(beams=self.elements, joint=self, debug_info=str(ae), debug_geometries=[cutting_plane])
         except Exception as ex:
-            raise BeamJoinningError(beams=self.elements, joint=self, debug_info=str(ex))
+            raise BeamJoiningError(beams=self.elements, joint=self, debug_info=str(ex))
         extension_tolerance = 0.01  # TODO: this should be proportional to the unit used
         self.main_beam.add_blank_extension(
             start_main + extension_tolerance,

--- a/src/compas_timber/connections/t_halflap.py
+++ b/src/compas_timber/connections/t_halflap.py
@@ -3,7 +3,7 @@ from compas.geometry import Frame
 from compas_timber.connections.lap_joint import LapJoint
 from compas_timber.elements import CutFeature
 from compas_timber.elements import MillVolume
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 
 from .solver import JointTopology
 
@@ -41,7 +41,7 @@ class THalfLapJoint(LapJoint):
 
         Raises
         ------
-        BeamJoinningError
+        BeamJoiningError
             If the extension could not be calculated.
 
         """
@@ -52,9 +52,9 @@ class THalfLapJoint(LapJoint):
             main_cutting_frame = self.get_main_cutting_frame()
             start_main, end_main = self.main_beam.extension_to_plane(main_cutting_frame)
         except AttributeError as ae:
-            raise BeamJoinningError(beams=self.beams, joint=self, debug_info=str(ae), debug_geometries=[main_cutting_frame])
+            raise BeamJoiningError(beams=self.beams, joint=self, debug_info=str(ae), debug_geometries=[main_cutting_frame])
         except Exception as ex:
-            raise BeamJoinningError(beams=self.beams, joint=self, debug_info=str(ex))
+            raise BeamJoiningError(beams=self.beams, joint=self, debug_info=str(ex))
 
         extension_tolerance = 0.01  # TODO: this should be proportional to the unit used
         self.main_beam.add_blank_extension(start_main + extension_tolerance, end_main + extension_tolerance, self.guid)
@@ -70,9 +70,9 @@ class THalfLapJoint(LapJoint):
             main_cutting_frame = self.get_main_cutting_frame()
             negative_brep_main_beam, negative_brep_cross_beam = self._create_negative_volumes()
         except AttributeError as ae:
-            raise BeamJoinningError(beams=self.beams, joint=self, debug_info=str(ae), debug_geometries=[main_cutting_frame])
+            raise BeamJoiningError(beams=self.beams, joint=self, debug_info=str(ae), debug_geometries=[main_cutting_frame])
         except Exception as ex:
-            raise BeamJoinningError(beams=self.beams, joint=self, debug_info=str(ex))
+            raise BeamJoiningError(beams=self.beams, joint=self, debug_info=str(ex))
 
         main_volume = MillVolume(negative_brep_main_beam)
         cross_volume = MillVolume(negative_brep_cross_beam)

--- a/src/compas_timber/connections/t_step_joint.py
+++ b/src/compas_timber/connections/t_step_joint.py
@@ -2,7 +2,7 @@ from compas.tolerance import TOL
 
 from compas_timber.connections.utilities import beam_ref_side_incidence
 from compas_timber.connections.utilities import beam_ref_side_incidence_with_vector
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 from compas_timber.fabrication import StepJoint
 from compas_timber.fabrication import StepJointNotch
 
@@ -156,7 +156,7 @@ class TStepJoint(Joint):
 
         Raises
         ------
-        BeamJoinningError
+        BeamJoiningError
             If the extension could not be calculated.
 
         """
@@ -167,9 +167,9 @@ class TStepJoint(Joint):
             start_a, end_a = self.main_beam.extension_to_plane(plane_a)
         except AttributeError as ae:
             # I want here just the plane that caused the error
-            raise BeamJoinningError(self.main_beam, self, debug_info=str(ae), debug_geometries=plane_a)
+            raise BeamJoiningError(self.main_beam, self, debug_info=str(ae), debug_geometries=plane_a)
         except Exception as ex:
-            raise BeamJoinningError(self.main_beam, self, debug_info=str(ex))
+            raise BeamJoiningError(self.main_beam, self, debug_info=str(ex))
         self.main_beam.add_blank_extension(start_a, end_a, self.main_beam_guid)
 
     def add_features(self):
@@ -226,7 +226,7 @@ class TStepJoint(Joint):
 
         Raises
         ------
-        BeamJoinningError
+        BeamJoiningError
             If the elements are not compatible for the creation of the joint.
 
         """
@@ -236,7 +236,7 @@ class TStepJoint(Joint):
             beam_normal = beam.frame.normal.unitized()
             dot = abs(beam_normal.dot(cross_vect.unitized()))
             if not (TOL.is_zero(dot) or TOL.is_close(dot, 1)):
-                raise BeamJoinningError(
+                raise BeamJoiningError(
                     self.main_beam,
                     self.cross_beam,
                     debug_info="The the two beams are not aligned to create a Step joint.")

--- a/src/compas_timber/connections/t_tenon_mortise.py
+++ b/src/compas_timber/connections/t_tenon_mortise.py
@@ -1,5 +1,5 @@
 from compas_timber.connections.utilities import beam_ref_side_incidence
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 from compas_timber.fabrication import Mortise
 from compas_timber.fabrication import Tenon
 from compas_timber.fabrication import TenonShapeType
@@ -176,7 +176,7 @@ class TenonMortiseJoint(Joint):
 
         Raises
         ------
-        BeamJoinningError
+        BeamJoiningError
             If the extension could not be calculated.
 
         """
@@ -189,7 +189,7 @@ class TenonMortiseJoint(Joint):
             cutting_plane = self.main_beam.ref_sides[opposing_ref_side]
             start_cross, end_cross = self.cross_beam.extension_to_plane(cutting_plane)
         except AttributeError as ae:
-            raise BeamJoinningError(beams=self.elements, joint=self, debug_info=str(ae), debug_geometries=[cutting_plane])
+            raise BeamJoiningError(beams=self.elements, joint=self, debug_info=str(ae), debug_geometries=[cutting_plane])
         self.cross_beam.add_blank_extension(
             start_cross + extension_tolerance,
             end_cross + extension_tolerance,
@@ -201,7 +201,7 @@ class TenonMortiseJoint(Joint):
             cutting_plane.translate(-cutting_plane.normal * self.height)
             start_main, end_main = self.main_beam.extension_to_plane(cutting_plane)
         except AttributeError as ae:
-            raise BeamJoinningError(beams=self.elements, joint=self, debug_info=str(ae), debug_geometries=[cutting_plane])
+            raise BeamJoiningError(beams=self.elements, joint=self, debug_info=str(ae), debug_geometries=[cutting_plane])
         self.main_beam.add_blank_extension(
             start_main + extension_tolerance,
             end_main + extension_tolerance,

--- a/src/compas_timber/connections/x_halflap.py
+++ b/src/compas_timber/connections/x_halflap.py
@@ -1,5 +1,5 @@
 from compas_timber.elements import MillVolume
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 
 from .lap_joint import LapJoint
 from .solver import JointTopology
@@ -37,7 +37,7 @@ class XHalfLapJoint(LapJoint):
         try:
             negative_brep_beam_a, negative_brep_beam_b = self._create_negative_volumes()
         except Exception as ex:
-            raise BeamJoinningError(beams=self.beams, joint=self, debug_info=str(ex))
+            raise BeamJoiningError(beams=self.beams, joint=self, debug_info=str(ex))
         volume_a = MillVolume(negative_brep_beam_a)
         volume_b = MillVolume(negative_brep_beam_b)
         self.main_beam.add_features(volume_a)

--- a/src/compas_timber/elements/fasteners/plate_fastener.py
+++ b/src/compas_timber/elements/fasteners/plate_fastener.py
@@ -214,7 +214,7 @@ class PlateFastener(Fastener):
 
         Raises
         ------
-        BeamJoinningError
+        BeamJoiningError
             If the beams are not compatible.
 
         """

--- a/src/compas_timber/errors/__init__.py
+++ b/src/compas_timber/errors/__init__.py
@@ -19,7 +19,7 @@ class FeatureApplicationError(Exception):
         self.message = message
 
 
-class BeamJoinningError(Exception):
+class BeamJoiningError(Exception):
     """Indicates that an error has occurred while trying to join two or more beams.
 
     This error should indicate that an error has occurred while calculating the features which
@@ -39,7 +39,7 @@ class BeamJoinningError(Exception):
     """
 
     def __init__(self, beams, joint, debug_info=None, debug_geometries=None):
-        super(BeamJoinningError, self).__init__()
+        super(BeamJoiningError, self).__init__()
         self.beams = beams
         self.joint = joint
         self.debug_info = debug_info
@@ -69,6 +69,6 @@ class FastenerApplicationError(Exception):
 
 __all__ = [
     "FeatureApplicationError",
-    "BeamJoinningError",
+    "BeamJoiningError",
     "FeatureApplicationError",
 ]

--- a/src/compas_timber/ghpython/components/CT_Model/code.py
+++ b/src/compas_timber/ghpython/components/CT_Model/code.py
@@ -11,7 +11,7 @@ from compas_timber.design import DebugInfomation
 from compas_timber.design import JointRule
 from compas_timber.elements import Beam
 from compas_timber.elements import Plate
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 from compas_timber.model import TimberModel
 
 JOINT_DEFAULTS = {
@@ -53,7 +53,7 @@ class ModelComponent(component):
             for joint in joints[::-1]:
                 try:
                     joint.joint_type.create(Model, *joint.elements, **joint.kwargs)
-                except BeamJoinningError as bje:
+                except BeamJoiningError as bje:
                     debug_info.add_joint_error(bje)
 
         # applies extensions and features resulting from joints


### PR DESCRIPTION
change the spelling of `BeamJoinningError` (sorry Chen)

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
