### PR TITLE
use update_gh_header from compas_invocations2

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import os
-from pathlib import Path
 
 from compas_invocations2 import build
 from compas_invocations2 import docs
@@ -10,7 +9,6 @@ from compas_invocations2 import tests
 from compas_invocations2 import grasshopper
 
 from invoke.collection import Collection
-from invoke.tasks import task
 from invoke.exceptions import Exit
 import tomlkit
 
@@ -39,28 +37,6 @@ def _get_package_name() -> str:
     return name
 
 
-@task(help={"version": "New minimum version to set in the header. If not provided, current version is used."})
-def update_gh_header(ctx, version=None):
-    """Update the minimum version header of all CPython Grasshopper components."""
-    version = version or _get_version_from_toml()
-    package_name = _get_package_name()
-    new_header = f"# r: {package_name}>={version}"
-
-    for file in Path(ctx.ghuser_cpython.source_dir).glob("**/code.py"):
-        try:
-            with open(file, "r", encoding="utf-8") as f:
-                original_content = f.readlines()
-            with open(file, "w", encoding="utf-8") as f:
-                for line in original_content:
-                    if line.startswith(f"# r: {package_name}"):
-                        f.write(new_header + "\n")
-                    else:
-                        f.write(line)
-            print(f"✅ Updated: {file}")
-        except Exception as e:
-            print(f"❌ Failed to update {file}: {e}")
-
-
 ns = Collection(
     docs.help,
     style.check,
@@ -78,7 +54,7 @@ ns = Collection(
     build.build_cpython_ghuser_components,
     grasshopper.yakerize,
     grasshopper.publish_yak,
-    update_gh_header,
+    grasshopper.update_gh_header,
 )
 
 ns.configure(


### PR DESCRIPTION
Use the `update_gh_header` task from `compas_invocations2`. this one has more options e.g. `--dev` flag to allow dependency-less header pointing to the local repository (AKA GH editable)
