### PR TITLE
fix transformation setters in `TimberElement` and `Beam`

### DIFF
--- a/src/compas_timber/elements/beam.py
+++ b/src/compas_timber/elements/beam.py
@@ -120,6 +120,10 @@ class Beam(TimberElement):
         extension_transformation = Translation.from_vector(-self.frame.xaxis * start)
         return extension_transformation * transformation  # TODO: should this be instead handled when calling `add_blank_extension` and `remove_blank_extension`?
 
+    @transformation.setter
+    def transformation(self, transformation):
+        super(Beam, self.__class__).transformation.__set__(self, transformation)
+
     @property
     def shape(self):
         """The shape of the beam in global coordinates."""

--- a/src/compas_timber/elements/timber.py
+++ b/src/compas_timber/elements/timber.py
@@ -77,6 +77,11 @@ class TimberElement(Element):
         """The transformation that transforms the element's geometry to the model's coordinate system."""
         return Transformation.from_frame(self.frame) if self.frame else Transformation()
 
+    @transformation.setter
+    @reset_computed
+    def transformation(self, transformation):
+        self._frame = Frame.from_transformation(transformation)
+
     @property
     def features(self):
         # type: () -> list[Feature]

--- a/src/compas_timber/elements/timber.py
+++ b/src/compas_timber/elements/timber.py
@@ -34,8 +34,9 @@ class TimberElement(Element):
         data["features"] = [f for f in self.features if not f.is_joinery]  # type: ignore
         return data
 
-    def __init__(self, features=None, **kwargs):
+    def __init__(self, frame=None, features=None, **kwargs):
         super(TimberElement, self).__init__(**kwargs)
+        self._frame = frame or Frame.worldXY()
         self._features = features or []
         self._geometry = None
         self.debug_info = []


### PR DESCRIPTION
this just adds the missing transformation setters for TimberElement and Beam which override the compas_model implementation. These setters work by applying the transformation to the Beam/TimberElement.frame.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
