### PR TITLE
Fastener_inherit_from_Element

### DIFF
--- a/src/compas_timber/elements/fastener.py
+++ b/src/compas_timber/elements/fastener.py
@@ -71,13 +71,14 @@ class Fastener(Element):
         """returns the geometry of the fastener in the model"""
         return self.shape.transformed(Transformation.from_frame(self.frame))
 
-    @property
-    # HACK: this is a hack/workaround to allow fasteners to be used without a model
-    def frame(self):
-        if self.model:
-            return super(Fastener, self).frame
-        else:
-            return Frame.from_transformation(self.transformation)
+    #TODO: this is necessary when we merge PR #454 compas_model_update
+    # @property
+    # # HACK: this is a hack/workaround to allow fasteners to be used without a model
+    # def frame(self):
+    #     if self.model:
+    #         return super(Fastener, self).frame
+    #     else:
+    #         return Frame.from_transformation(self.transformation)
 
 class FastenerTimberInterface(Data):
     """A class to represent the interface between a fastener and a timber element.

--- a/src/compas_timber/elements/fastener.py
+++ b/src/compas_timber/elements/fastener.py
@@ -5,12 +5,12 @@ from compas.geometry import Line
 from compas.geometry import Transformation
 from compas.geometry import Vector
 
-from compas_timber.elements.timber import TimberElement
+from compas_model.elements import Element
 from compas_timber.fabrication import Drilling
 from compas_timber.utils import intersection_line_beam_param
 
 
-class Fastener(TimberElement):
+class Fastener(Element):
     """
     A class to represent timber fasteners (screws, dowels, brackets).
 
@@ -37,7 +37,7 @@ class Fastener(TimberElement):
         super(Fastener, self).__init__(**kwargs)
         self._shape = shape
         self.interfaces = []
-        self.frame = frame
+        self.transformation = Transformation.from_frame(frame) if frame else Transformation()
         self.attributes = {}
         self.attributes.update(kwargs)
         self.debug_info = []
@@ -51,21 +51,13 @@ class Fastener(TimberElement):
         return "<Fastener {}>".format(self.name)
 
     @property
-    def frame(self):
-        return self._frame
-
-    @frame.setter
-    def frame(self, frame):
-        self._frame = frame
-
-    @property
     def is_fastener(self):
         return True
 
     @property
     def key(self):
         # type: () -> int | None
-        return self.graph_node
+        return self.graphnode
 
     @property
     def __data__(self):
@@ -79,6 +71,13 @@ class Fastener(TimberElement):
         """returns the geometry of the fastener in the model"""
         return self.shape.transformed(Transformation.from_frame(self.frame))
 
+    @property
+    # HACK: this is a hack/workaround to allow fasteners to be used without a model
+    def frame(self):
+        if self.model:
+            return super(Fastener, self).frame
+        else:
+            return Frame.from_transformation(self.transformation)
 
 class FastenerTimberInterface(Data):
     """A class to represent the interface between a fastener and a timber element.

--- a/tests/compas_timber/test_fastener.py
+++ b/tests/compas_timber/test_fastener.py
@@ -9,7 +9,7 @@ def test_fastener_initialization():
 
 def test_fastener_repr():
     fastener = Fastener()
-    assert repr(fastener) == "Fastener(frame=None, name=Fastener)"
+    assert repr(fastener) == "Fastener(frame=Frame(point=Point(x=0.0, y=0.0, z=0.0), xaxis=Vector(x=1.0, y=0.0, z=0.0), yaxis=Vector(x=0.0, y=1.0, z=0.0)), name=Fastener)"
 
 
 def test_fastener_str():

--- a/tests/compas_timber/test_fastener.py
+++ b/tests/compas_timber/test_fastener.py
@@ -9,7 +9,9 @@ def test_fastener_initialization():
 
 def test_fastener_repr():
     fastener = Fastener()
-    assert repr(fastener) == "Fastener(frame=Frame(point=Point(x=0.0, y=0.0, z=0.0), xaxis=Vector(x=1.0, y=0.0, z=0.0), yaxis=Vector(x=0.0, y=1.0, z=0.0)), name=Fastener)"
+    #TODO: swap these two lines when we merge PR #454 compas_model_update
+    #assert repr(fastener) == "Fastener(frame=Frame(point=Point(x=0.0, y=0.0, z=0.0), xaxis=Vector(x=1.0, y=0.0, z=0.0), yaxis=Vector(x=0.0, y=1.0, z=0.0)), name=Fastener)"
+    assert repr(fastener) == "Fastener(frame=None, name=Fastener)"
 
 
 def test_fastener_str():


### PR DESCRIPTION
This removes inheritance of `TimberElement` by `Fastener`. I don't see any other elements that inherit from `TimberElement`, meaning that class can now strictly represent BTLx-ables AKA `Beam` and `Plate`. 

This is a small change, but it might make sense to wait until #454 has been merged. 

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
