### PR TITLE
`XNotchJoint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `scale` method to `compas_timber.fabrication.Text`.
 * Added `is_joinery` flag to `BTLxProcessing` to indicate if the processing is a result of joinery operation.
 * Added tasks `update-gh-header` to update the version in the header of the GH components.
+* Added new `compas_timber.connections.XNotchJoint`.
+* Added a proxy class for `Pocket` BTLx processing for performance optimization. 
 
 ### Changed
 

--- a/docs/api/compas_timber.connections.rst
+++ b/docs/api/compas_timber.connections.rst
@@ -28,6 +28,7 @@ Classes
     TStepJoint
     TenonMortiseJoint
     XLapJoint
+    XNotchJoint
     YButtJoint
 
 Functions

--- a/src/compas_timber/connections/__init__.py
+++ b/src/compas_timber/connections/__init__.py
@@ -13,6 +13,7 @@ from .t_step_joint import TStepJoint
 from .t_birdsmouth import TBirdsmouthJoint
 from .t_lap import TLapJoint
 from .x_lap import XLapJoint
+from .x_notch import XNotchJoint
 from .t_dovetail import TDovetailJoint
 from .t_tenon_mortise import TenonMortiseJoint
 from .ball_node import BallNodeJoint
@@ -35,6 +36,7 @@ __all__ = [
     "TBirdsmouthJoint",
     "LMiterJoint",
     "XLapJoint",
+    "XNotchJoint",
     "TLapJoint",
     "LLapJoint",
     "NullJoint",

--- a/src/compas_timber/connections/x_notch.py
+++ b/src/compas_timber/connections/x_notch.py
@@ -24,7 +24,7 @@ class XNotchJoint(Joint):
     main_beam : :class:`~compas_timber.parts.Beam`
         The first beam to be joined. This beam will have a notch applied to it.
     cross_beam : :class:`~compas_timber.parts.Beam`
-        The second beam to be joined.
+        The second beam to be joined. No features are applied to this beam.
 
     Attributes
     ----------

--- a/src/compas_timber/connections/x_notch.py
+++ b/src/compas_timber/connections/x_notch.py
@@ -1,0 +1,134 @@
+from compas.geometry import Brep
+from compas.geometry import BrepTrimmingError
+from compas.geometry import Vector
+from compas.geometry import intersection_line_line
+
+from compas_timber.errors import BeamJoiningError
+from compas_timber.fabrication import PocketProxy
+
+from .lap_joint import Joint
+from .solver import JointTopology
+from .utilities import beam_ref_side_incidence_with_vector
+
+
+class XNotchJoint(Joint):
+    """Represents an X-Notch type joint which joins the two beams somewhere along their length with a notch applied on the main_beam.
+    This joint type is typically used to connect two beams whose centerlines are offseted from each other, resulting in one resting on top of the other through a notch.
+
+    This joint type is compatible with beams in X topology.
+
+    Please use `XNotchJoint.create()` to properly create an instance of this class and associate it with a model.
+
+    Parameters
+    ----------
+    main_beam : :class:`~compas_timber.parts.Beam`
+        The first beam to be joined. This beam will have a notch applied to it.
+    cross_beam : :class:`~compas_timber.parts.Beam`
+        The second beam to be joined.
+
+    Attributes
+    ----------
+    main_beam : :class:`~compas_timber.parts.Beam`
+        The first beam to be joined. This beam will have a notch applied to it.
+    cross_beam : :class:`~compas_timber.parts.Beam`
+        The second beam to be joined. No features are applied to this beam.
+
+    """
+
+    SUPPORTED_TOPOLOGY = JointTopology.TOPO_X
+
+    @property
+    def __data__(self):
+        data = super(XNotchJoint, self).__data__
+        data["main_beam_guid"] = self.main_beam_guid
+        data["cross_beam_guid"] = self.cross_beam_guid
+        return data
+
+    def __init__(self, main_beam=None, cross_beam=None, **kwargs):
+        super(XNotchJoint, self).__init__(**kwargs)
+        self.main_beam = main_beam
+        self.cross_beam = cross_beam
+        self.main_beam_guid = kwargs.get("main_beam_guid", None) or str(main_beam.guid)
+        self.cross_beam_guid = kwargs.get("cross_beam_guid", None) or str(cross_beam.guid)
+        self.features = []
+        self._main_ref_side_index = None
+
+    @property
+    def elements(self):
+        return [self.main_beam, self.cross_beam]
+
+    @property
+    def main_ref_side_index(self):
+        """The reference side index of the main beam."""
+        if self._main_ref_side_index is None:
+            self._main_ref_side_index = self._get_beam_ref_side_index()
+        return self._main_ref_side_index
+
+    def _get_beam_ref_side_index(self):
+        """Determines the reference side index of the main beam based on the intersection of the centerlines of the two beams."""
+        # get the offset vector of the two centerlines, if any
+        main_beam, cross_beam = self.elements
+        offset_vector = Vector.from_start_end(*intersection_line_line(main_beam.centerline, cross_beam.centerline))
+        cross_vector = main_beam.centerline.direction.cross(cross_beam.centerline.direction)
+        # flip the cross_vector if it is pointing in the opposite direction of the offset_vector
+        if cross_vector.dot(offset_vector) < 0:
+            cross_vector = -cross_vector
+        ref_side_dict = beam_ref_side_incidence_with_vector(main_beam, cross_vector, ignore_ends=True)
+        return min(ref_side_dict, key=ref_side_dict.get)
+
+    def _create_negative_volume(self):
+        """Creates a negative volume for the X-Notch joint.
+
+        This method creates a negative volume that represents the notch to be applied to the main beam.
+        It uses the blank of the cross beam and trims it with the side frames of the main beam.
+        The negative volume is then used to create a pocket feature on the main beam.
+
+        Returns
+        -------
+        :class:`~compas.geometry.Brep`
+            The negative volume representing the notch.
+        """
+        assert self.elements
+        main_beam, cross_beam = self.elements
+
+        # create a Brep from the cross beam's blank
+        neg_vol = Brep.from_box(cross_beam.blank)
+        side_cutting_frames = [main_beam.front_side(self.main_ref_side_index), main_beam.back_side(self.main_ref_side_index)]
+        # trim the negative volume with the side frames of the main beam
+        for frame in side_cutting_frames:
+            try:
+                neg_vol.trim(frame)
+            except BrepTrimmingError as bte:
+                raise BeamJoiningError(
+                    beams=self.elements,
+                    joint=self,
+                    debug_info=f"Failed to generate the negative volume used to create the notch feature: {str(bte)}",
+                )
+        return neg_vol
+
+    def add_features(self):
+        """Adds the required extension and trimming features to both beams.
+
+        This method is automatically called when joint is created by the call to `Joint.create()`.
+
+        """
+        assert self.main_beam and self.cross_beam
+
+        if self.features:
+            self.main_beam.remove_features(self.features)
+            self.cross_beam.remove_features(self.features)
+
+        # create pocket features
+        negative_volume = self._create_negative_volume()
+        pocket_feature = PocketProxy.from_volume_and_element(negative_volume, self.main_beam, ref_side_index=self.main_ref_side_index)
+
+        # add features to the beams
+        self.main_beam.add_features(pocket_feature)
+
+        # register processings to the joint
+        self.features.append(pocket_feature)
+
+    def restore_beams_from_keys(self, model):
+        """After de-serialization, restores references to the main and cross beams saved in the model."""
+        self.main_beam = model.element_by_guid(self.main_beam_guid)
+        self.cross_beam = model.element_by_guid(self.cross_beam_guid)

--- a/src/compas_timber/fabrication/__init__.py
+++ b/src/compas_timber/fabrication/__init__.py
@@ -17,6 +17,7 @@ from .tenon import Tenon
 from .mortise import Mortise
 from .slot import Slot
 from .pocket import Pocket
+from .pocket import PocketProxy
 from .free_contour import FreeContour
 from .text import Text
 from .btlx import TenonShapeType
@@ -49,6 +50,7 @@ __all__ = [
     "Mortise",
     "Slot",
     "Pocket",
+    "PocketProxy",
     "FreeContour",
     "Text",
     "TenonShapeType",

--- a/src/compas_timber/fabrication/pocket.py
+++ b/src/compas_timber/fabrication/pocket.py
@@ -329,7 +329,7 @@ class Pocket(BTLxProcessing):
             raise ValueError("Volume must have 6 faces.")
 
         # get ref_side of the element
-        if not ref_side_index:
+        if ref_side_index is None:
             ref_side_index = cls._get_optimal_ref_side_index(element, volume)
         ref_side = element.ref_sides[ref_side_index]
 
@@ -380,10 +380,7 @@ class Pocket(BTLxProcessing):
         tilt_start_side = cls._calculate_tilt_angle(bottom_plane, start_plane)
 
         # define machining limits
-        if machining_limits:
-            if not isinstance(machining_limits, dict):
-                raise ValueError("machining_limits must be a dictionary.")
-        else:
+        if not machining_limits:
             machining_limits = cls._define_machining_limits(planes, element, ref_side_index)
 
         return cls(
@@ -643,7 +640,7 @@ class Pocket(BTLxProcessing):
         if self.machining_limits["FaceLimitedFront"]:
             front_frame = bottom_frame.rotated(math.radians(self.tilt_ref_side), -bottom_frame.yaxis, point=bottom_frame.point)
         else:
-            front_frame = element.ref_sides[(self.ref_side_index+1)%4]
+            front_frame = element.front_side(self.ref_side_index)
             front_frame.translate(front_frame.normal * tol.absolute)
 
         # tilt back frame
@@ -651,7 +648,7 @@ class Pocket(BTLxProcessing):
             back_frame = bottom_frame.rotated(math.radians(self.tilt_opp_side), bottom_frame.yaxis, point=bottom_frame.point)
             back_frame.translate(back_frame.normal * self.width)
         else:
-            back_frame = element.ref_sides[(self.ref_side_index-1)%4]
+            back_frame = element.back_side(self.ref_side_index)
             back_frame.translate(back_frame.normal * tol.absolute)
 
         frames = [start_frame, end_frame, top_frame, bottom_frame, front_frame, back_frame]


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
![image](https://github.com/user-attachments/assets/1ad4fdae-827c-4d68-8e1b-4891ae851201)

### What type of change is this?
Introduction of X-Notch Joint. This joint essentially creates a notch in the form of a `Pocket` BTLx Processing on one of the two beams, using the volume of the other beam.

This could be used for both joint configurations requested from @Stryzhevska (#444, #445) 


- [ ] Bug fix in a **backwards-compatible** manner.
- [X] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [X] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [X] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [X] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added necessary documentation (if appropriate)
