### PR TITLE
Optimize default Lap Side in `LapJoint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Refactored `compas_timber.connections.LapJoint` to comply with the new system.
 * Changed `THalfLapJoint`, `LHalfLapJoint`, `XHalfLapJoint` from `compas_timber.connections` so that they use the `Lap` BTLx processing.
 * Renamed all `X/T/LHalfLapJoint` classes to `X/T/LLapJoint`.
+* Adjusted `_get_beam_ref_side_index` method in `LapJoint` class so that the default lap side is the most optimal one.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Refactored `compas_timber.connections.LapJoint` to comply with the new system.
 * Changed `THalfLapJoint`, `LHalfLapJoint`, `XHalfLapJoint` from `compas_timber.connections` so that they use the `Lap` BTLx processing.
 * Renamed all `X/T/LHalfLapJoint` classes to `X/T/LLapJoint`.
-* Adjusted `_get_beam_ref_side_index` method in `LapJoint` class so that the default lap side is the most optimal one.
+* Enhanced lap behavior for optimal beam orientation in `LapJoint` class.
 
 ### Removed
 

--- a/src/compas_timber/connections/lap_joint.py
+++ b/src/compas_timber/connections/lap_joint.py
@@ -7,6 +7,7 @@ from compas.geometry import Point
 from compas.geometry import Polyhedron
 from compas.geometry import Vector
 from compas.geometry import angle_vectors
+from compas.geometry import intersection_line_line
 from compas.geometry import intersection_line_plane
 from compas.geometry import intersection_plane_plane_plane
 
@@ -109,7 +110,12 @@ class LapJoint(Joint):
     @staticmethod
     def _get_beam_ref_side_index(beam_a, beam_b, flip):
         """Returns the reference side index of beam_a with respect to beam_b."""
+        # get the offset vector of the two centerlines, if any
+        offset_vector = Vector.from_start_end(*intersection_line_line(beam_a.centerline, beam_b.centerline))
         cross_vector = beam_a.centerline.direction.cross(beam_b.centerline.direction)
+        # flip the cross_vector if it is pointing in the opposite direction of the offset_vector
+        if cross_vector.dot(offset_vector) < 0:
+            cross_vector = -cross_vector
         ref_side_dict = beam_ref_side_incidence_with_vector(beam_a, cross_vector, ignore_ends=True)
         if flip:
             return max(ref_side_dict, key=ref_side_dict.get)


### PR DESCRIPTION

![ViewCapture20250123_180758](https://github.com/user-attachments/assets/f7d38e4a-6780-4eaa-bf91-7063cbbd38c5)

<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
This is a minor adjustment of the `LapJoint` class, to ensure that the default lap side is the most optimal one. This is handy when the centerlines are offseted (ie. quarter-lap joint) were one lap side makes more sense than the other. The `flip_lap_side` argument is retained, allowing users to select the opposite lap side if desired.

### What type of change is this?

- [X] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [X] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [X] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
