### PR TITLE
Canditate joint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Processings which are not the result of joinery are now serialized with `TimberElement`.
 * Fixed visualization bug in `Plate` due to loft resulting in flipped volume.
 * Fixed a few bugs in the `WallPopulator` workflow including GH component updates.
-* Renamed `NullJoint` to `GenericJoint`.
+* Renamed `NullJoint` to `JointCandidate`.
 * Fixed bug in show_ref_faces GH component.
 * `BTLxProcessing.ref_side_index` defaults to `0` if not set, instead of the invalid `None`.
 * Fixed several GH Components for Rhino8 compatibility.

--- a/src/compas_timber/connections/__init__.py
+++ b/src/compas_timber/connections/__init__.py
@@ -5,7 +5,7 @@ from .l_lap import LLapJoint
 from .l_miter import LMiterJoint
 from .l_french_ridge_lap import LFrenchRidgeLapJoint
 from .lap_joint import LapJoint
-from .generic_joint import GenericJoint
+from .generic_joint import JointCandidate
 from .solver import ConnectionSolver
 from .solver import PlateConnectionSolver
 from .solver import JointTopology
@@ -55,7 +55,7 @@ __all__ = [
     "XNotchJoint",
     "TLapJoint",
     "LLapJoint",
-    "GenericJoint",
+    "JointCandidate",
     "LFrenchRidgeLapJoint",
     "JointTopology",
     "ConnectionSolver",

--- a/src/compas_timber/connections/analyzers.py
+++ b/src/compas_timber/connections/analyzers.py
@@ -78,7 +78,7 @@ class NBeamKDTreeAnalyzer(BeamGroupAnalyzer):
 
     def __init__(self, model, n=2, tolerance=None):
         super(NBeamKDTreeAnalyzer, self).__init__()
-        # ignore any joints that are not GenericJoint as we cannot guarantee they old the appropriate information
+        # ignore any joints that are not `JointCandidate` as we cannot guarantee they old the appropriate information
         self._joints = list(filter(lambda joint: isinstance(joint, JointCandidate), model.joints))
         if not self._joints:
             raise ValueError("The model has no joints to analyze. Forgot to call `model.connect_adjacent_beams()`?")

--- a/src/compas_timber/connections/analyzers.py
+++ b/src/compas_timber/connections/analyzers.py
@@ -78,7 +78,7 @@ class NBeamKDTreeAnalyzer(BeamGroupAnalyzer):
 
     def __init__(self, model, n=2, tolerance=None):
         super(NBeamKDTreeAnalyzer, self).__init__()
-        # ignore any joints that are not `JointCandidate` as we cannot guarantee they old the appropriate information
+        # ignore any joints that are not `JointCandidate` as we cannot guarantee they hold the appropriate information
         self._joints = list(filter(lambda joint: isinstance(joint, JointCandidate), model.joints))
         if not self._joints:
             raise ValueError("The model has no joints to analyze. Forgot to call `model.connect_adjacent_beams()`?")

--- a/src/compas_timber/connections/analyzers.py
+++ b/src/compas_timber/connections/analyzers.py
@@ -9,7 +9,7 @@ from compas.tolerance import TOL
 
 import compas_timber.connections  # noqa: F401
 import compas_timber.elements  # noqa: F401
-from compas_timber.connections import GenericJoint
+from compas_timber.connections import JointCandidate
 
 
 class Cluster(object):
@@ -79,7 +79,7 @@ class NBeamKDTreeAnalyzer(BeamGroupAnalyzer):
     def __init__(self, model, n=2, tolerance=None):
         super(NBeamKDTreeAnalyzer, self).__init__()
         # ignore any joints that are not GenericJoint as we cannot guarantee they old the appropriate information
-        self._joints = list(filter(lambda joint: isinstance(joint, GenericJoint), model.joints))
+        self._joints = list(filter(lambda joint: isinstance(joint, JointCandidate), model.joints))
         if not self._joints:
             raise ValueError("The model has no joints to analyze. Forgot to call `model.connect_adjacent_beams()`?")
 

--- a/src/compas_timber/connections/generic_joint.py
+++ b/src/compas_timber/connections/generic_joint.py
@@ -1,7 +1,7 @@
 from .joint import Joint
 
 
-class GenericJoint(Joint):
+class JointCandidate(Joint):
     """A GenericJoint is an information-only joint, which does not add any features to the elements it connects.
 
     It is used to create a first-pass joinery information which can be later used to perform analysis using :class:`~compas_timber.connections.analyzers.BeamGroupAnalyzer`.
@@ -30,7 +30,7 @@ class GenericJoint(Joint):
             "element_a_guid": self.element_a_guid,
             "element_b_guid": self.element_b_guid,
         }
-        data_dict.update(super(GenericJoint, self).__data__)
+        data_dict.update(super(JointCandidate, self).__data__)
         return data_dict
 
     @classmethod
@@ -41,7 +41,7 @@ class GenericJoint(Joint):
         return instance
 
     def __init__(self, element_a=None, element_b=None, **kwargs):
-        super(GenericJoint, self).__init__(**kwargs)
+        super(JointCandidate, self).__init__(**kwargs)
         self.element_a = element_a
         self.element_b = element_b
         self.element_a_guid = str(element_a.guid) if element_a else None

--- a/src/compas_timber/connections/generic_joint.py
+++ b/src/compas_timber/connections/generic_joint.py
@@ -2,11 +2,11 @@ from .joint import Joint
 
 
 class JointCandidate(Joint):
-    """A GenericJoint is an information-only joint, which does not add any features to the elements it connects.
+    """A JointCandidate is an information-only joint, which does not add any features to the elements it connects.
 
     It is used to create a first-pass joinery information which can be later used to perform analysis using :class:`~compas_timber.connections.analyzers.BeamGroupAnalyzer`.
 
-    Please use `GenericJoint.create()` to properly create an instance of this class and associate it with an model.
+    Please use `JointCandidate.create()` to properly create an instance of this class and associate it with an model.
 
     Parameters
     ----------

--- a/src/compas_timber/model/model.py
+++ b/src/compas_timber/model/model.py
@@ -12,7 +12,7 @@ from compas.tolerance import TOL
 from compas_model.models import Model
 
 from compas_timber.connections import ConnectionSolver
-from compas_timber.connections import GenericJoint
+from compas_timber.connections import JointCandidate
 from compas_timber.connections import Joint
 from compas_timber.connections import JointTopology
 from compas_timber.connections import WallJoint
@@ -401,7 +401,7 @@ class TimberModel(Model):
             p1, _ = intersection_line_line(beam_a.centerline, beam_b.centerline)
             p1 = Point(*p1) if p1 else None
 
-            GenericJoint.create(self, beam_a, beam_b, topology=topology, location=p1)
+            JointCandidate.create(self, beam_a, beam_b, topology=topology, location=p1)
 
     def connect_adjacent_walls(self, max_distance=None):
         """Connects adjacent walls in the model.

--- a/tests/compas_timber/test_joint.py
+++ b/tests/compas_timber/test_joint.py
@@ -9,7 +9,7 @@ from compas.geometry import Point
 from compas.geometry import Vector
 from compas.tolerance import TOL
 
-from compas_timber.connections import GenericJoint
+from compas_timber.connections import JointCandidate
 from compas_timber.connections import JointTopology
 from compas_timber.connections import LButtJoint
 from compas_timber.connections import LLapJoint
@@ -246,7 +246,7 @@ def test_generic_joint():
 
     model.connect_adjacent_beams()
 
-    assert all((isinstance(j, GenericJoint) for j in model.joints))
+    assert all((isinstance(j, JointCandidate) for j in model.joints))
 
     assert len(model.joints) == 4
     l_joints = [j for j in model.joints if j.topology == JointTopology.TOPO_L]


### PR DESCRIPTION
closes https://github.com/gramaziokohler/compas_timber/issues/472

* Renamed `GenericJoint` to `JointCandidate`

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
