### PR TITLE
Prevent circular import of fabrication/FreeContour

### DIFF
--- a/src/compas_timber/elements/plate.py
+++ b/src/compas_timber/elements/plate.py
@@ -1,3 +1,11 @@
+try:
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from compas_timber.fabrication import FreeContour  # noqa: F401
+except ImportError:
+    pass
+
 from compas.geometry import Box
 from compas.geometry import Point
 from compas.geometry import Polyline
@@ -5,7 +13,6 @@ from compas.geometry import Transformation
 from compas_model.elements import reset_computed
 
 from compas_timber.errors import FeatureApplicationError
-from compas_timber.fabrication import FreeContour
 
 from .plate_geometry import PlateGeometry
 from .timber import TimberElement
@@ -112,6 +119,8 @@ class Plate(PlateGeometry, TimberElement):
 
     @property
     def features(self):
+        from compas_timber.fabrication import FreeContour
+        
         if not self._outline_feature:
             self._outline_feature = FreeContour.from_top_bottom_and_elements(self.outline_a, self.outline_b, self, interior=False)
         if not self._opening_features:


### PR DESCRIPTION
A minor fix to prevent a circular import that was arising when running e.g. ```import compas_timber.connections``` due to ```from compas_timber.fabrication import JackRafterCutProxy``` partially initialising ```fabrication```

### What type of change is this?

- [X] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [X] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [X] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
