### PR TITLE
add .vs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,8 @@ temp/**
 
 .vscode
 
+.vs
+
 .idea
 
 docs/api/generated/


### PR DESCRIPTION
I wanted to try using VisualStudio instead of VSCode, and it wants to add a .vs file. This shouldn't be included in the repo. 