### PR TITLE
fix ball_node_joint and add Joint.from_element_list constructor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `PlateMiterJoint`.
 * Added `PlateConnectionSolver`.
 * Added generic `ButtJoint` class from which `TButtJoint` and `LButtJoint` inherit.
-* Added generic alternate constructor `Joint.from_element_list` to allow joints to override construction without reference to model. 
 
 ### Changed
 
@@ -62,8 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed attribute error when creating a `TButtJoint`.
 * Fixed a bug in `BeamsFromMesh` GH Component.
 * Changed default value for `modify_cross` to `True` for `LButtJoint`.
-* Fixed geometry creation for `BallNodeJoint`.
-* `BallNodeJoint` overrides instantiation with `BallNodeJoint.from_element_list` instead of create.
+* Fixed `elements` and geometry creation for `BallNodeJoint`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `PlateMiterJoint`.
 * Added `PlateConnectionSolver`.
 * Added generic `ButtJoint` class from which `TButtJoint` and `LButtJoint` inherit.
+* Added generic alternate constructor `Joint.from_element_list` to allow joints to override construction without reference to model. 
 
 ### Changed
 
@@ -59,6 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed several GH Components for Rhino8 compatibility.
 * Fixed `graph_node` is `None` after deserializing a `TimberModel`.
 * Fixed attribute error when creating a `TButtJoint`.
+* Fixed geometry creation for `BallNodeJoint`.
+* `BallNodeJoint` overrides instantiation with `BallNodeJoint.from_element_list` instead of create.
 
 ### Removed
 

--- a/src/compas_timber/connections/ball_node.py
+++ b/src/compas_timber/connections/ball_node.py
@@ -102,7 +102,6 @@ class BallNodeJoint(Joint):
         """
         return cls(elements, **kwargs)
 
-
     @property
     def node_point(self):
         """Returns the point at which the beams are joined, essentially the average of their intersection points."""

--- a/src/compas_timber/connections/ball_node.py
+++ b/src/compas_timber/connections/ball_node.py
@@ -70,7 +70,7 @@ class BallNodeJoint(Joint):
 
     @property
     def elements(self):
-        return self.beams + [self.generated_elements]
+        return list(self.beams) + self.generated_elements
 
     @property
     def interactions(self):
@@ -78,13 +78,11 @@ class BallNodeJoint(Joint):
             yield (beam, self.fastener)
 
     @classmethod
-    def create(cls, model, *elements, **kwargs):
-        """Creates an instance of the BallNodeJoint and creates the new connection in `model`.
+    def from_element_list(cls, elements, **kwargs):
+        """Creates an instance of the BallNodeJoint.
 
         This differs fom the generic `Joint.create()` method in that it passes the `beams` to
         the constructor of the BallNodeJoint as a list instead of as separate arguments.
-
-        `beams` are expected to have been added to `model` before calling this method.
 
         This code does not verify that the given beams are adjacent and/or lie in a topology which allows connecting
         them. This is the responsibility of the calling code.
@@ -93,8 +91,6 @@ class BallNodeJoint(Joint):
 
         Parameters
         ----------
-        model : :class:`~compas_timber.model.TimberModel`
-            The model to which the beams and this joing belong.
         beams : list(:class:`~compas_timber.parts.Beam`)
             A list containing beams that whould be joined together
 
@@ -104,10 +100,8 @@ class BallNodeJoint(Joint):
             The instance of the created joint.
 
         """
-        elements = list(elements)
-        joint = cls(elements, **kwargs)
-        model.add_joint(joint)
-        return joint
+        return cls(elements, **kwargs)
+
 
     @property
     def node_point(self):

--- a/src/compas_timber/connections/ball_node.py
+++ b/src/compas_timber/connections/ball_node.py
@@ -78,11 +78,13 @@ class BallNodeJoint(Joint):
             yield (beam, self.fastener)
 
     @classmethod
-    def from_element_list(cls, elements, **kwargs):
-        """Creates an instance of the BallNodeJoint.
+    def create(cls, model, *elements, **kwargs):
+        """Creates an instance of the BallNodeJoint and creates the new connection in `model`.
 
         This differs fom the generic `Joint.create()` method in that it passes the `beams` to
         the constructor of the BallNodeJoint as a list instead of as separate arguments.
+
+        `beams` are expected to have been added to `model` before calling this method.
 
         This code does not verify that the given beams are adjacent and/or lie in a topology which allows connecting
         them. This is the responsibility of the calling code.
@@ -91,6 +93,8 @@ class BallNodeJoint(Joint):
 
         Parameters
         ----------
+        model : :class:`~compas_timber.model.TimberModel`
+            The model to which the beams and this joing belong.
         beams : list(:class:`~compas_timber.parts.Beam`)
             A list containing beams that whould be joined together
 
@@ -100,7 +104,10 @@ class BallNodeJoint(Joint):
             The instance of the created joint.
 
         """
-        return cls(elements, **kwargs)
+        elements = list(elements)
+        joint = cls(elements, **kwargs)
+        model.add_joint(joint)
+        return joint
 
     @property
     def node_point(self):

--- a/src/compas_timber/connections/joint.py
+++ b/src/compas_timber/connections/joint.py
@@ -189,13 +189,12 @@ class Joint(Interaction):
         model.add_joint(joint)
         return joint
 
-
     @classmethod
     def from_element_list(cls, elements, **kwargs):
         """Creates an instance of this joint from a list of elements. This should be overridden when a joint type takes a list of elements.
 
         This code does not verify that the given elements are adjacent and/or lie in a topology which allows connecting
-        them. This is the responsibility of the calling code.
+        them. This is the responsibility of the calling code. TODO: evaluate whose responsibility this is.
 
         Parameters
         ----------

--- a/src/compas_timber/connections/joint.py
+++ b/src/compas_timber/connections/joint.py
@@ -185,6 +185,31 @@ class Joint(Interaction):
 
         """
 
-        joint = cls(*elements, **kwargs)
+        joint = cls.from_element_list(elements, **kwargs)
         model.add_joint(joint)
         return joint
+
+
+    @classmethod
+    def from_element_list(cls, elements, **kwargs):
+        """Creates an instance of this joint from a list of elements. This should be overridden when a joint type takes a list of elements.
+
+        This code does not verify that the given elements are adjacent and/or lie in a topology which allows connecting
+        them. This is the responsibility of the calling code.
+
+        Parameters
+        ----------
+        *elements : :class:`~compas_model.elements.Element`
+            The elements to be connected by this joint. The number of elements must comply with the `Joint` class's
+            `MIN_ELEMENT_COUNT` and `MAX_ELEMENT_COUNT` attributes.
+        **kwargs : dict
+            Additional keyword arguments that are passed to the joint's constructor.
+
+        Returns
+        -------
+        :class:`compas_timber.connections.Joint`
+            The instance of the created joint.
+
+        """
+
+        return cls(*elements, **kwargs)

--- a/src/compas_timber/connections/joint.py
+++ b/src/compas_timber/connections/joint.py
@@ -185,30 +185,6 @@ class Joint(Interaction):
 
         """
 
-        joint = cls.from_element_list(elements, **kwargs)
+        joint = cls(*elements, **kwargs)
         model.add_joint(joint)
         return joint
-
-    @classmethod
-    def from_element_list(cls, elements, **kwargs):
-        """Creates an instance of this joint from a list of elements. This should be overridden when a joint type takes a list of elements.
-
-        This code does not verify that the given elements are adjacent and/or lie in a topology which allows connecting
-        them. This is the responsibility of the calling code. TODO: evaluate whose responsibility this is.
-
-        Parameters
-        ----------
-        *elements : :class:`~compas_model.elements.Element`
-            The elements to be connected by this joint. The number of elements must comply with the `Joint` class's
-            `MIN_ELEMENT_COUNT` and `MAX_ELEMENT_COUNT` attributes.
-        **kwargs : dict
-            Additional keyword arguments that are passed to the joint's constructor.
-
-        Returns
-        -------
-        :class:`compas_timber.connections.Joint`
-            The instance of the created joint.
-
-        """
-
-        return cls(*elements, **kwargs)

--- a/src/compas_timber/elements/fasteners/ball_node_fastener.py
+++ b/src/compas_timber/elements/fasteners/ball_node_fastener.py
@@ -153,7 +153,7 @@ class BallNodeFastener(Fastener):
         """Generate a plate from outline_points, thickness, and holes."""
         if not self.base_interface.outline_points:
             return None
-        outline_points = correct_polyline_direction(self.base_interface.outline_points, Vector(0, 0, 1))
+        outline_points = correct_polyline_direction(self.base_interface.outline_points, Vector(0, 0, 1), clockwise=True)
         outline = NurbsCurve.from_points(outline_points, degree=1)
         holes = self.base_interface.holes
         thickness = self.base_interface.thickness


### PR DESCRIPTION
This fixes the `fastener.geometry` creation in `BallNodeJoint`. It also introduces a new generic joint constructor `Joint.from _element_list()` which is necessary to have a generic joint constructor that doesn't need a model. `Joint.create()` will call this internally, and the upcoming JointRule workflow rework will use this as well.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [x] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
