### PR TITLE
Reject unsupported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Fixed "No intersection found between walls" error when walls connect in unsupported topology.
+* Implemented slab perimeter offset workaround.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed "No intersection found between walls" error when walls connect in unsupported topology.
+
 ### Removed
 
 

--- a/src/compas_timber/design/wall_populator.py
+++ b/src/compas_timber/design/wall_populator.py
@@ -686,11 +686,15 @@ class WallPopulator(object):
         edge_studs = [beam_def for beam_def in perimeter_beams if beam_def.type == "edge_stud"]
         plate_beams = [beam_def for beam_def in perimeter_beams if beam_def.type == "plate"]
 
-        # HACK alert! slabs seem to want it differently, get to the bottom of this
         if self._wall.is_wall:
             offset_elements(edge_studs + plate_beams)
         else:
-            offset_elements(edge_studs + plate_beams, offset_inside=False)
+            # HACK alert! slabs seem to want it differently, get to the bottom of this
+            if self.normal.z < 0:
+                offset_elements(edge_studs + plate_beams, offset_inside=False)
+            else:
+                offset_elements(edge_studs + plate_beams)
+
         shorten_edges_to_fit_between_plates(edge_studs, plate_beams, self.dist_tolerance)
 
         self._beam_definitions.extend(perimeter_beams)

--- a/src/compas_timber/model/model.py
+++ b/src/compas_timber/model/model.py
@@ -373,7 +373,9 @@ class TimberModel(Model):
             result = solver.find_wall_wall_topology(wall_a, wall_b, tol=1e-6, max_distance=max_distance)
 
             topology = result[0]
-            if topology == JointTopology.TOPO_UNKNOWN:
+
+            unsupported_topos = (JointTopology.TOPO_UNKNOWN, JointTopology.TOPO_I, JointTopology.TOPO_X)
+            if topology in unsupported_topos:
                 continue
 
             wall_a, wall_b = result[1], result[2]


### PR DESCRIPTION
Some wall populator fixes:
* Only join walls meeting in supported topologies (L and T)
* Workaround for the perimeter offset issue in floor slabs

![image](https://github.com/user-attachments/assets/5580d30f-0043-4ee0-b01b-d1a951451272)

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
