### PR TITLE
fixes the joint rule from list component

### DIFF
--- a/src/compas_timber/ghpython/components_cpython/CT_Joint_Rule_From_List/code.py
+++ b/src/compas_timber/ghpython/components_cpython/CT_Joint_Rule_From_List/code.py
@@ -44,7 +44,7 @@ class JointRuleFromList(Grasshopper.Kernel.GH_ScriptInstance):
                 if val is not None:
                     kwargs[self.arg_names[i]] = val
 
-            return DirectRule(self.joint_type, elements, **kwargs)
+            return DirectRule(self.joint_type, [e for e in elements], **kwargs)
 
     @property
     def arg_start_index(self):


### PR DESCRIPTION
this fixes the joint rule from list GH component. There is some issue where the list object coming from the component input parameter is a generic object and so I just create a new list as parameter to the DirectRule using `[e for e in elements]`. 

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
