### PR TITLE
added custom reduce to errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed `TypeError` when deepcopying beams with `debug_info` on them.
+
 ### Removed
 
 

--- a/src/compas_timber/errors/__init__.py
+++ b/src/compas_timber/errors/__init__.py
@@ -18,6 +18,10 @@ class FeatureApplicationError(Exception):
         self.element_geometry = element_geometry
         self.message = message
 
+    def __reduce__(self):
+        # without this the error cannot be deepcopied
+        return (FeatureApplicationError, (self.feature_geometry, self.element_geometry, self.message))
+
 
 class BeamJoiningError(Exception):
     """Indicates that an error has occurred while trying to join two or more beams.
@@ -39,11 +43,15 @@ class BeamJoiningError(Exception):
     """
 
     def __init__(self, beams, joint, debug_info=None, debug_geometries=None):
-        super(BeamJoiningError, self).__init__()
+        super(BeamJoiningError, self).__init__(debug_info)
         self.beams = beams
         self.joint = joint
         self.debug_info = debug_info
         self.debug_geometries = debug_geometries or []
+
+    def __reduce__(self):
+        # without this the error cannot be deepcopied
+        return (BeamJoiningError, (self.beams, self.joint, self.debug_info, self.debug_geometries))
 
 
 class FastenerApplicationError(Exception):
@@ -65,6 +73,10 @@ class FastenerApplicationError(Exception):
         self.elements = elements
         self.fastener = fastener
         self.message = message
+
+    def __reduce__(self):
+        # without this the error cannot be deepcopied
+        return (FastenerApplicationError, (self.elements, self.fastener, self.message))
 
 
 __all__ = [

--- a/tests/compas_timber/test_model.py
+++ b/tests/compas_timber/test_model.py
@@ -210,3 +210,30 @@ def test_copy_model_with_processing_jackraftercut_proxy():
     assert len(copied_beams) == 1
     assert len(copied_beams[0].features) == 1
     assert isinstance(copied_beams[0].features[0], JackRafterCut)
+
+
+def test_error_deepcopy_feature():
+    from copy import deepcopy
+    from compas_timber.errors import FeatureApplicationError
+
+    error = FeatureApplicationError("mama", "papa", "dog")
+
+    deepcopy(error)
+
+
+def test_error_deepcopy_fastener():
+    from copy import deepcopy
+    from compas_timber.errors import FastenerApplicationError
+
+    error = FastenerApplicationError("mama", "papa", "dog")
+
+    deepcopy(error)
+
+
+def test_error_deepcopy_joint():
+    from copy import deepcopy
+    from compas_timber.errors import BeamJoiningError
+
+    error = BeamJoiningError("mama", "papa", "dog", "cucumber")
+
+    deepcopy(error)

--- a/tests/compas_timber/test_model.py
+++ b/tests/compas_timber/test_model.py
@@ -218,7 +218,11 @@ def test_error_deepcopy_feature():
 
     error = FeatureApplicationError("mama", "papa", "dog")
 
-    deepcopy(error)
+    error = deepcopy(error)
+
+    assert error.feature_geometry == "mama"
+    assert error.element_geometry == "papa"
+    assert error.message == "dog"
 
 
 def test_error_deepcopy_fastener():
@@ -227,7 +231,11 @@ def test_error_deepcopy_fastener():
 
     error = FastenerApplicationError("mama", "papa", "dog")
 
-    deepcopy(error)
+    error = deepcopy(error)
+
+    assert error.elements == "mama"
+    assert error.fastener == "papa"
+    assert error.message == "dog"
 
 
 def test_error_deepcopy_joint():
@@ -236,4 +244,9 @@ def test_error_deepcopy_joint():
 
     error = BeamJoiningError("mama", "papa", "dog", "cucumber")
 
-    deepcopy(error)
+    error = deepcopy(error)
+
+    assert error.beams == "mama"
+    assert error.joint == "papa"
+    assert error.debug_info == "dog"
+    assert error.debug_geometries == "cucumber"


### PR DESCRIPTION
* Fixed our errors so that they can be deepcopied along with the elements they're set on.

This involved adding a custom `__reduce__`, reason this is needed is discussed here:
https://stackoverflow.com/questions/16244923/how-to-make-a-custom-exception-class-with-multiple-init-args-pickleable

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
