### PR TITLE
warn when category rule inspects elements with now category attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Fixed models with `XLapJoint` fail to serialize.
+* Print warning when CategoryRules are inspecting elements which have no `category` attributes set.
 
 ### Removed
 

--- a/src/compas_timber/design/workflow.py
+++ b/src/compas_timber/design/workflow.py
@@ -387,6 +387,7 @@ class CategoryRule(JointRule):
         bool
             True if the order complies, False otherwise.
         """
+        self._warn_if_cluster_elemenst_missing_category(cluster)
         if cluster.topology == JointTopology.TOPO_T or cluster.topology == JointTopology.TOPO_EDGE_FACE:
             if cluster.joints[0].elements[0].attributes.get("category", None) != self.category_a:
                 if not raise_error:
@@ -411,7 +412,14 @@ class CategoryRule(JointRule):
         bool
             True if the categories comply, False otherwise.
         """
-        return set([e.attributes.get("category", None) for e in cluster.elements]) == {self.category_a, self.category_b}
+        self._warn_if_cluster_elemenst_missing_category(cluster)
+        return set([e.attributes.get("category") for e in cluster.elements]) == {self.category_a, self.category_b}
+
+    def _warn_if_cluster_elemenst_missing_category(self, cluster):
+        cluster_categories = [e.attributes.get("category") for e in cluster.elements]
+        if not all(cluster_categories):
+            # printing instead of `warn()`ing because warning behavior in Grasshopper is weird
+            print("CategoryRule found elements without category attribute! Have you set element.attributes['category'] on the relevant elements?")
 
     def _get_ordered_elements(self, cluster):
         """Returns the elements in the order of the rule's categories.


### PR DESCRIPTION
* Print warning to stdout when `CategoryRule` inspects elements which don't have a `category` attribute set.

This can easily happen when attempting to set `beam.category` instead of `beam.attributes['category']`. Since `category` is a design specific attribute, it is not a direct attribute of `Beam` or `TimberElement`.

If such elements are inspected by the rule solver, the following will be printed:
```
CategoryRule found elements without category attribute! Have you set element.attributes['category'] where on the relevant elements?
```

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).
