### PR TITLE
update LongitudinalCut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added new `DrillingProxy` and `DoubleCutProxy` classes.
 * Added `planar_surface_point_at` to `compas_timber.utils`.
 * Added `Panel` class as a renaming of `Slab`.
+* Added `**kwargs` argument to `LongitudinalCut` and `LongitudinalCutProxy` constructors to allow passing additional parameters, particularly `is_joinery=False` to keep the processing during serialization.
 
 ### Changed
 * Updated `compas_model` version pinning from `0.4.4` to `0.9.1` to align with the latest development.
@@ -63,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `Slab` to inherit from `PlateGeometry` and `compas_model.Element`.
 * Changed `Slab.from_boundary` to `Slab.from_outline_thickness`, inherited from `PlateGeometry`.
 * Renamed `Slab` to `Panel` everywhere in code and docs. 
+* Changed `LongitudinalCut` to properly generate `tool_position` parameter.
 
 ### Removed
 * Removed the `add_element()` method from `compas_timber.model.TimberModel`, as the inherited method from `Model` now covers this functionality.

--- a/tests/compas_timber/test_longitudinal_cut.py
+++ b/tests/compas_timber/test_longitudinal_cut.py
@@ -41,7 +41,7 @@ def test_longitudinal_cut_from_plane_with_ref_side_index(tol):
     assert instance.end_limited is False
     assert tol.is_close(instance.length, 998.293)
     assert instance.depth_limited is False
-    assert tol.is_close(instance.depth, 55.601)
+    assert tol.is_close(instance.depth, 0.0)
     assert tol.is_close(instance.angle_start, 90.0)
     assert tol.is_close(instance.angle_end, 90.0)
     assert tol.is_close(instance.ref_side_index, 2)
@@ -70,7 +70,7 @@ def test_longitudinal_cut_from_plane_without_ref_side_index(tol):
     assert instance.end_limited is True
     assert tol.is_close(instance.length, 300.0)
     assert instance.depth_limited is False
-    assert tol.is_close(instance.depth, 41.349)
+    assert tol.is_close(instance.depth, 0.0)
     assert tol.is_close(instance.angle_start, 90.0)
     assert tol.is_close(instance.angle_end, 90.0)
     assert tol.is_close(instance.ref_side_index, 1)
@@ -99,7 +99,7 @@ def test_jack_rafter_cut_from_frame(tol):
     assert instance.end_limited is True
     assert tol.is_close(instance.length, 300.0)
     assert instance.depth_limited is False
-    assert tol.is_close(instance.depth, 41.349)
+    assert tol.is_close(instance.depth, 0.0)
     assert tol.is_close(instance.angle_start, 90.0)
     assert tol.is_close(instance.angle_end, 90.0)
     assert tol.is_close(instance.ref_side_index, 1)


### PR DESCRIPTION
This fixes a few errors found in the Fall timber Demo planning. It changes how `tool_position` is calculated, it changes how `depth` and `depth_limited` are calculated, and it adds a `**kwargs` argument for passing kwargs like `is_joinery=False`.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
