### PR TITLE
added deepcopy dunder to proxy processings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed max recursion depth error when copying `TimberModel`/`Beam` with proxy processings.
+
 ### Removed
 
 

--- a/src/compas_timber/fabrication/jack_cut.py
+++ b/src/compas_timber/fabrication/jack_cut.py
@@ -350,6 +350,12 @@ class JackRafterCutProxy(object):
 
     """
 
+    def __deepcopy__(self, *args, **kwargs):
+        # not sure there's value in copying the proxt as it's more of a performance hack.
+        # plus it references a beam so it would be a bit of a mess to copy it.
+        # for now just return the unproxified version
+        return self.unproxified()
+
     def __init__(self, plane, beam, ref_side_index=0):
         self.plane = plane
         self.beam = beam

--- a/src/compas_timber/fabrication/lap.py
+++ b/src/compas_timber/fabrication/lap.py
@@ -879,6 +879,12 @@ class LapProxy(object):
 
     """
 
+    def __deepcopy__(self, *args, **kwargs):
+        # not sure there's value in copying the proxt as it's more of a performance hack.
+        # plus it references a beam so it would be a bit of a mess to copy it.
+        # for now just return the unproxified version
+        return self.unproxified()
+
     def __init__(self, volume, beam, machining_limits=None, ref_side_index=None):
         self.volume = volume
         self.beam = beam

--- a/tests/compas_timber/test_model.py
+++ b/tests/compas_timber/test_model.py
@@ -184,3 +184,29 @@ def test_type_properties():
     assert not beam.is_plate
     assert not wall.is_plate
     assert not wall.is_beam
+
+
+def test_copy_model_with_processing_jackraftercut_proxy():
+    from compas_timber.fabrication import JackRafterCutProxy
+    from compas_timber.fabrication import JackRafterCut
+
+    # Create a TimberModel instance
+    model = TimberModel()
+
+    # Add a beam to the model
+    height, width, length = 200.11, 100.05, 2001.12
+    frame = Frame(point=Point(x=390.000, y=780.000, z=0.000), xaxis=Vector(x=0.989, y=0.145, z=0.000), yaxis=Vector(x=-0.145, y=0.989, z=-0.000))
+    beam = Beam(frame, length=length, width=width, height=height)
+    model.add_element(beam)
+
+    cutting_plane = Frame(point=Point(x=627.517, y=490.000, z=-187.681), xaxis=Vector(x=0.643, y=0.000, z=0.766), yaxis=Vector(x=0.000, y=1.000, z=-0.000))
+
+    # Create a processing proxy for the model
+    beam.add_feature(JackRafterCutProxy.from_plane_and_beam(cutting_plane, beam))
+
+    copied_model = model.copy()
+
+    copied_beams = list(copied_model.beams)
+    assert len(copied_beams) == 1
+    assert len(copied_beams[0].features) == 1
+    assert isinstance(copied_beams[0].features[0], JackRafterCut)


### PR DESCRIPTION
* Added `__deepcopy__` to proxies so not to get stuck in recursion when deep copying them. They don't actually get copied as this would be a bit complicated, but rather they just become the unproxified processing.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
