### PR TITLE
Merge and extract models 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `TimberModel.remove_element_subtree(element)` — removes all children and their descendants from the model while keeping *element* itself. Joints are cleaned up consistently.
 * Added `TimberModel.extract_model_from_parent(parent)` — moves *parent*'s entire child subtree (hierarchy and joints preserved) into a new standalone `TimberModel` and returns it.
 * Added `TimberModel.merge_model(model, parent=None)` — moves all elements and joints from *model* into this model, optionally re-rooting them under *parent*.
-
+* Added `clear_model_dependent_cache()` method to `TimberElement`, `Plate`, `Panel`, `Fastener`.
 
 ### Changed
 * Refactored `ButtJoint` to calculate trimming planes with the `butt_plane` and `back_plane` attributes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `back_plane` attribute to `ButtJoint`.
 * Added `force_pocket` and `conical_tool` flags to `TButtJoint`
 * Added `force_pocket` and `conical_tool` flags to `LButtJoint`
+* Added `clear_model_dependent_cache()` to all element classes (`TimberElement`, `Beam`, `Plate`, `Panel`, `Fastener`). Clears only the cached attributes that depend on the element's position in the model hierarchy (world-space geometry, bounding boxes, blank, ref_frame) while preserving model-independent caches such as `_elementgeometry`, features, and blank extensions.
+* Added `TimberModel.remove_element_subtree(element)` — removes all children and their descendants from the model while keeping *element* itself. Joints are cleaned up consistently.
+* Added `TimberModel.extract_model_from_parent(parent)` — moves *parent*'s entire child subtree (hierarchy and joints preserved) into a new standalone `TimberModel` and returns it.
+* Added `TimberModel.merge_model(model, parent=None)` — moves all elements and joints from *model* into this model, optionally re-rooting them under *parent*.
 
 
 ### Changed
-* Refactored `ButtJoint` to calculate trimming planes with the `butt_plane` and `back_plane` attributes. 
+* Refactored `ButtJoint` to calculate trimming planes with the `butt_plane` and `back_plane` attributes.
 
 ### Removed
 

--- a/src/compas_timber/base.py
+++ b/src/compas_timber/base.py
@@ -95,6 +95,21 @@ class TimberElement(Element, abc.ABC):
         """Reset all computed/cached properties."""
         self._reset_computed_dummy()
 
+    def clear_model_dependent_cache(self):
+        """Clear cached attributes that depend on the element's position in the model hierarchy.
+
+        Preserves model-independent caches such as ``_elementgeometry``, features,
+        and blank extensions.
+        """
+        self._modeltransformation = None
+        self._modelgeometry = None
+        self._aabb = None
+        self._obb = None
+        self._collision_mesh = None
+        self._blank = None
+        self._ref_frame = None
+        self._geometry = None
+
     @property
     def is_beam(self):
         return False

--- a/src/compas_timber/elements/fastener.py
+++ b/src/compas_timber/elements/fastener.py
@@ -78,6 +78,14 @@ class Fastener(Element):
             "interfaces": self.interfaces,
         }
 
+    def clear_model_dependent_cache(self):
+        """Clear cached attributes that depend on the element's position in the model hierarchy."""
+        self._modeltransformation = None
+        self._modelgeometry = None
+        self._aabb = None
+        self._obb = None
+        self._collision_mesh = None
+
     def compute_elementgeometry(self):
         """Returns the geometry of the fastener in the model.
 

--- a/src/compas_timber/elements/panel.py
+++ b/src/compas_timber/elements/panel.py
@@ -204,6 +204,15 @@ class Panel(Element):
         """list[:class:`~compas_timber.panel_features.PanelConnectionInterface`]: The interfaces associated with this panel."""
         return [f for f in self.features if f.panel_feature_type == PanelFeatureType.CONNECTION_INTERFACE]
 
+    def clear_model_dependent_cache(self):
+        """Clear cached attributes that depend on the element's position in the model hierarchy."""
+        self._modeltransformation = None
+        self._modelgeometry = None
+        self._aabb = None
+        self._obb = None
+        self._collision_mesh = None
+        self._planes = None
+
     @reset_computed
     def reset(self):
         """Resets the element to its initial state by removing all features, extensions, and debug_info."""

--- a/src/compas_timber/elements/plate.py
+++ b/src/compas_timber/elements/plate.py
@@ -196,6 +196,13 @@ class Plate(TimberElement):
         """Sets the features of the plate."""
         self._features = features
 
+    def clear_model_dependent_cache(self):
+        """Clear cached attributes that depend on the element's position in the model hierarchy."""
+        super().clear_model_dependent_cache()
+        self._planes = []
+        self._outline_feature = None
+        self._opening_features = None
+
     @reset_computed
     def reset(self):
         """Resets the element to its initial state by removing all features, extensions, and debug_info."""

--- a/src/compas_timber/model.py
+++ b/src/compas_timber/model.py
@@ -722,33 +722,47 @@ class TimberModel(Model):
             candidate = PlateJointCandidate(result.plate_a, result.plate_b, **kwargs)
             self.add_joint_candidate(candidate)
 
-
     # =============================================================================
     # Model sub-tree surgery
     # =============================================================================
 
     def remove_element_subtree(self, element):
-        """Removes all descendants of *element*.
+        """Remove all children (and their descendants) of *element* from the model.
 
-        ``Model.remove_element`` drops a node's whole treenode subtree but only one
-        guid from the element dict, so removing a non-leaf directly orphans its
-        descendants.  Recursing to leaves keeps the model consistent.
+        *element* itself is kept in the model as a childless leaf.  Any joints
+        whose both elements are among the removed descendants are also removed;
+        joints that span a removed element and an element outside the subtree are
+        removed as well.
+
+        Parameters
+        ----------
+        element : :class:`~compas_model.elements.Element`
+            The element whose descendants are removed.  Must already be in the model.
         """
         _, _ = self._detach_subtree(element)
 
-
     def _detach_subtree(self, parent=None):
-        # type: (TimberModel, Element | None) -> list
-        """Remove a subtree from *model*, returning ``(parent, [children])`` tuples.
+        # type: (Element | None) -> tuple[list, list]
+        """Remove elements from the model and return the information needed to re-attach them.
 
-        When *parent* is an element it is **kept** in *model* and only its descendants
-        are removed; its direct children are recorded under ``None`` so they can be
-        re-rooted elsewhere.  When *parent* is ``None`` every top-level element of
-        *model* (and its subtree) is removed, also recorded under ``None``.
+        Parameters
+        ----------
+        parent : :class:`~compas_model.elements.Element`, optional
+            When given, *parent* is **kept** in the model and only its descendants
+            are removed.  The direct children are recorded under ``None`` in the
+            returned tuples so they can be re-rooted under a different parent on
+            re-insertion.
+            When ``None``, every element in the model is removed.
 
-        Removal is leaves-first (so each removed node is a tree leaf, which
-        ``remove_element`` handles cleanly); the returned tuples are ordered
-        parents-before-children for re-insertion.
+        Returns
+        -------
+        tuple(list, list)
+            * ``tuples`` — list of ``(parent_element_or_None, [children])`` pairs,
+              ordered parents-before-children so ``_attach_subtree`` can re-insert
+              them in a single pass while preserving hierarchy.
+            * ``joints`` — list of joints that were removed because all their
+              elements were part of the detached subtree.  Joints that spanned a
+              removed element and a kept element are dropped entirely.
         """
         tuples = []
         elements_children_first = []
@@ -783,17 +797,23 @@ class TimberModel(Model):
             self.remove_element(e)
             e.clear_model_dependent_cache()
 
-
         return tuples, joints
 
-
     def _attach_subtree(self, tuples, joints=None, parent=None):
-        # type: (list, TimberModel, Element | None) -> None
-        """Re-add ``(parent, [children])`` tuples into *model* (parents before children).
+        # type: (list, list | None, Element | None) -> None
+        """Re-add elements described by *tuples* into this model.
 
-        Tuples whose recorded parent is ``None`` are attached under *root_element*.  Each
-        re-added element has its computed properties reset so geometry recomputes
-        against the new tree.
+        Parameters
+        ----------
+        tuples : list
+            ``(tuple_parent, [children])`` pairs as returned by :meth:`_detach_subtree`.
+            Pairs whose ``tuple_parent`` is ``None`` are rooted under *parent*
+            (or at the model root when *parent* is also ``None``).
+        joints : list, optional
+            Joints to restore after all elements have been re-added.
+        parent : :class:`~compas_model.elements.Element`, optional
+            Default parent for top-level elements (those recorded under ``None``).
+            When ``None``, they are added as model-root elements.
         """
         for tuple_parent, children in tuples:
             target_parent = tuple_parent if tuple_parent is not None else parent
@@ -830,7 +850,6 @@ class TimberModel(Model):
         new_model = TimberModel()
         new_model._attach_subtree(tuples, joints=joints)
         return new_model
-
 
     def merge_model(self, model, parent=None):
         # type: (TimberModel, TimberModel, Element | None) -> None

--- a/src/compas_timber/model.py
+++ b/src/compas_timber/model.py
@@ -721,3 +721,135 @@ class TimberModel(Model):
 
             candidate = PlateJointCandidate(result.plate_a, result.plate_b, **kwargs)
             self.add_joint_candidate(candidate)
+
+
+    # =============================================================================
+    # Model sub-tree surgery
+    # =============================================================================
+
+    def remove_element_subtree(self, element):
+        """Removes all descendants of *element*.
+
+        ``Model.remove_element`` drops a node's whole treenode subtree but only one
+        guid from the element dict, so removing a non-leaf directly orphans its
+        descendants.  Recursing to leaves keeps the model consistent.
+        """
+        _, _ = self._detach_subtree(element)
+
+
+    def _detach_subtree(self, parent=None):
+        # type: (TimberModel, Element | None) -> list
+        """Remove a subtree from *model*, returning ``(parent, [children])`` tuples.
+
+        When *parent* is an element it is **kept** in *model* and only its descendants
+        are removed; its direct children are recorded under ``None`` so they can be
+        re-rooted elsewhere.  When *parent* is ``None`` every top-level element of
+        *model* (and its subtree) is removed, also recorded under ``None``.
+
+        Removal is leaves-first (so each removed node is a tree leaf, which
+        ``remove_element`` handles cleanly); the returned tuples are ordered
+        parents-before-children for re-insertion.
+        """
+        tuples = []
+        elements_children_first = []
+
+        def walk(element, is_kept_root):
+            children = list(element.children)
+            if children:
+                tuples.append((None if is_kept_root else element, children))
+                for child in children:
+                    walk(child, is_kept_root=False)
+            if not is_kept_root:
+                elements_children_first.append(element)
+
+        if parent:
+            walk(parent, is_kept_root=True)
+        else:
+            tops = [element for element in self.elements() if element.parent is None]
+            tuples.append((None, tops))
+            for top in tops:
+                walk(top, is_kept_root=False)
+
+        joints = []
+        for j in list(self.joints):
+            elements_in_joint = [e in elements_children_first for e in j.elements]
+            if all(elements_in_joint):
+                joints.append(j)
+                self.remove_joint(j)
+            elif any(elements_in_joint):
+                self.remove_joint(j)
+
+        for e in elements_children_first:
+            self.remove_element(e)
+            e.clear_model_dependent_cache()
+
+
+        return tuples, joints
+
+
+    def _attach_subtree(self, tuples, joints=None, parent=None):
+        # type: (list, TimberModel, Element | None) -> None
+        """Re-add ``(parent, [children])`` tuples into *model* (parents before children).
+
+        Tuples whose recorded parent is ``None`` are attached under *root_element*.  Each
+        re-added element has its computed properties reset so geometry recomputes
+        against the new tree.
+        """
+        for tuple_parent, children in tuples:
+            target_parent = tuple_parent if tuple_parent is not None else parent
+            for child in children:
+                self.add_element(child, parent=target_parent)
+                child.clear_model_dependent_cache()
+        if joints:
+            for joint in joints:
+                self.add_joint(joint)
+
+    def extract_model_from_parent(self, parent):
+        # type: (Element) -> TimberModel
+        """Detach *parent*'s child subtree into a new, standalone :class:`TimberModel`.
+
+        The *parent* element itself stays in its current model; its descendants are
+        removed from that model and re-rooted (hierarchy preserved) in a fresh
+        :class:`TimberModel`, which is returned.
+
+        A child element detached from its parent reports its geometry in the
+        parent's local frame — convenient for operating on, e.g., a panel's layers
+        in isolation, then merging them back with :func:`merge_model_into_model`.
+
+        Parameters
+        ----------
+        parent : :class:`~compas_model.elements.Element`
+            The element whose children are extracted.  Must be in a model.
+
+        Returns
+        -------
+        :class:`TimberModel`
+            A new model containing *parent*'s former subtree.
+        """
+        tuples, joints = self._detach_subtree(parent)
+        new_model = TimberModel()
+        new_model._attach_subtree(tuples, joints=joints)
+        return new_model
+
+
+    def merge_model(self, model, parent=None):
+        # type: (TimberModel, TimberModel, Element | None) -> None
+        """Move every element (and joints) of *model* into *target_model* under *parent*.
+
+        All of *model*'s top-level elements and their subtrees are detached and
+        re-added beneath *parent* in *target_model* (or under the root when *parent*
+        is ``None``), preserving the hierarchy and resetting each moved element's
+        computed properties.  Joints defined on *model* are copied across.
+
+        Parameters
+        ----------
+        model : :class:`TimberModel`
+            The source model whose contents are moved out.
+        target_model : :class:`TimberModel`
+            The model to merge *model*'s elements into.
+        parent : :class:`~compas_model.elements.Element`, optional
+            The element under which the moved elements are re-rooted.  ``None``
+            attaches them under the target model's root.
+        """
+        tuples, joints = model._detach_subtree()
+        self._attach_subtree(tuples, joints=joints, parent=parent)

--- a/tests/compas_timber/test_model_subtree.py
+++ b/tests/compas_timber/test_model_subtree.py
@@ -1,8 +1,7 @@
 """Tests for TimberModel subtree surgery methods:
-    remove_element_subtree, _detach_subtree, _attach_subtree,
-    extract_model_from_parent, merge_model.
+remove_element_subtree, _detach_subtree, _attach_subtree,
+extract_model_from_parent, merge_model.
 """
-import pytest
 
 from compas.geometry import Frame
 from compas.geometry import Point
@@ -295,7 +294,7 @@ def test_extract_model_from_parent_preserves_hierarchy(mocker):
     model.add_element(inner_panel, parent=beam_a)
     model.add_element(inner_beam, parent=inner_panel)
 
-    extracted = model.extract_model_from_parent(panel)
+    _ = model.extract_model_from_parent(panel)
 
     assert inner_beam in inner_panel.children
     assert inner_panel in beam_a.children

--- a/tests/compas_timber/test_model_subtree.py
+++ b/tests/compas_timber/test_model_subtree.py
@@ -1,0 +1,382 @@
+"""Tests for TimberModel subtree surgery methods:
+    remove_element_subtree, _detach_subtree, _attach_subtree,
+    extract_model_from_parent, merge_model.
+"""
+import pytest
+
+from compas.geometry import Frame
+from compas.geometry import Point
+from compas.geometry import Vector
+
+from compas_timber.connections import LButtJoint
+from compas_timber.elements import Beam
+from compas_timber.elements import Panel
+from compas_timber.model import TimberModel
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_beam(x=0.0):
+    frame = Frame(Point(x, 0, 0), Vector(1, 0, 0), Vector(0, 1, 0))
+    return Beam(frame, length=1.0, width=0.1, height=0.1)
+
+
+def make_panel():
+    return Panel(Frame.worldXY(), length=2.0, width=1.0, thickness=0.1)
+
+
+def _flat_model():
+    """Model with two root-level beams and a joint between them."""
+    model = TimberModel()
+    b1 = make_beam(x=0)
+    b2 = make_beam(x=2)
+    model.add_element(b1)
+    model.add_element(b2)
+    return model, b1, b2
+
+
+def _hierarchy_model():
+    """Panel (root) → [beam_a, beam_b] with a joint between the two beams."""
+    model = TimberModel()
+    panel = make_panel()
+    beam_a = make_beam(x=0)
+    beam_b = make_beam(x=2)
+    model.add_element(panel)
+    model.add_element(beam_a, parent=panel)
+    model.add_element(beam_b, parent=panel)
+    return model, panel, beam_a, beam_b
+
+
+# ===========================================================================
+# remove_element_subtree
+# ===========================================================================
+
+
+def test_remove_element_subtree_removes_all_descendants():
+    model, panel, beam_a, beam_b = _hierarchy_model()
+
+    model.remove_element_subtree(panel)
+
+    elements = list(model.elements())
+    assert beam_a not in elements
+    assert beam_b not in elements
+
+
+def test_remove_element_subtree_keeps_parent():
+    model, panel, beam_a, beam_b = _hierarchy_model()
+
+    model.remove_element_subtree(panel)
+
+    assert panel in list(model.elements())
+
+
+def test_remove_element_subtree_panel_has_no_children_after():
+    model, panel, beam_a, beam_b = _hierarchy_model()
+
+    model.remove_element_subtree(panel)
+
+    assert panel.children == []
+
+
+def test_remove_element_subtree_clears_cache_on_removed_elements():
+    model, panel, beam_a, beam_b = _hierarchy_model()
+    # Warm the cache first
+    _ = beam_a.modeltransformation
+    _ = beam_a.aabb
+
+    model.remove_element_subtree(panel)
+
+    assert beam_a._modeltransformation is None
+    assert beam_a._aabb is None
+
+
+def test_remove_element_subtree_removes_joints_spanning_only_descendants(mocker):
+    mocker.patch("compas_timber.connections.LButtJoint.add_features")
+    model, panel, beam_a, beam_b = _hierarchy_model()
+    LButtJoint.create(model, beam_a, beam_b)
+    assert len(list(model.joints)) == 1
+
+    model.remove_element_subtree(panel)
+
+    assert len(list(model.joints)) == 0
+
+
+def test_remove_element_subtree_leaf_element():
+    """Calling on a leaf (no children) removes nothing — no-op."""
+    model, panel, beam_a, beam_b = _hierarchy_model()
+
+    model.remove_element_subtree(beam_a)
+
+    elements = list(model.elements())
+    assert beam_a in elements
+    assert panel in elements
+    assert beam_b in elements
+
+
+# ===========================================================================
+# _detach_subtree / _attach_subtree round-trip
+# ===========================================================================
+
+
+def test_detach_subtree_no_parent_empties_model():
+    model, panel, beam_a, beam_b = _hierarchy_model()
+
+    tuples, joints = model._detach_subtree()
+
+    assert len(list(model.elements())) == 0
+
+
+def test_detach_subtree_with_parent_removes_only_children():
+    model, panel, beam_a, beam_b = _hierarchy_model()
+
+    tuples, joints = model._detach_subtree(panel)
+
+    elements = list(model.elements())
+    assert panel in elements
+    assert beam_a not in elements
+    assert beam_b not in elements
+
+
+def test_detach_subtree_returns_correct_tuples_for_flat_model():
+    model, b1, b2 = _flat_model()
+
+    tuples, joints = model._detach_subtree()
+
+    # All top-level elements should be recorded under None
+    assert len(tuples) == 1
+    parent, children = tuples[0]
+    assert parent is None
+    assert set(children) == {b1, b2}
+
+
+def test_detach_subtree_returns_correct_tuples_for_hierarchy():
+    model, panel, beam_a, beam_b = _hierarchy_model()
+
+    tuples, joints = model._detach_subtree()
+
+    # Tuple 0: (None, [panel]) — top-level
+    # Tuple 1: (panel, [beam_a, beam_b]) — panel's children
+    assert len(tuples) == 2
+    parents = {t[0] for t in tuples}
+    assert None in parents
+    assert panel in parents
+
+
+def test_detach_subtree_captures_joints(mocker):
+    mocker.patch("compas_timber.connections.LButtJoint.add_features")
+    model, b1, b2 = _flat_model()
+    joint = LButtJoint.create(model, b1, b2)
+
+    tuples, joints = model._detach_subtree()
+
+    assert joint in joints
+    assert len(list(model.joints)) == 0
+
+
+def test_attach_subtree_restores_elements():
+    model, panel, beam_a, beam_b = _hierarchy_model()
+    tuples, joints = model._detach_subtree()
+
+    new_model = TimberModel()
+    new_model._attach_subtree(tuples, joints=joints)
+
+    elements = list(new_model.elements())
+    assert panel in elements
+    assert beam_a in elements
+    assert beam_b in elements
+
+
+def test_attach_subtree_restores_hierarchy():
+    model, panel, beam_a, beam_b = _hierarchy_model()
+    tuples, joints = model._detach_subtree()
+
+    new_model = TimberModel()
+    new_model._attach_subtree(tuples, joints=joints)
+
+    assert beam_a in panel.children
+    assert beam_b in panel.children
+
+
+def test_attach_subtree_restores_joints(mocker):
+    mocker.patch("compas_timber.connections.LButtJoint.add_features")
+    model, b1, b2 = _flat_model()
+    joint = LButtJoint.create(model, b1, b2)
+    tuples, joints = model._detach_subtree()
+
+    new_model = TimberModel()
+    new_model._attach_subtree(tuples, joints=joints)
+
+    assert len(list(new_model.joints)) == 1
+    assert joint in new_model.joints
+
+
+def test_attach_subtree_does_not_add_joints_twice(mocker):
+    mocker.patch("compas_timber.connections.LButtJoint.add_features")
+    model, b1, b2 = _flat_model()
+    LButtJoint.create(model, b1, b2)
+    tuples, joints = model._detach_subtree()
+
+    new_model = TimberModel()
+    new_model._attach_subtree(tuples, joints=joints)
+
+    assert len(list(new_model.joints)) == 1
+
+
+def test_attach_subtree_under_parent():
+    """_attach_subtree with a parent arg should root detached elements under that parent."""
+    model, b1, b2 = _flat_model()
+    tuples, joints = model._detach_subtree()
+
+    target_model = TimberModel()
+    root_panel = make_panel()
+    target_model.add_element(root_panel)
+    target_model._attach_subtree(tuples, parent=root_panel)
+
+    assert b1 in root_panel.children
+    assert b2 in root_panel.children
+
+
+# ===========================================================================
+# extract_model_from_parent
+# ===========================================================================
+
+
+def test_extract_model_from_parent_returns_new_model():
+    model, panel, beam_a, beam_b = _hierarchy_model()
+
+    extracted = model.extract_model_from_parent(panel)
+
+    assert extracted is not model
+    assert isinstance(extracted, TimberModel)
+
+
+def test_extract_model_from_parent_new_model_contains_children():
+    model, panel, beam_a, beam_b = _hierarchy_model()
+
+    extracted = model.extract_model_from_parent(panel)
+
+    elements = list(extracted.elements())
+    assert beam_a in elements
+    assert beam_b in elements
+
+
+def test_extract_model_from_parent_panel_stays_in_original():
+    model, panel, beam_a, beam_b = _hierarchy_model()
+
+    model.extract_model_from_parent(panel)
+
+    assert panel in list(model.elements())
+
+
+def test_extract_model_from_parent_children_leave_original():
+    model, panel, beam_a, beam_b = _hierarchy_model()
+
+    model.extract_model_from_parent(panel)
+
+    elements = list(model.elements())
+    assert beam_a not in elements
+    assert beam_b not in elements
+
+
+def test_extract_model_from_parent_preserves_hierarchy(mocker):
+    mocker.patch("compas_timber.connections.LButtJoint.add_features")
+    model = TimberModel()
+    panel = make_panel()
+    beam_a = make_beam(x=0)
+    beam_b = make_beam(x=2)
+    inner_panel = make_panel()
+    inner_beam = make_beam(x=4)
+    model.add_element(panel)
+    model.add_element(beam_a, parent=panel)
+    model.add_element(beam_b, parent=panel)
+    model.add_element(inner_panel, parent=beam_a)
+    model.add_element(inner_beam, parent=inner_panel)
+
+    extracted = model.extract_model_from_parent(panel)
+
+    assert inner_beam in inner_panel.children
+    assert inner_panel in beam_a.children
+
+
+def test_extract_model_from_parent_moves_joints(mocker):
+    mocker.patch("compas_timber.connections.LButtJoint.add_features")
+    model, panel, beam_a, beam_b = _hierarchy_model()
+    joint = LButtJoint.create(model, beam_a, beam_b)
+
+    extracted = model.extract_model_from_parent(panel)
+
+    assert joint in extracted.joints
+    assert len(list(model.joints)) == 0
+
+
+# ===========================================================================
+# merge_model
+# ===========================================================================
+
+
+def test_merge_model_moves_all_elements():
+    source, panel, beam_a, beam_b = _hierarchy_model()
+    target = TimberModel()
+
+    target.merge_model(source)
+
+    elements = list(target.elements())
+    assert panel in elements
+    assert beam_a in elements
+    assert beam_b in elements
+
+
+def test_merge_model_empties_source():
+    source, panel, beam_a, beam_b = _hierarchy_model()
+    target = TimberModel()
+
+    target.merge_model(source)
+
+    assert len(list(source.elements())) == 0
+
+
+def test_merge_model_preserves_hierarchy():
+    source, panel, beam_a, beam_b = _hierarchy_model()
+    target = TimberModel()
+
+    target.merge_model(source)
+
+    assert beam_a in panel.children
+    assert beam_b in panel.children
+
+
+def test_merge_model_moves_joints_exactly_once(mocker):
+    mocker.patch("compas_timber.connections.LButtJoint.add_features")
+    source, b1, b2 = _flat_model()
+    LButtJoint.create(source, b1, b2)
+    target = TimberModel()
+
+    target.merge_model(source)
+
+    assert len(list(target.joints)) == 1
+
+
+def test_merge_model_with_parent_roots_under_parent():
+    source, b1, b2 = _flat_model()
+    target = TimberModel()
+    root_panel = make_panel()
+    target.add_element(root_panel)
+
+    target.merge_model(source, parent=root_panel)
+
+    assert b1 in root_panel.children
+    assert b2 in root_panel.children
+
+
+def test_merge_model_source_joints_cleared(mocker):
+    mocker.patch("compas_timber.connections.LButtJoint.add_features")
+    source, b1, b2 = _flat_model()
+    LButtJoint.create(source, b1, b2)
+    target = TimberModel()
+
+    target.merge_model(source)
+
+    assert len(list(source.joints)) == 0


### PR DESCRIPTION
  - Added clear_model_dependent_cache() to all element classes (TimberElement, Plate, Panel, Fastener). It clears  only the cached attributes that depend on the element's position in the model hierarchy (world-space geometry,  bounding boxes, blank, ref_frame, etc.) while preserving model-independent caches like _elementgeometry,  features, and blank extensions.
  - Added TimberModel.remove_element_subtree(element) — removes all descendants of element from the model while  keeping element itself. Joints are cleaned up consistently (fully-internal joints removed, cross-boundary joints  dropped).
  - Added TimberModel.extract_model_from_parent(parent) — detaches parent's entire child subtree (hierarchy and  joints preserved) into a new standalone TimberModel. Useful for operating on a sub-assembly in isolation.
  - Added TimberModel.merge_model(model, parent=None) — moves all elements and joints from a source TimberModel  into this model, optionally re-rooting them under a given parent element.
  - Added clear_model_dependent_cache() to all element classes (TimberElement, Plate, Panel, Fastener). It clears  only the cached attributes that depend on the element's position in the model hierarchy (world-space geometry,  bounding boxes, blank, ref_frame, etc.) while preserving model-independent caches like _elementgeometry,  features, and blank extensions.
 

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate). 
