### PR TITLE
Processing proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+
 * Added `distance_segment_segment` to `compas_timber.utils`
 * Added `BTLxFromGeometryDefinition` class to replace the depricated `FeatureDefinition`. This allows deferred calculation of BTLx processings.
 * Added `from_shapes_and_element` class method to `Drilling`, `JackRafterCut`, and `DoubleCut` as a wrapper for their geometry based constructors for use with `BTLxFromGeometryDefinition`.
 * Added `YButtJoint` which joins the ends of three joints where the `cross_beams` get a miter cut and the `main_beam` gets a double cut.
+* Added `JackRafterCutProxy` to allow for deferred calculation of the `JackRafterCut` geometry thus improving visualization performance.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `max_distance` argument to `JointRule` subclasses and GH components so that max_distance can be set for each joint rule individually.
 * Changed referenced to `beam` in `Drilling` to `element`. 
 * Changed `Drill Hole` and `Trim Feature` GH components to generate the relevant `BTLxProcessing` type rather than the deprecated `FeatureDefinition` type.
-
-* Changed `Show_beam_faces` gh component to `Show_ref_sides`, which now takes an `int` index and shows the corresponding face
-  including origin corner.
+* Changed `Show_beam_faces` gh component to `Show_ref_sides`, which now takes an `int` index and shows the corresponding face including origin corner.
+* Using new `JackRafterCutProxy` in LMiterJoint, LButtJoint and TButtJoint.
 
 ### Removed
 

--- a/src/compas_timber/connections/l_butt.py
+++ b/src/compas_timber/connections/l_butt.py
@@ -1,6 +1,6 @@
 from compas_timber.connections.utilities import beam_ref_side_incidence
 from compas_timber.errors import BeamJoiningError
-from compas_timber.fabrication import JackRafterCut
+from compas_timber.fabrication import JackRafterCutProxy
 from compas_timber.fabrication import Lap
 
 from .joint import Joint
@@ -168,7 +168,7 @@ class LButtJoint(Joint):
             cutting_plane.translate(cutting_plane.normal * self.mill_depth)
 
         # apply the cut on the main beam
-        main_feature = JackRafterCut.from_plane_and_beam(cutting_plane, self.main_beam, self.main_beam_ref_side_index)
+        main_feature = JackRafterCutProxy.from_plane_and_beam(cutting_plane, self.main_beam, self.main_beam_ref_side_index)
         self.main_beam.add_features(main_feature)
         # store the feature
         self.features = [main_feature]
@@ -191,7 +191,7 @@ class LButtJoint(Joint):
         # apply a refinement cut on the cross beam
         if self.modify_cross:
             modification_plane = self.main_beam.ref_sides[self.main_beam_opposing_side_index]
-            cross_refinement_feature = JackRafterCut.from_plane_and_beam(modification_plane, self.cross_beam, self.cross_beam_ref_side_index)
+            cross_refinement_feature = JackRafterCutProxy.from_plane_and_beam(modification_plane, self.cross_beam, self.cross_beam_ref_side_index)
             self.cross_beam.add_features(cross_refinement_feature)
             self.features.append(cross_refinement_feature)
 

--- a/src/compas_timber/connections/l_miter.py
+++ b/src/compas_timber/connections/l_miter.py
@@ -5,7 +5,7 @@ from compas.geometry import Vector
 from compas.geometry import cross_vectors
 
 from compas_timber.errors import BeamJoiningError
-from compas_timber.fabrication import JackRafterCut
+from compas_timber.fabrication import JackRafterCutProxy
 from compas_timber.utils import intersection_line_line_param
 
 from .joint import Joint
@@ -140,8 +140,8 @@ class LMiterJoint(Joint):
         except Exception as ex:
             raise BeamJoiningError(self.elements, self, debug_info=str(ex))
 
-        cut1 = JackRafterCut.from_plane_and_beam(plane_a, self.beam_a)
-        cut2 = JackRafterCut.from_plane_and_beam(plane_b, self.beam_b)
+        cut1 = JackRafterCutProxy.from_plane_and_beam(plane_a, self.beam_a)
+        cut2 = JackRafterCutProxy.from_plane_and_beam(plane_b, self.beam_b)
         self.beam_a.add_features(cut1)
         self.beam_b.add_features(cut2)
         self.features = [cut1, cut2]

--- a/src/compas_timber/connections/t_butt.py
+++ b/src/compas_timber/connections/t_butt.py
@@ -2,7 +2,7 @@ from compas_timber.connections import Joint
 from compas_timber.connections import JointTopology
 from compas_timber.connections.utilities import beam_ref_side_incidence
 from compas_timber.errors import BeamJoiningError
-from compas_timber.fabrication import JackRafterCut
+from compas_timber.fabrication import JackRafterCutProxy
 from compas_timber.fabrication import Lap
 
 
@@ -147,7 +147,7 @@ class TButtJoint(Joint):
             cutting_plane.translate(cutting_plane.normal * self.mill_depth)
 
         # apply the cut on the main beam
-        main_feature = JackRafterCut.from_plane_and_beam(cutting_plane, self.main_beam, self.main_beam_ref_side_index)
+        main_feature = JackRafterCutProxy.from_plane_and_beam(cutting_plane, self.main_beam, self.main_beam_ref_side_index)
         self.main_beam.add_features(main_feature)
         # store the feature
         self.features = [main_feature]

--- a/src/compas_timber/fabrication/__init__.py
+++ b/src/compas_timber/fabrication/__init__.py
@@ -3,6 +3,7 @@ from .btlx import BTLxProcessing
 from .btlx import BTLxPart
 from .btlx import OrientationType
 from .jack_cut import JackRafterCut
+from .jack_cut import JackRafterCutProxy
 from .double_cut import DoubleCut
 from .drilling import Drilling
 from .step_joint_notch import StepJointNotch
@@ -26,6 +27,7 @@ __all__ = [
     "BTLxPart",
     "BTLxProcessing",
     "JackRafterCut",
+    "JackRafterCutProxy",
     "OrientationType",
     "DoubleCut",
     "Drilling",

--- a/src/compas_timber/fabrication/jack_cut.py
+++ b/src/compas_timber/fabrication/jack_cut.py
@@ -349,8 +349,6 @@ class JackRafterCutProxy(object):
 
     """
 
-    PROCESSING_NAME = "JackRafterCut"
-
     def __init__(self, plane, beam, ref_side_index=0):
         self.plane = plane
         self.beam = beam

--- a/src/compas_timber/model/model.py
+++ b/src/compas_timber/model/model.py
@@ -280,7 +280,8 @@ class TimberModel(Model):
 
         """
         errors = []
-        for joint in self.joints:
+        joints = self.joints
+        for joint in joints:
             try:
                 joint.check_elements_compatibility()
                 joint.add_extensions()
@@ -289,7 +290,7 @@ class TimberModel(Model):
                 if stop_on_first_error:
                     raise bje
 
-        for joint in self.joints:
+        for joint in joints:
             try:
                 joint.add_features()
             except BeamJoiningError as bje:


### PR DESCRIPTION
As noticed by @jonashaldemann, the new processing system tends to be quite a bit slower then the previous one. This is a little experiment trying to get some improvement.

Implemented a proxy object for `JackRafterCut` that's a drop-in replacement and behaves almost like it.
`JackRafterCutProxy` can be created similarly to `JackRafterCut` but it does not calculate machining parameters until they are requested either by calling `unproxified()` (which returns an actual instance of `JackRafterCut`) or by trying to call any attributes that are not available in `JackRafterCutProxy`. such calls are then passed through to an instance of `JackRafterCut`.

I replaced `JackRafterCut` with the proxy version in some joints and noticed some improvement.

We can implement these for some other processing or not depending on-demand, as otherwise everything behaves the same.

incidentally this creates a deferring effect which I know @obucklin you're working on, perhaps these could  be eventually merged as they are very similar.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
