### PR TITLE
Test/662 reset tolerance state

### DIFF
--- a/tests/compas_timber/conftest.py
+++ b/tests/compas_timber/conftest.py
@@ -1,0 +1,13 @@
+from compas.tolerance import TOL
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_tolerance():
+    """
+    Reset the global tolerance before each test.
+    This fixture is automatically applied to all tests.
+    It enforces test isolation by ensuring that no test depends on tolerance values modified by other tests.
+    Tests that require a non-default tolerance must set it explicitly within their own scope.
+    """
+    TOL.reset()

--- a/tests/compas_timber/test_slot.py
+++ b/tests/compas_timber/test_slot.py
@@ -12,6 +12,8 @@ from compas_timber.fabrication import Slot
 from compas_timber.fabrication import OrientationType
 from compas_timber.fabrication import MachiningLimits
 
+from compas.tolerance import TOL
+
 
 @pytest.fixture
 def beam():
@@ -19,6 +21,12 @@ def beam():
     height = 120.0
     centerline = Line(Point(x=80.4429082858, y=26.8976400207, z=0.0), Point(x=542.848108719, y=26.8976400207, z=0.0))
     return Beam.from_centerline(centerline, width, height)
+
+
+@pytest.fixture
+def tol():
+    TOL.absolute = 0.001
+    TOL.relative = 0.01
 
 
 def test_horizontal_slot_negative_angle(beam):
@@ -193,7 +201,7 @@ def test_slot_scaled():
     assert scaled_slot.ref_side_index == slot.ref_side_index
 
 
-def test_slot_apply_points():
+def test_slot_apply_points(tol):
     beam = Beam.from_centerline(Line(Point(0, 0, 0), Point(100, 0, 0)), width=30, height=50)
     ml = MachiningLimits()
     slot = slot = Slot(
@@ -230,7 +238,7 @@ def test_slot_apply_points():
     assert p4 == Point(x=32.036, y=-10.478, z=-22.587)
 
 
-def test_slot_apply_frames():
+def test_slot_apply_frames(tol):
     beam = Beam.from_centerline(Line(Point(0, 0, 0), Point(100, 0, 0)), width=30, height=50)
     ml = MachiningLimits()
     slot = slot = Slot(
@@ -311,7 +319,7 @@ def test_slot_apply_frames():
     assert back_frame == Frame(point=Point(x=8.943, y=-0.769, z=24.607), xaxis=Vector(x=0.000, y=-0.174, z=-0.985), yaxis=Vector(x=-0.906, y=-0.416, z=0.073))
 
 
-def test_slot_volume_subtracting_polyhedron(beam):
+def test_slot_volume_subtracting_polyhedron(beam, tol):
     beam = Beam.from_centerline(Line(Point(0, 0, 0), Point(100, 0, 0)), width=30, height=50)
     ml = MachiningLimits()
     slot = slot = Slot(

--- a/tests/compas_timber/test_utils.py
+++ b/tests/compas_timber/test_utils.py
@@ -45,6 +45,10 @@ def test_intersection_line_line_param():
 
 
 def test_intersection_line_plane_param():
+    TOL.absolute = 0.001
+    TOL.unit = "MM"
+    TOL.relative = 0.001
+
     line = Line(Point(x=5.53733031674, y=12.3190045249, z=0.0), Point(x=20.8427601810, y=12.3190045249, z=0.0))
     plane = Plane(point=Point(x=15.436, y=16.546, z=-2.703), normal=Vector(x=-0.957, y=-0.289, z=0.000))
 


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
This PR follows up on #662, and fixes order-dependent test behavior caused by shared global state in `compas.tolerance.Tolerance`.
The goal is to make tolerance assumptions explicit and restore proper test isolation, without changing the underlying behavior being tested.

A global pytest fixture was added to reset the tolerance before each test, ensuring a clean and consistent baseline. (tests/compas_timber/conftest.py) 
Tests that previously relied on a modified tolerance are updated to set the required tolerance explicitly, using the same values they were implicitly relying on before. (previous implicit value was obtained through debugging)

Now tests pass both as a full suite and when run in isolation.

No production code is affected.

### What type of change is this?
- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist
- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
