### PR TITLE
Fix bug with LongitudinalCut._get_default_ref_side_index()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed the way the `ref_frame` is computed from the `Blank`'s geometry in `TimberElement`.
 * Changed the way the `blank` is computed in `compas_timber.elements.Beam` applying the `modeltransformation` to a locally generated geometry.
 * Changed the `apply()` method in `DoubleCut`, `DovetailMortise`, `DovetailTenon`, `Drilling`, `FrenchRidgeLap`, `JackRafterCut`, `Lap`, `LongitudinalCut`, `Mortise`, `Pocket`, `StepJointNotch`, `StepJoint`, `Tenon` by transforming the computed feature geometry in the element's local space to allow the element geometry computation to happen in local coordinates.
+* Fixed bug in `LongitudinalCut` that occured when the cutting plane intersected a ref_side but the normals pointed away from each other, resulting in the cut parameter being out of range. 
 
 ### Removed
 

--- a/src/compas_timber/fabrication/longitudinal_cut.py
+++ b/src/compas_timber/fabrication/longitudinal_cut.py
@@ -10,6 +10,7 @@ from compas.geometry import Polyline
 from compas.geometry import angle_vectors
 from compas.geometry import angle_vectors_signed
 from compas.geometry import distance_point_point
+from compas.geometry import dot_vectors
 from compas.geometry import intersection_line_plane
 from compas.geometry import intersection_segment_plane
 from compas.tolerance import TOL
@@ -367,7 +368,8 @@ class LongitudinalCut(BTLxProcessing):
         for i, ref_side in enumerate(beam.ref_sides[:4]):
             width, _ = beam.get_dimensions_relative_to_side(i)
             y_seg = Line.from_point_and_vector(ref_side.point, ref_side.yaxis * width)
-            if intersection_segment_plane(y_seg, plane):  # check if the plane intersects with the reference side
+            # check if the plane intersects with the reference side and the angle between their normals is positive
+            if intersection_segment_plane(y_seg, plane,tol=TOL.absolute) and dot_vectors(ref_side.normal, plane.normal) > 0:
                 angle = angle_vectors(plane.normal, ref_side.normal)
                 angles[i] = angle
         return min(angles, key=angles.get)


### PR DESCRIPTION
This fixes a bug that occurs when a LongitudinalCut cutting plane aligns with an edge or cuts through opposite sides of a beam. The bug occurs when the plane and the ref_side intersect but their normals point in different directions (dot product negative). This resulted in values for the `inclination` parameter to be outside of the allowed range -90 to 90. 

The fix adds a check that the dot product of the normals is positive. 

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
