### PR TITLE
removed MaxNCompositeAnalyzer from rule solver logic due to performan…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+### Changed
+
+* Fixed performance issue in GH Model component caused by naiive implementation of `MaxNCompositeAnalyzer`.
+
+### Removed
+
+
 ## [1.0.1] 2025-10-16
 
 ### Added

--- a/src/compas_timber/design/workflow.py
+++ b/src/compas_timber/design/workflow.py
@@ -2,7 +2,7 @@ from compas.tolerance import TOL
 
 from compas_timber.connections import JointTopology
 from compas_timber.connections import LMiterJoint
-from compas_timber.connections import MaxNCompositeAnalyzer
+from compas_timber.connections import NBeamKDTreeAnalyzer
 from compas_timber.connections import PlateMiterJoint
 from compas_timber.connections import PlateTButtJoint
 from compas_timber.connections import TButtJoint
@@ -635,7 +635,7 @@ def get_clusters_from_model(model, max_distance=None):
     """
     model.connect_adjacent_beams(max_distance=max_distance)  # ensure that the model is connected before analyzing
     model.connect_adjacent_plates(max_distance=max_distance)  # ensure that the model is connected before analyzing
-    analyzer = MaxNCompositeAnalyzer(model, n=len(list(model.elements())), max_distance=max_distance)
+    analyzer = NBeamKDTreeAnalyzer(model, max_distance=max_distance)
     clusters = analyzer.find()
     return clusters
 


### PR DESCRIPTION
This is an LTS performance fix. 

The naiive implementation of `MaxNCompositeAnalyzer` has quite a performance impact on even small designs. Removed it for now as we don't really have automation for multi-beam joints.

will rework `MaxNCompositeAnalyzer` and re-introduce it once it's more efficient.