### PR TITLE
Fix `BeamJoiningError` handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the error message when beam endpoints coincide, e.g. when a closed polyline is used as input. 
 * Changed `index` input of `ShowFeatureErrors` and `ShowJoiningErrors` do have default value of 0.
 * Fixed spelling of `BeamJoinningError` to `BeamJoiningError`.
+* Changed `process_joinery()` method to handle `BeamJoiningError` exceptions and return them. Also updated `Model` GH component.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `index` input of `ShowFeatureErrors` and `ShowJoiningErrors` do have default value of 0.
 * Fixed spelling of `BeamJoinningError` to `BeamJoiningError`.
 * Changed `process_joinery()` method to handle `BeamJoiningError` exceptions and return them. Also updated `Model` GH component.
+* Updated `add_joint_error()` method in `DebugInformation` class to handle lists.
 
 ### Removed
 

--- a/src/compas_timber/connections/l_french_ridge_lap.py
+++ b/src/compas_timber/connections/l_french_ridge_lap.py
@@ -159,11 +159,8 @@ class LFrenchRidgeLapJoint(Joint):
             beam_normal = beam.frame.normal.unitized()
             dot = abs(beam_normal.dot(cross_vect.unitized()))
             if not (TOL.is_zero(dot) or TOL.is_close(dot, 1)):
-                raise BeamJoinningError(
-                    self.beam_a,
-                    self.beam_b,
-                    debug_info="The the two beams are not aligned to create a French Ridge Lap joint.",
-                )
+                raise BeamJoinningError(self.elements, self, debug_info="The two beams are not aligned to create a French Ridge Lap joint.")
+
         # calculate widths and heights of the beams
         dimensions = []
         ref_side_indices = [self.beam_a_ref_side_index, self.beam_b_ref_side_index]
@@ -173,7 +170,7 @@ class LFrenchRidgeLapJoint(Joint):
             dimensions.append((width, height))
         # check if the dimensions of both beams match
         if dimensions[0] != dimensions[1]:
-            raise BeamJoinningError(self.beam_a, self.beam_b, debug_info="The beams have different dimensions.")
+            raise BeamJoinningError(self.elements, self, debug_info="The two beams must have the same dimensions to create a French Ridge Lap joint.")
 
     def restore_beams_from_keys(self, model):
         """After de-serialization, restores references to the main and cross beams saved in the model."""

--- a/src/compas_timber/design/workflow.py
+++ b/src/compas_timber/design/workflow.py
@@ -405,4 +405,7 @@ class DebugInfomation(object):
             self.feature_errors.append(error)
 
     def add_joint_error(self, error):
-        self.joint_errors.append(error)
+        if isinstance(error, list):
+            self.joint_errors.extend(error)
+        else:
+            self.joint_errors.append(error)

--- a/src/compas_timber/ghpython/components/CT_Model/code.py
+++ b/src/compas_timber/ghpython/components/CT_Model/code.py
@@ -51,13 +51,12 @@ class ModelComponent(component):
         if joints:
             # apply reversed. later joints in orginal list override ealier ones
             for joint in joints[::-1]:
-                try:
-                    joint.joint_type.create(Model, *joint.elements, **joint.kwargs)
-                except BeamJoinningError as bje:
-                    debug_info.add_joint_error(bje)
+                joint.joint_type.create(Model, *joint.elements, **joint.kwargs)
 
-        # applies extensions and features resulting from joints
-        Model.process_joinery()
+        # checks elements compatibility and applies extensions and features resulting from joints
+        bje = Model.process_joinery()
+        if bje:
+            debug_info.add_joint_error(bje)
 
         if Features:
             features = [f for f in Features if f is not None]

--- a/src/compas_timber/model/model.py
+++ b/src/compas_timber/model/model.py
@@ -7,7 +7,7 @@ from compas.geometry import Point
 from compas_model.models import Model
 
 from compas_timber.connections import Joint
-from compas_timber.errors import BeamJoinningError
+from compas_timber.errors import BeamJoiningError
 
 
 class TimberModel(Model):
@@ -275,7 +275,7 @@ class TimberModel(Model):
 
         Returns
         -------
-        list[:class:`~compas_timber.errors.BeamJoinningError`]
+        list[:class:`~compas_timber.errors.BeamJoiningError`]
             A list of errors that occurred during the joinery process.
 
         """
@@ -284,7 +284,7 @@ class TimberModel(Model):
             try:
                 joint.check_elements_compatibility()
                 joint.add_extensions()
-            except BeamJoinningError as bje:
+            except BeamJoiningError as bje:
                 errors.append(bje)
                 if stop_on_first_error:
                     raise bje
@@ -292,7 +292,7 @@ class TimberModel(Model):
         for joint in self.joints:
             try:
                 joint.add_features()
-            except BeamJoinningError as bje:
+            except BeamJoiningError as bje:
                 errors.append(bje)
                 if stop_on_first_error:
                     raise bje


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR updates the `process_joinery()` method to properly handle `BeamJoiningError` exceptions, which were previously unhandled, causing them to be raised immediately during execution. 
The method now collects and returns all errors instead of terminating unexpectedly. 
Additionally, the `stop_on_first_error` parameter was introduced to optionally halt execution upon encountering the first error.

### What type of change is this?

- [X] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [X] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [X] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
