### PR TITLE
propose slab inherits from Plate

### DIFF
--- a/docs/contribution/class_diagrams.rst
+++ b/docs/contribution/class_diagrams.rst
@@ -70,41 +70,42 @@ The elements subsystem contains all the core timber elements that can be modeled
          +blank_length : float
          +width : float
          +height : float
+         +blank : Box
          +ref_frame : Frame
          +is_plate : bool = True
-         +compute_geometry()
-         +compute_aabb()
-         +compute_obb()
-      }
-
-      class Slab {
-         +outline : Polyline
-         +thickness : float
-         +openings : list[Opening]
-         +frame : Frame
-         +origin : Point
-         +baseline : Line
-         +centerline : Line
-         +width : float
-         +length : float
-         +height : float
-         +corners : tuple[Point]
-         +faces : tuple[Frame]
-         +end_faces : tuple[Frame]
-         +envelope_faces : tuple[Frame]
-         +is_slab : bool = True
-         +is_group_element : bool = True
-         +from_boundary()
+         +from_outline_thickness()
          +from_brep()
          +compute_geometry()
          +compute_aabb()
          +compute_obb()
-         +rotate()
+         +compute_collision_mesh()
+      }
+
+      class Slab {
+         +outline_a : Polyline
+         +outline_b : Polyline
+         +openings : list[Opening]
+         +frame : Frame
+         +thickness : float
+         +planes : tuple[Plane]
+         +blank_length : float
+         +width : float
+         +height : float
+         +ref_frame : Frame
+         +is_slab : bool = True
+         +is_group_element : bool = True
+         +from_outline_thickness()
+         +from_brep()
+         +compute_geometry()
+         +compute_aabb()
+         +compute_obb()
       }
 
       class Wall {
          +outline : Polyline
          +thickness : float
+         +baseline : Line
+         +centerline : Line
          +openings : list[Polyline]
          +is_wall : bool = True
       }
@@ -137,8 +138,8 @@ The elements subsystem contains all the core timber elements that can be modeled
       Element <|-- TimberElement
       TimberElement <|-- Beam
       TimberElement <|-- Plate
-      TimberElement <|-- Slab
       TimberElement <|-- Fastener
+      Plate <|-- Slab
       Slab <|-- Wall
 
       %% Composition relationships


### PR DESCRIPTION
As discussed in the last standup, I am using the mermaid documentation to propose a change in the class structure before changing in code. 

I believe `Slab` should inherit from `Plate`. This gives much more formal flexibility and allows compatibility with `PlateJoint`s. 

The logic of a wall, with a baseline and eventually also justificaiton about that line(left, right, center, etc. ) would be downstreamed to the `Wall`. 

The way it is currently written, `Wall` acts like a `beam`. We eventually need to discuss what to do with Slabs and Walls. I would propose that walls have alternate constructors such as `from_baseline()`, `from_box()`, etc. This of coulrse should be coordinated with innosuisse_cadwork, ukraine, etc. 

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
