### PR TITLE
better tolerance isolation accross unittests

### DIFF
--- a/tests/compas_timber/conftest.py
+++ b/tests/compas_timber/conftest.py
@@ -2,13 +2,25 @@ from compas.tolerance import TOL
 import pytest
 
 
+@pytest.fixture(autouse=True, scope="session")
+def tolerance_session_default():
+    # Session scope is broader than module scope, so this runs before any
+    # module-scoped fixture build - including the first one in the whole run,
+    # which the function-scoped reset_tolerance below cannot cover.
+    TOL.reset()
+    TOL.unit = "MM"
+
+
 @pytest.fixture(autouse=True)
 def reset_tolerance():
     """
-    Reset the global tolerance before each test.
+    Reset the global tolerance before and after each test.
     This fixture is automatically applied to all tests.
     It enforces test isolation by ensuring that no test depends on tolerance values modified by other tests.
     Tests that require a non-default tolerance must set it explicitly within their own scope.
     """
+    TOL.reset()
+    TOL.unit = "MM"
+    yield
     TOL.reset()
     TOL.unit = "MM"

--- a/tests/compas_timber/test_slot.py
+++ b/tests/compas_timber/test_slot.py
@@ -25,8 +25,8 @@ def beam():
 
 @pytest.fixture
 def tol():
-    TOL.absolute = 0.001
-    TOL.relative = 0.01
+    with TOL.temporary(absolute=0.001, relative=0.01):
+        yield
 
 
 def test_horizontal_slot_negative_angle(beam):

--- a/tests/compas_timber/test_utils.py
+++ b/tests/compas_timber/test_utils.py
@@ -54,10 +54,6 @@ def test_intersection_line_line_param():
 
 
 def test_intersection_line_plane_param():
-    TOL.absolute = 0.001
-    TOL.unit = "MM"
-    TOL.relative = 0.001
-
     line = Line(Point(x=5.53733031674, y=12.3190045249, z=0.0), Point(x=20.8427601810, y=12.3190045249, z=0.0))
     plane = Plane(point=Point(x=15.436, y=16.546, z=-2.703), normal=Vector(x=-0.957, y=-0.289, z=0.000))
 
@@ -67,10 +63,11 @@ def test_intersection_line_plane_param():
     expected_point = [16.712490796555798, 12.3190045249, 0.0]
     expected_t = 0.7301435228494384
 
-    intersection_point, t = intersection_line_plane_param(line, plane)
+    with TOL.temporary(absolute=0.001, relative=0.001, unit="MM"):
+        intersection_point, t = intersection_line_plane_param(line, plane)
 
-    assert TOL.is_allclose(expected_point, intersection_point)
-    assert TOL.is_close(expected_t, t)
+        assert TOL.is_allclose(expected_point, intersection_point)
+        assert TOL.is_close(expected_t, t)
 
 
 def test_is_polyline_clockwise():


### PR DESCRIPTION
Fixed flaky tests cause by some tests that mutated the global TOL singleton (e.g. `TOL.absolute = 0.001`). the values leaked into subsequent tests, since TOL is shared global state and the per-test `reset_tolerance` fixture only reset before each test, not after.

- Added a session-scoped tolerance_session_default fixture in conftest.py to set the default tolerance before the very first test runs — module-scoped fixtures built earlier in a run weren't covered by the function-scoped reset.
- Extended reset_tolerance to also reset TOL after each test (via yield), closing the gap where a test's mutation could bleed into whatever ran next.
- Replaced direct, persistent mutation of TOL in test_slot.py and test_utils.py with TOL.temporary(...) context managers, scoping the non-default tolerance to just the code that needs it instead of relying on global resets.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).
