### PR TITLE
fix Direct Joint and Plate form outline thickness GH components

### DIFF
--- a/src/compas_timber/ghpython/components_cpython/CT_Joint_Rule_Direct/metadata.json
+++ b/src/compas_timber/ghpython/components_cpython/CT_Joint_Rule_Direct/metadata.json
@@ -13,13 +13,13 @@
                 "name": "element_a",
                 "description": "Element A.",
                 "typeHintID": "none",
-                "scriptParamAccess": 1
+                "scriptParamAccess": 0
             },
             {
                 "name": "element_b",
                 "description": "Element B.",
                 "typeHintID": "none",
-                "scriptParamAccess": 1
+                "scriptParamAccess": 0
             }
         ],
         "outputParameters": [

--- a/src/compas_timber/ghpython/components_cpython/CT_Plate/code.py
+++ b/src/compas_timber/ghpython/components_cpython/CT_Plate/code.py
@@ -25,16 +25,14 @@ class Plate(Grasshopper.Kernel.GH_ScriptInstance):
         guid, geometry = self._get_guid_and_geometry(outline)
         rhino_polyline = rs.coercecurve(geometry)
         line = polyline_to_compas(rhino_polyline.ToPolyline())
-        v = vector_to_compas(vector)
+        v = vector_to_compas(vector) if vector else None
         o = []
         if openings:
             for o_outline in openings:
                 o_guid, o_geometry = self._get_guid_and_geometry(o_outline)
                 o_rhino_polyline = rs.coercecurve(o_geometry)
                 o.append(polyline_to_compas(o_rhino_polyline.ToPolyline()))
-        v = vector_to_compas(vector)
         plate = CTPlate.from_outline_thickness(line, thickness, vector=v, openings=o)
-        print(plate.geometry)
         plate.attributes["rhino_guid"] = str(guid) if guid else None
         plate.attributes["category"] = category
 


### PR DESCRIPTION
fixes the Direct joint GH component and make vector optional for plate_from_outline_and_thickness GH component

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
