### PR TITLE
fixed t butt joint cutting cross beam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Fixed `TButtJoint` errorneously cutting cross beam even though `modify_cross` is set to `False`.
+* Fixed `TButtJoint` erroneously cutting cross beam even though `modify_cross` is set to `False`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed `TButtJoint` errorneously cutting cross beam even though `modify_cross` is set to `False`.
+
 ### Removed
 
 ## [2.1.1] 2026-06-16

--- a/data/model_test.btlx
+++ b/data/model_test.btlx
@@ -1,13 +1,13 @@
 <?xml version="1.0" ?>
 <BTLx xmlns="https://www.design2machine.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="2.0.0" Language="en" xsi:schemaLocation="https://www.design2machine.com https://www.design2machine.com/btlx/btlx_2_0_0.xsd">
    <FileHistory>
-      <InitialExportProgram CompanyName="Gramazio Kohler Research" ProgramName="COMPAS_Timber" ProgramVersion="Compas: 2.15.1" ComputerName="ITA-GK-W-30" UserName="egozzi" FileName="" Date="2026-06-04" Time="15:43:56" Comment=""/>
+      <InitialExportProgram CompanyName="Gramazio Kohler Research" ProgramName="COMPAS_Timber" ProgramVersion="Compas: 2.15.1" ComputerName="None" UserName="None" FileName="" Date="2026-06-16" Time="17:26:56" Comment=""/>
    </FileHistory>
    <Project Name="COMPAS Timber Project">
       <Parts>
-         <Part SingleMemberNumber="0" AssemblyNumber="" OrderNumber="0" Designation="Beam" Annotation="window" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1507.081" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="6a98" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="0" AssemblyNumber="" OrderNumber="0" Designation="Beam" Annotation="window" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1507.081" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="d5f3" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{6a981e44-1623-49dc-b475-bf029f0c47bd}">
+               <Transformation GUID="{d5f30507-f7fb-4a0b-9c91-492f725364ca}">
                   <Position>
                      <ReferencePoint X="2004.984" Y="-60.000" Z="1539.572"/>
                      <XVector X="-1.000" Y="0.000" Z="0.000"/>
@@ -19,22 +19,6 @@
             <ReferenceSide Side="1" Align="no"/>
             <Processings>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>end</Orientation>
-                  <StartX>1477.081</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
-                  <Orientation>end</Orientation>
-                  <StartX>1012.157</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
                   <Orientation>start</Orientation>
                   <StartX>30.000</StartX>
                   <StartY>0.000</StartY>
@@ -42,9 +26,9 @@
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
-                  <Orientation>start</Orientation>
-                  <StartX>474.984</StartX>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
+                  <Orientation>end</Orientation>
+                  <StartX>1477.081</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -52,9 +36,9 @@
                </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="1" AssemblyNumber="" OrderNumber="1" Designation="Beam" Annotation="window" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1507.081" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="c760" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="1" AssemblyNumber="" OrderNumber="1" Designation="Beam" Annotation="window" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1507.081" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="0a04" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{c760f2d8-37d6-41bd-8ccd-a03f4fd1e968}">
+               <Transformation GUID="{0a04cf8c-a620-4200-a218-006461b51686}">
                   <Position>
                      <ReferencePoint X="2004.984" Y="-60.000" Z="940.000"/>
                      <XVector X="-1.000" Y="0.000" Z="0.000"/>
@@ -65,22 +49,6 @@
             <GrainDirection X="1" Y="0" Z="0" Align="no"/>
             <ReferenceSide Side="1" Align="no"/>
             <Processings>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>end</Orientation>
-                  <StartX>1477.081</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>end</Orientation>
-                  <StartX>1012.157</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
                   <Orientation>start</Orientation>
                   <StartX>30.000</StartX>
@@ -90,8 +58,8 @@
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>start</Orientation>
-                  <StartX>474.984</StartX>
+                  <Orientation>end</Orientation>
+                  <StartX>1477.081</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -99,9 +67,9 @@
                </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="2" AssemblyNumber="" OrderNumber="2" Designation="Beam" Annotation="ceiling" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2270.897" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="0608" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="2" AssemblyNumber="" OrderNumber="2" Designation="Beam" Annotation="ceiling" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2270.897" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="d4c9" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{060875a1-a057-4dc8-9684-e7f233f521d2}">
+               <Transformation GUID="{d4c95d21-c986-4ec8-9c7f-1dc3cc35844b}">
                   <Position>
                      <ReferencePoint X="1085.731" Y="14.210" Z="1940.000"/>
                      <XVector X="0.474" Y="-0.881" Z="0.000"/>
@@ -113,12 +81,12 @@
             <ReferenceSide Side="1" Align="no"/>
             <Processings>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>end</Orientation>
-                  <StartX>1433.643</StartX>
+                  <Orientation>start</Orientation>
+                  <StartX>84.261</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
-                  <Inclination>86.235</Inclination>
+                  <Inclination>118.272</Inclination>
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
                   <Orientation>end</Orientation>
@@ -128,27 +96,11 @@
                   <Angle>90.000</Angle>
                   <Inclination>118.272</Inclination>
                </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>start</Orientation>
-                  <StartX>580.121</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>100.733</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>start</Orientation>
-                  <StartX>84.261</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>118.272</Inclination>
-               </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="3" AssemblyNumber="" OrderNumber="3" Designation="Beam" Annotation="ceiling" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1403.229" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="9d51" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="3" AssemblyNumber="" OrderNumber="3" Designation="Beam" Annotation="ceiling" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1403.229" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="2b5d" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{9d51b9d4-721d-4579-b6ad-41228650cb5c}">
+               <Transformation GUID="{2b5dd74c-1ce8-4234-9416-ed44da6a0c15}">
                   <Position>
                      <ReferencePoint X="1710.746" Y="-1207.108" Z="1940.000"/>
                      <XVector X="0.910" Y="0.415" Z="0.000"/>
@@ -177,9 +129,9 @@
                </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="4" AssemblyNumber="" OrderNumber="4" Designation="Beam" Annotation="ceiling" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1731.927" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="c1c7" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="4" AssemblyNumber="" OrderNumber="4" Designation="Beam" Annotation="ceiling" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1731.927" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="2882" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{c1c7146e-c7b9-4912-a0cd-09d68222b617}">
+               <Transformation GUID="{28828f51-d0f8-4d8f-840c-9565ff4e684d}">
                   <Position>
                      <ReferencePoint X="1364.739" Y="-556.114" Z="1940.000"/>
                      <XVector X="-0.777" Y="-0.629" Z="0.000"/>
@@ -190,14 +142,6 @@
             <GrainDirection X="1" Y="0" Z="0" Align="no"/>
             <ReferenceSide Side="1" Align="no"/>
             <Processings>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>end</Orientation>
-                  <StartX>1630.418</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>129.005</Inclination>
-               </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
                   <Orientation>start</Orientation>
                   <StartX>36.221</StartX>
@@ -206,11 +150,19 @@
                   <Angle>90.000</Angle>
                   <Inclination>100.733</Inclination>
                </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
+                  <Orientation>end</Orientation>
+                  <StartX>1630.418</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>129.005</Inclination>
+               </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="5" AssemblyNumber="" OrderNumber="5" Designation="Beam" Annotation="support" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1414.214" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="de24" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="5" AssemblyNumber="" OrderNumber="5" Designation="Beam" Annotation="support" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1414.214" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="2dca" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{de24c9aa-92d2-422e-bdf6-09e47d7649c0}">
+               <Transformation GUID="{2dcaa239-4558-414d-a0e7-2c75568d590c}">
                   <Position>
                      <ReferencePoint X="2940.000" Y="-1042.426" Z="1957.574"/>
                      <XVector X="0.000" Y="0.707" Z="-0.707"/>
@@ -221,14 +173,6 @@
             <GrainDirection X="1" Y="0" Z="0" Align="no"/>
             <ReferenceSide Side="1" Align="no"/>
             <Processings>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
-                  <Orientation>end</Orientation>
-                  <StartX>1269.361</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>135.000</Inclination>
-               </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
                   <Orientation>start</Orientation>
                   <StartX>24.853</StartX>
@@ -237,9 +181,9 @@
                   <Angle>90.000</Angle>
                   <Inclination>45.000</Inclination>
                </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>start</Orientation>
-                  <StartX>682.254</StartX>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
+                  <Orientation>end</Orientation>
+                  <StartX>1269.361</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -247,9 +191,9 @@
                </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="6" AssemblyNumber="" OrderNumber="6" Designation="Beam" Annotation="support" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1414.214" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="e626" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="6" AssemblyNumber="" OrderNumber="6" Designation="Beam" Annotation="support" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1414.214" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="4fc6" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{e62615e3-3d55-4988-9b4c-3706f41ad351}">
+               <Transformation GUID="{4fc6b138-6bee-4808-8d9c-824de512490d}">
                   <Position>
                      <ReferencePoint X="60.000" Y="-42.426" Z="957.574"/>
                      <XVector X="0.000" Y="-0.707" Z="0.707"/>
@@ -260,14 +204,6 @@
             <GrainDirection X="1" Y="0" Z="0" Align="no"/>
             <ReferenceSide Side="1" Align="no"/>
             <Processings>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>start</Orientation>
-                  <StartX>562.254</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>45.000</Inclination>
-               </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
                   <Orientation>start</Orientation>
                   <StartX>24.853</StartX>
@@ -286,9 +222,9 @@
                </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="7" AssemblyNumber="" OrderNumber="7" Designation="Beam" Annotation="support" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1500.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="5094" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="7" AssemblyNumber="" OrderNumber="7" Designation="Beam" Annotation="support" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1500.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="0328" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{50940319-a44b-4eb5-be67-14933c16f538}">
+               <Transformation GUID="{03285a2b-8eae-408e-8358-67c487c1c107}">
                   <Position>
                      <ReferencePoint X="2940.000" Y="-440.000" Z="1500.000"/>
                      <XVector X="0.000" Y="0.000" Z="-1.000"/>
@@ -317,9 +253,9 @@
                </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="8" AssemblyNumber="" OrderNumber="8" Designation="Beam" Annotation="support" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1500.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="efde" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="8" AssemblyNumber="" OrderNumber="8" Designation="Beam" Annotation="support" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1500.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="1e88" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{efde03ed-a40a-4212-85d2-9a5477e828b3}">
+               <Transformation GUID="{1e88ad95-f487-4600-a5ef-8320662a903c}">
                   <Position>
                      <ReferencePoint X="-60.000" Y="-440.000" Z="1500.000"/>
                      <XVector X="0.000" Y="0.000" Z="-1.000"/>
@@ -348,11 +284,11 @@
                </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="9" AssemblyNumber="" OrderNumber="9" Designation="Beam" Annotation="verticals" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2060.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="1a71" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="9" AssemblyNumber="" OrderNumber="9" Designation="Beam" Annotation="verticals" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2000.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="7438" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{1a711710-6c26-49dc-8ae0-43ae1692624c}">
+               <Transformation GUID="{74381909-2c04-4510-b880-17df88cd93e1}">
                   <Position>
-                     <ReferencePoint X="2496.669" Y="-60.000" Z="-60.000"/>
+                     <ReferencePoint X="2496.669" Y="-60.000" Z="-0.000"/>
                      <XVector X="0.000" Y="0.000" Z="1.000"/>
                      <YVector X="0.000" Y="1.000" Z="-0.000"/>
                   </Position>
@@ -361,77 +297,6 @@
             <GrainDirection X="1" Y="0" Z="0" Align="no"/>
             <ReferenceSide Side="1" Align="no"/>
             <Processings>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>start</Orientation>
-                  <StartX>0.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>start</Orientation>
-                  <StartX>120.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>end</Orientation>
-                  <StartX>2000.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-            </Processings>
-         </Part>
-         <Part SingleMemberNumber="10" AssemblyNumber="" OrderNumber="10" Designation="Beam" Annotation="verticals" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2000.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="cf11" Layer="0" ModuleNumber="">
-            <Transformations>
-               <Transformation GUID="{cf11abdc-899c-42ca-bed1-d6f9e6a450ca}">
-                  <Position>
-                     <ReferencePoint X="2034.984" Y="-60.000" Z="-0.000"/>
-                     <XVector X="0.000" Y="0.000" Z="1.000"/>
-                     <YVector X="0.000" Y="1.000" Z="-0.000"/>
-                  </Position>
-               </Transformation>
-            </Transformations>
-            <GrainDirection X="1" Y="0" Z="0" Align="no"/>
-            <ReferenceSide Side="1" Align="no"/>
-            <Processings>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>end</Orientation>
-                  <StartX>1659.572</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>start</Orientation>
-                  <StartX>60.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>start</Orientation>
-                  <StartX>940.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>start</Orientation>
-                  <StartX>60.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
                   <Orientation>end</Orientation>
                   <StartX>1940.000</StartX>
@@ -440,13 +305,68 @@
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
+                  <Orientation>start</Orientation>
+                  <StartX>60.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
+                  <Orientation>start</Orientation>
+                  <StartX>60.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="11" AssemblyNumber="" OrderNumber="11" Designation="Beam" Annotation="verticals" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2060.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="251f" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="10" AssemblyNumber="" OrderNumber="10" Designation="Beam" Annotation="verticals" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2060.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="c32d" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{251f3ab6-5580-4d40-9219-ff11788f2d30}">
+               <Transformation GUID="{c32d947d-70b8-4e4c-8a8f-6667e567f511}">
                   <Position>
-                     <ReferencePoint X="527.903" Y="-60.000" Z="-60.000"/>
+                     <ReferencePoint X="2034.984" Y="-60.000" Z="-60.000"/>
+                     <XVector X="0.000" Y="0.000" Z="1.000"/>
+                     <YVector X="0.000" Y="1.000" Z="-0.000"/>
+                  </Position>
+               </Transformation>
+            </Transformations>
+            <GrainDirection X="1" Y="0" Z="0" Align="no"/>
+            <ReferenceSide Side="1" Align="no"/>
+            <Processings>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
+                  <Orientation>start</Orientation>
+                  <StartX>0.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
+                  <Orientation>start</Orientation>
+                  <StartX>120.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
+                  <Orientation>end</Orientation>
+                  <StartX>2000.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+            </Processings>
+         </Part>
+         <Part SingleMemberNumber="11" AssemblyNumber="" OrderNumber="11" Designation="Beam" Annotation="verticals" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2000.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="ec1d" Layer="0" ModuleNumber="">
+            <Transformations>
+               <Transformation GUID="{ec1d8453-49fc-4d85-b51e-233fdd02df57}">
+                  <Position>
+                     <ReferencePoint X="527.903" Y="-60.000" Z="-0.000"/>
                      <XVector X="0.000" Y="0.000" Z="1.000"/>
                      <YVector X="0.000" Y="1.000" Z="-0.000"/>
                   </Position>
@@ -457,15 +377,15 @@
             <Processings>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
                   <Orientation>end</Orientation>
-                  <StartX>1719.572</StartX>
+                  <StartX>1940.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>end</Orientation>
-                  <StartX>1120.000</StartX>
+                  <Orientation>start</Orientation>
+                  <StartX>60.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -473,7 +393,38 @@
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
                   <Orientation>start</Orientation>
+                  <StartX>60.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+            </Processings>
+         </Part>
+         <Part SingleMemberNumber="12" AssemblyNumber="" OrderNumber="12" Designation="Beam" Annotation="verticals" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1060.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="7aed" Layer="0" ModuleNumber="">
+            <Transformations>
+               <Transformation GUID="{7aedfe70-6276-4029-aaa8-9892bf0e736f}">
+                  <Position>
+                     <ReferencePoint X="1530.000" Y="-60.000" Z="-60.000"/>
+                     <XVector X="0.000" Y="0.000" Z="1.000"/>
+                     <YVector X="0.000" Y="1.000" Z="-0.000"/>
+                  </Position>
+               </Transformation>
+            </Transformations>
+            <GrainDirection X="1" Y="0" Z="0" Align="no"/>
+            <ReferenceSide Side="1" Align="no"/>
+            <Processings>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
+                  <Orientation>start</Orientation>
                   <StartX>0.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
+                  <Orientation>end</Orientation>
+                  <StartX>1000.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -487,58 +438,11 @@
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>end</Orientation>
-                  <StartX>2000.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="12" AssemblyNumber="" OrderNumber="12" Designation="Beam" Annotation="verticals" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1000.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="83d6" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="13" AssemblyNumber="" OrderNumber="13" Designation="Beam" Annotation="verticals" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1000.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="6421" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{83d65f37-b71c-4774-8704-53520465b4b6}">
-                  <Position>
-                     <ReferencePoint X="1530.000" Y="-60.000" Z="-0.000"/>
-                     <XVector X="0.000" Y="0.000" Z="1.000"/>
-                     <YVector X="0.000" Y="1.000" Z="-0.000"/>
-                  </Position>
-               </Transformation>
-            </Transformations>
-            <GrainDirection X="1" Y="0" Z="0" Align="no"/>
-            <ReferenceSide Side="1" Align="no"/>
-            <Processings>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>start</Orientation>
-                  <StartX>60.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>start</Orientation>
-                  <StartX>60.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>end</Orientation>
-                  <StartX>940.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-            </Processings>
-         </Part>
-         <Part SingleMemberNumber="13" AssemblyNumber="" OrderNumber="13" Designation="Beam" Annotation="verticals" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1000.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="895b" Layer="0" ModuleNumber="">
-            <Transformations>
-               <Transformation GUID="{895beb30-28c4-4794-98e0-06d24a086217}">
+               <Transformation GUID="{642120b1-28c3-4762-8607-e889f56645f9}">
                   <Position>
                      <ReferencePoint X="1052.827" Y="-60.000" Z="-0.000"/>
                      <XVector X="0.000" Y="0.000" Z="1.000"/>
@@ -549,6 +453,14 @@
             <GrainDirection X="1" Y="0" Z="0" Align="no"/>
             <ReferenceSide Side="1" Align="no"/>
             <Processings>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
+                  <Orientation>start</Orientation>
+                  <StartX>60.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
                   <Orientation>start</Orientation>
                   <StartX>60.000</StartX>
@@ -565,19 +477,11 @@
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>start</Orientation>
-                  <StartX>60.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="14" AssemblyNumber="" OrderNumber="14" Designation="Beam" Annotation="verticals" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="400.428" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="4507" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="14" AssemblyNumber="" OrderNumber="14" Designation="Beam" Annotation="verticals" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="400.428" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="9ce9" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{45078bb4-7729-4624-9966-b8609ddf1afd}">
+               <Transformation GUID="{9ce9f96e-1547-4e44-b74d-4605672b54e2}">
                   <Position>
                      <ReferencePoint X="1530.000" Y="-60.000" Z="1599.572"/>
                      <XVector X="0.000" Y="0.000" Z="1.000"/>
@@ -606,9 +510,9 @@
                </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="15" AssemblyNumber="" OrderNumber="15" Designation="Beam" Annotation="verticals" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="400.428" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="928e" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="15" AssemblyNumber="" OrderNumber="15" Designation="Beam" Annotation="verticals" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="400.428" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="af5b" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{928eb8b5-bea9-4504-832f-318c3231854a}">
+               <Transformation GUID="{af5b648d-a596-4317-a730-218c28434b39}">
                   <Position>
                      <ReferencePoint X="1052.827" Y="-60.000" Z="1599.572"/>
                      <XVector X="0.000" Y="0.000" Z="1.000"/>
@@ -620,6 +524,14 @@
             <ReferenceSide Side="1" Align="no"/>
             <Processings>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
+                  <Orientation>start</Orientation>
+                  <StartX>60.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
                   <Orientation>end</Orientation>
                   <StartX>340.428</StartX>
                   <StartY>0.000</StartY>
@@ -627,21 +539,13 @@
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>start</Orientation>
-                  <StartX>60.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="16" AssemblyNumber="" OrderNumber="16" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2000.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="960c" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="16" AssemblyNumber="" OrderNumber="16" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2120.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="68aa" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{960cda32-1a88-46a1-b360-1cd586c88067}">
+               <Transformation GUID="{68aa3b3a-9ac4-4e38-a91b-a665dc0cd250}">
                   <Position>
-                     <ReferencePoint X="3060.000" Y="0.000" Z="1940.000"/>
+                     <ReferencePoint X="3060.000" Y="60.000" Z="1940.000"/>
                      <XVector X="0.000" Y="-1.000" Z="0.000"/>
                      <YVector X="0.000" Y="0.000" Z="1.000"/>
                   </Position>
@@ -650,62 +554,15 @@
             <GrainDirection X="1" Y="0" Z="0" Align="no"/>
             <ReferenceSide Side="1" Align="no"/>
             <Processings>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>start</Orientation>
-                  <StartX>646.715</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>114.507</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>start</Orientation>
-                  <StartX>60.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>start</Orientation>
-                  <StartX>60.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
                   <Orientation>end</Orientation>
-                  <StartX>1940.000</StartX>
+                  <StartX>2120.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>start</Orientation>
-                  <StartX>855.147</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>45.000</Inclination>
-               </JackRafterCut>
-            </Processings>
-         </Part>
-         <Part SingleMemberNumber="17" AssemblyNumber="" OrderNumber="17" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1620.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="b30d" Layer="0" ModuleNumber="">
-            <Transformations>
-               <Transformation GUID="{b30d063f-6537-477a-aa64-f5ff59f4a947}">
-                  <Position>
-                     <ReferencePoint X="3060.000" Y="60.000" Z="-60.000"/>
-                     <XVector X="0.000" Y="-1.000" Z="0.000"/>
-                     <YVector X="0.000" Y="0.000" Z="1.000"/>
-                  </Position>
-               </Transformation>
-            </Transformations>
-            <GrainDirection X="1" Y="0" Z="0" Align="no"/>
-            <ReferenceSide Side="1" Align="no"/>
-            <Processings>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
                   <Orientation>start</Orientation>
                   <StartX>0.000</StartX>
                   <StartY>0.000</StartY>
@@ -721,9 +578,32 @@
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
+            </Processings>
+         </Part>
+         <Part SingleMemberNumber="17" AssemblyNumber="" OrderNumber="17" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1500.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="52c7" Layer="0" ModuleNumber="">
+            <Transformations>
+               <Transformation GUID="{52c72e39-f5ad-4de6-a423-77b11aa36e20}">
+                  <Position>
+                     <ReferencePoint X="3060.000" Y="0.000" Z="-60.000"/>
+                     <XVector X="0.000" Y="-1.000" Z="0.000"/>
+                     <YVector X="0.000" Y="0.000" Z="1.000"/>
+                  </Position>
+               </Transformation>
+            </Transformations>
+            <GrainDirection X="1" Y="0" Z="0" Align="no"/>
+            <ReferenceSide Side="1" Align="no"/>
+            <Processings>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
                   <Orientation>end</Orientation>
-                  <StartX>1620.000</StartX>
+                  <StartX>1440.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
+                  <Orientation>start</Orientation>
+                  <StartX>60.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -731,7 +611,7 @@
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
                   <Orientation>start</Orientation>
-                  <StartX>500.000</StartX>
+                  <StartX>60.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -739,9 +619,9 @@
                </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="18" AssemblyNumber="" OrderNumber="18" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="3060.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="2748" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="18" AssemblyNumber="" OrderNumber="18" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="3120.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="cfb8" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{2748d58b-7ad2-40fd-ac6a-0855a497a000}">
+               <Transformation GUID="{cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0}">
                   <Position>
                      <ReferencePoint X="-60.000" Y="60.000" Z="-60.000"/>
                      <XVector X="1.000" Y="0.000" Z="0.000"/>
@@ -754,7 +634,7 @@
             <Processings>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
                   <Orientation>end</Orientation>
-                  <StartX>3000.000</StartX>
+                  <StartX>3120.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -762,69 +642,13 @@
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
                   <Orientation>start</Orientation>
-                  <StartX>1530.000</StartX>
+                  <StartX>0.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>start</Orientation>
-                  <StartX>1052.827</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>start</Orientation>
-                  <StartX>1530.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>start</Orientation>
-                  <StartX>-0.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>end</Orientation>
-                  <StartX>3000.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
-                  <Orientation>start</Orientation>
-                  <StartX>527.903</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>end</Orientation>
-                  <StartX>2094.984</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
-                  <Orientation>end</Orientation>
-                  <StartX>2094.984</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
                   <Orientation>start</Orientation>
                   <StartX>120.000</StartX>
                   <StartY>0.000</StartY>
@@ -832,33 +656,9 @@
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
-                  <Orientation>end</Orientation>
-                  <StartX>2556.669</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
-                  <Orientation>start</Orientation>
-                  <StartX>1052.827</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
                   <Orientation>end</Orientation>
-                  <StartX>2556.669</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>start</Orientation>
-                  <StartX>527.903</StartX>
+                  <StartX>3120.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -866,9 +666,9 @@
                </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="19" AssemblyNumber="" OrderNumber="19" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2120.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="6b02" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="19" AssemblyNumber="" OrderNumber="19" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2060.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="a58f" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{6b029936-f988-407f-8b8e-8b4473795e0a}">
+               <Transformation GUID="{a58f3f5a-c3eb-40e2-a967-e4d7cc7795c8}">
                   <Position>
                      <ReferencePoint X="2940.000" Y="-60.000" Z="-60.000"/>
                      <XVector X="0.000" Y="0.000" Z="1.000"/>
@@ -880,38 +680,14 @@
             <ReferenceSide Side="1" Align="no"/>
             <Processings>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>start</Orientation>
-                  <StartX>1035.147</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>135.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
                   <Orientation>end</Orientation>
-                  <StartX>2120.000</StartX>
+                  <StartX>2000.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>end</Orientation>
-                  <StartX>2120.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>start</Orientation>
-                  <StartX>-0.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
                   <Orientation>start</Orientation>
                   <StartX>120.000</StartX>
                   <StartY>0.000</StartY>
@@ -919,11 +695,27 @@
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
+                  <Orientation>end</Orientation>
+                  <StartX>2000.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
+                  <Orientation>start</Orientation>
+                  <StartX>-0.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="20" AssemblyNumber="" OrderNumber="20" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="3060.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="934f" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="20" AssemblyNumber="" OrderNumber="20" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="3120.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="cef8" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{934feddd-8db9-4d08-9ad0-083bba29a35f}">
+               <Transformation GUID="{cef865a8-469f-45ea-96fe-43d6f896ac29}">
                   <Position>
                      <ReferencePoint X="3060.000" Y="-60.000" Z="1940.000"/>
                      <XVector X="-1.000" Y="0.000" Z="0.000"/>
@@ -934,15 +726,23 @@
             <GrainDirection X="1" Y="0" Z="0" Align="no"/>
             <ReferenceSide Side="1" Align="no"/>
             <Processings>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
                   <Orientation>end</Orientation>
-                  <StartX>2067.173</StartX>
+                  <StartX>3120.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
+                  <Orientation>end</Orientation>
+                  <StartX>3120.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
                   <Orientation>start</Orientation>
                   <StartX>120.000</StartX>
                   <StartY>0.000</StartY>
@@ -950,7 +750,7 @@
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
                   <Orientation>start</Orientation>
                   <StartX>0.000</StartX>
                   <StartY>0.000</StartY>
@@ -958,69 +758,13 @@
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>end</Orientation>
-                  <StartX>3000.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>end</Orientation>
-                  <StartX>2002.485</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>118.272</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>start</Orientation>
-                  <StartX>1530.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>end</Orientation>
-                  <StartX>2592.097</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>end</Orientation>
-                  <StartX>3000.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>start</Orientation>
-                  <StartX>563.331</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>start</Orientation>
-                  <StartX>1025.016</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="21" AssemblyNumber="" OrderNumber="21" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2120.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="2181" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="21" AssemblyNumber="" OrderNumber="21" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2000.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="7ac9" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{2181217f-7468-4cdd-ba5d-a2203d39f36b}">
+               <Transformation GUID="{7ac92736-9a70-4979-8441-430e924ab9d9}">
                   <Position>
-                     <ReferencePoint X="-60.000" Y="60.000" Z="2060.000"/>
+                     <ReferencePoint X="-60.000" Y="60.000" Z="2000.000"/>
                      <XVector X="0.000" Y="0.000" Z="-1.000"/>
                      <YVector X="1.000" Y="0.000" Z="0.000"/>
                   </Position>
@@ -1031,7 +775,7 @@
             <Processings>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
                   <Orientation>end</Orientation>
-                  <StartX>2120.000</StartX>
+                  <StartX>1940.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -1039,15 +783,15 @@
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
                   <Orientation>start</Orientation>
-                  <StartX>915.147</StartX>
+                  <StartX>60.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
-                  <Inclination>45.000</Inclination>
+                  <Inclination>90.000</Inclination>
                </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
                   <Orientation>start</Orientation>
-                  <StartX>0.000</StartX>
+                  <StartX>60.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -1055,15 +799,7 @@
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
                   <Orientation>end</Orientation>
-                  <StartX>2120.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
-                  <Orientation>start</Orientation>
-                  <StartX>0.000</StartX>
+                  <StartX>1940.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -1071,9 +807,9 @@
                </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="22" AssemblyNumber="" OrderNumber="22" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2060.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="0e91" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="22" AssemblyNumber="" OrderNumber="22" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="2120.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="6f51" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{0e918642-9d6b-4437-845a-03a8b85f59cd}">
+               <Transformation GUID="{6f516961-c0c9-4264-8749-716cd22a985f}">
                   <Position>
                      <ReferencePoint X="60.000" Y="60.000" Z="1940.000"/>
                      <XVector X="0.000" Y="-1.000" Z="0.000"/>
@@ -1086,37 +822,13 @@
             <Processings>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
                   <Orientation>end</Orientation>
-                  <StartX>1672.875</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>129.005</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>start</Orientation>
-                  <StartX>0.000</StartX>
+                  <StartX>2120.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>end</Orientation>
-                  <StartX>2000.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
-                  <Orientation>start</Orientation>
-                  <StartX>915.147</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>45.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
                   <Orientation>start</Orientation>
                   <StartX>120.000</StartX>
                   <StartY>0.000</StartY>
@@ -1124,13 +836,21 @@
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="1">
+                  <Orientation>start</Orientation>
+                  <StartX>0.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="23" AssemblyNumber="" OrderNumber="23" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="3120.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="203d" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="23" AssemblyNumber="" OrderNumber="23" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="3000.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="9b43" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{203d7dd5-1e80-4f15-9b36-fc4b925d79a1}">
+               <Transformation GUID="{9b4340ab-e094-48a2-823a-2b464c54c41c}">
                   <Position>
-                     <ReferencePoint X="-60.000" Y="-1940.000" Z="1940.000"/>
+                     <ReferencePoint X="0.000" Y="-1940.000" Z="1940.000"/>
                      <XVector X="1.000" Y="0.000" Z="0.000"/>
                      <YVector X="-0.000" Y="0.000" Z="1.000"/>
                   </Position>
@@ -1141,15 +861,46 @@
             <Processings>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
                   <Orientation>end</Orientation>
-                  <StartX>2196.732</StartX>
+                  <StartX>2940.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
-                  <Inclination>118.272</Inclination>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
+                  <Orientation>start</Orientation>
+                  <StartX>60.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+            </Processings>
+         </Part>
+         <Part SingleMemberNumber="24" AssemblyNumber="" OrderNumber="24" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1620.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="6f95" Layer="0" ModuleNumber="">
+            <Transformations>
+               <Transformation GUID="{6f955f15-b316-4918-8764-9e4106dda755}">
+                  <Position>
+                     <ReferencePoint X="60.000" Y="60.000" Z="-60.000"/>
+                     <XVector X="0.000" Y="-1.000" Z="0.000"/>
+                     <YVector X="0.000" Y="0.000" Z="1.000"/>
+                  </Position>
+               </Transformation>
+            </Transformations>
+            <GrainDirection X="1" Y="0" Z="0" Align="no"/>
+            <ReferenceSide Side="1" Align="no"/>
+            <Processings>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
+                  <Orientation>start</Orientation>
+                  <StartX>0.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
                   <Orientation>end</Orientation>
-                  <StartX>3120.000</StartX>
+                  <StartX>1620.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -1165,58 +916,11 @@
                </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="24" AssemblyNumber="" OrderNumber="24" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1500.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="2898" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="25" AssemblyNumber="" OrderNumber="25" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="3060.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="bdb2" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{28984213-5f27-4ef5-8d12-a4dab0091968}">
+               <Transformation GUID="{bdb24d25-87c7-431f-ad70-8fc2ce5e770d}">
                   <Position>
-                     <ReferencePoint X="60.000" Y="0.000" Z="-60.000"/>
-                     <XVector X="0.000" Y="-1.000" Z="0.000"/>
-                     <YVector X="0.000" Y="0.000" Z="1.000"/>
-                  </Position>
-               </Transformation>
-            </Transformations>
-            <GrainDirection X="1" Y="0" Z="0" Align="no"/>
-            <ReferenceSide Side="1" Align="no"/>
-            <Processings>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>end</Orientation>
-                  <StartX>1440.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
-                  <Orientation>start</Orientation>
-                  <StartX>60.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>start</Orientation>
-                  <StartX>60.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
-                  <Orientation>start</Orientation>
-                  <StartX>440.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-            </Processings>
-         </Part>
-         <Part SingleMemberNumber="25" AssemblyNumber="" OrderNumber="25" Designation="Beam" Annotation="main" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="3060.000" Height="120.000" Width="120.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="a1a3" Layer="0" ModuleNumber="">
-            <Transformations>
-               <Transformation GUID="{a1a31d0f-d10f-4f4a-9c70-77ce34f62795}">
-                  <Position>
-                     <ReferencePoint X="-60.000" Y="-1440.000" Z="-60.000"/>
+                     <ReferencePoint X="0.000" Y="-1440.000" Z="-60.000"/>
                      <XVector X="1.000" Y="0.000" Z="0.000"/>
                      <YVector X="-0.000" Y="0.000" Z="1.000"/>
                   </Position>
@@ -1226,56 +930,16 @@
             <ReferenceSide Side="1" Align="no"/>
             <Processings>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>start</Orientation>
-                  <StartX>1052.827</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>start</Orientation>
-                  <StartX>0.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>start</Orientation>
-                  <StartX>1530.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>start</Orientation>
-                  <StartX>527.903</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
                   <Orientation>end</Orientation>
-                  <StartX>3000.000</StartX>
+                  <StartX>3060.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>end</Orientation>
-                  <StartX>2556.669</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>end</Orientation>
-                  <StartX>2094.984</StartX>
+                  <Orientation>start</Orientation>
+                  <StartX>60.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -1283,11 +947,11 @@
                </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="26" AssemblyNumber="" OrderNumber="26" Designation="Beam" Annotation="floor" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1500.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="faee" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="26" AssemblyNumber="" OrderNumber="26" Designation="Beam" Annotation="floor" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1560.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="4974" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{faee9be6-610d-4c46-86d0-01c4d4609bb1}">
+               <Transformation GUID="{4974254b-9a12-4d3e-b83e-6251ab157f8f}">
                   <Position>
-                     <ReferencePoint X="527.903" Y="0.000" Z="-60.000"/>
+                     <ReferencePoint X="527.903" Y="60.000" Z="-60.000"/>
                      <XVector X="0.000" Y="-1.000" Z="0.000"/>
                      <YVector X="0.000" Y="0.000" Z="1.000"/>
                   </Position>
@@ -1298,15 +962,7 @@
             <Processings>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
                   <Orientation>end</Orientation>
-                  <StartX>1440.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
-                  <Orientation>start</Orientation>
-                  <StartX>60.000</StartX>
+                  <StartX>1500.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -1314,7 +970,15 @@
                </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
                   <Orientation>start</Orientation>
-                  <StartX>60.000</StartX>
+                  <StartX>120.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
+                  <Orientation>start</Orientation>
+                  <StartX>-0.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>
@@ -1322,9 +986,9 @@
                </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="27" AssemblyNumber="" OrderNumber="27" Designation="Beam" Annotation="floor" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1560.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="ffde" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="27" AssemblyNumber="" OrderNumber="27" Designation="Beam" Annotation="floor" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1560.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="658a" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{ffde3ca4-8413-4b8a-8a78-d36e230b7adf}">
+               <Transformation GUID="{658a71ec-3e5e-4f60-a468-39ec51dd47cd}">
                   <Position>
                      <ReferencePoint X="1052.827" Y="60.000" Z="-60.000"/>
                      <XVector X="0.000" Y="-1.000" Z="0.000"/>
@@ -1336,6 +1000,14 @@
             <ReferenceSide Side="1" Align="no"/>
             <Processings>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
+                  <Orientation>start</Orientation>
+                  <StartX>120.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
                   <Orientation>end</Orientation>
                   <StartX>1500.000</StartX>
                   <StartY>0.000</StartY>
@@ -1351,99 +1023,13 @@
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>start</Orientation>
-                  <StartX>120.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
             </Processings>
          </Part>
-         <Part SingleMemberNumber="28" AssemblyNumber="" OrderNumber="28" Designation="Beam" Annotation="floor" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1560.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="503c" Layer="0" ModuleNumber="">
+         <Part SingleMemberNumber="28" AssemblyNumber="" OrderNumber="28" Designation="Beam" Annotation="floor" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1500.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="e4db" Layer="0" ModuleNumber="">
             <Transformations>
-               <Transformation GUID="{503cf99d-5860-4e4e-a792-fab1d00a91ee}">
+               <Transformation GUID="{e4db5300-d801-4945-a8f3-896a2666016f}">
                   <Position>
-                     <ReferencePoint X="1530.000" Y="60.000" Z="-60.000"/>
-                     <XVector X="0.000" Y="-1.000" Z="0.000"/>
-                     <YVector X="0.000" Y="0.000" Z="1.000"/>
-                  </Position>
-               </Transformation>
-            </Transformations>
-            <GrainDirection X="1" Y="0" Z="0" Align="no"/>
-            <ReferenceSide Side="1" Align="no"/>
-            <Processings>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>end</Orientation>
-                  <StartX>1500.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
-                  <Orientation>start</Orientation>
-                  <StartX>120.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
-                  <Orientation>start</Orientation>
-                  <StartX>0.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-            </Processings>
-         </Part>
-         <Part SingleMemberNumber="29" AssemblyNumber="" OrderNumber="29" Designation="Beam" Annotation="floor" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1560.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="c8c6" Layer="0" ModuleNumber="">
-            <Transformations>
-               <Transformation GUID="{c8c6c5b4-a35c-4175-92e7-65c6fed4a00b}">
-                  <Position>
-                     <ReferencePoint X="2034.984" Y="60.000" Z="-60.000"/>
-                     <XVector X="0.000" Y="-1.000" Z="0.000"/>
-                     <YVector X="0.000" Y="0.000" Z="1.000"/>
-                  </Position>
-               </Transformation>
-            </Transformations>
-            <GrainDirection X="1" Y="0" Z="0" Align="no"/>
-            <ReferenceSide Side="1" Align="no"/>
-            <Processings>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
-                  <Orientation>start</Orientation>
-                  <StartX>0.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>start</Orientation>
-                  <StartX>120.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
-                  <Orientation>end</Orientation>
-                  <StartX>1500.000</StartX>
-                  <StartY>0.000</StartY>
-                  <StartDepth>0.000</StartDepth>
-                  <Angle>90.000</Angle>
-                  <Inclination>90.000</Inclination>
-               </JackRafterCut>
-            </Processings>
-         </Part>
-         <Part SingleMemberNumber="30" AssemblyNumber="" OrderNumber="30" Designation="Beam" Annotation="floor" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1500.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="f4c0" Layer="0" ModuleNumber="">
-            <Transformations>
-               <Transformation GUID="{f4c08ca9-60ea-48a3-a981-a4e587da6809}">
-                  <Position>
-                     <ReferencePoint X="2496.669" Y="0.000" Z="-60.000"/>
+                     <ReferencePoint X="1530.000" Y="0.000" Z="-60.000"/>
                      <XVector X="0.000" Y="-1.000" Z="0.000"/>
                      <YVector X="0.000" Y="0.000" Z="1.000"/>
                   </Position>
@@ -1460,6 +1046,37 @@
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
+                  <Orientation>end</Orientation>
+                  <StartX>1440.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="2">
+                  <Orientation>start</Orientation>
+                  <StartX>60.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+            </Processings>
+         </Part>
+         <Part SingleMemberNumber="29" AssemblyNumber="" OrderNumber="29" Designation="Beam" Annotation="floor" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1500.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="950b" Layer="0" ModuleNumber="">
+            <Transformations>
+               <Transformation GUID="{950b5119-3208-4291-be1d-c77e1e9d6fa6}">
+                  <Position>
+                     <ReferencePoint X="2034.984" Y="0.000" Z="-60.000"/>
+                     <XVector X="0.000" Y="-1.000" Z="0.000"/>
+                     <YVector X="0.000" Y="0.000" Z="1.000"/>
+                  </Position>
+               </Transformation>
+            </Transformations>
+            <GrainDirection X="1" Y="0" Z="0" Align="no"/>
+            <ReferenceSide Side="1" Align="no"/>
+            <Processings>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
                   <Orientation>end</Orientation>
                   <StartX>1440.000</StartX>
@@ -1468,9 +1085,56 @@
                   <Angle>90.000</Angle>
                   <Inclination>90.000</Inclination>
                </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
+                  <Orientation>start</Orientation>
+                  <StartX>60.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
                <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
                   <Orientation>start</Orientation>
                   <StartX>60.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+            </Processings>
+         </Part>
+         <Part SingleMemberNumber="30" AssemblyNumber="" OrderNumber="30" Designation="Beam" Annotation="floor" Storey="" Group="" Package="" Material="" TimberGrade="" QualityGrade="" Count="1" Length="1560.000" Height="120.000" Width="60.000" Weight="0" ProcessingQuality="automatic" StoreyType="" ElementNumber="dd34" Layer="0" ModuleNumber="">
+            <Transformations>
+               <Transformation GUID="{dd34a65b-c4c1-41ea-a7cc-c68bf32f0889}">
+                  <Position>
+                     <ReferencePoint X="2496.669" Y="60.000" Z="-60.000"/>
+                     <XVector X="0.000" Y="-1.000" Z="0.000"/>
+                     <YVector X="0.000" Y="0.000" Z="1.000"/>
+                  </Position>
+               </Transformation>
+            </Transformations>
+            <GrainDirection X="1" Y="0" Z="0" Align="no"/>
+            <ReferenceSide Side="1" Align="no"/>
+            <Processings>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="3">
+                  <Orientation>start</Orientation>
+                  <StartX>0.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
+                  <Orientation>start</Orientation>
+                  <StartX>120.000</StartX>
+                  <StartY>0.000</StartY>
+                  <StartDepth>0.000</StartDepth>
+                  <Angle>90.000</Angle>
+                  <Inclination>90.000</Inclination>
+               </JackRafterCut>
+               <JackRafterCut Name="JackRafterCut" Process="yes" Priority="0" ProcessID="0" ReferencePlaneID="4">
+                  <Orientation>end</Orientation>
+                  <StartX>1500.000</StartX>
                   <StartY>0.000</StartY>
                   <StartDepth>0.000</StartDepth>
                   <Angle>90.000</Angle>

--- a/data/model_test.json
+++ b/data/model_test.json
@@ -1,337 +1,7 @@
 {
     "data": {
         "elements": {
-            "060875a1-a057-4dc8-9684-e7f233f521d2": {
-                "data": {
-                    "category": "ceiling",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                1059.3096199336605,
-                                0.0,
-                                2000.0
-                            ],
-                            "xaxis": [
-                                0.4736575925664665,
-                                -0.8807090808003171,
-                                0.0
-                            ],
-                            "yaxis": [
-                                0.8807090808003171,
-                                0.4736575925664665,
-                                0.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "b2d89ea2-c9b4-4e22-8fa3-0c1e7ea6507a"
-                    },
-                    "height": 120,
-                    "length": 2270.897443435649,
-                    "width": 60
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "060875a1-a057-4dc8-9684-e7f233f521d2",
-                "name": "ceiling"
-            },
-            "0e918642-9d6b-4437-845a-03a8b85f59cd": {
-                "data": {
-                    "category": "main",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                0.0,
-                                0.0,
-                                2000.0
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                -1.0,
-                                0.0
-                            ],
-                            "yaxis": [
-                                1.0,
-                                6.123233995736766e-17,
-                                0.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "336ab62d-f859-4204-ac50-888ada53307e"
-                    },
-                    "height": 120,
-                    "length": 2000.0,
-                    "width": 120
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "0e918642-9d6b-4437-845a-03a8b85f59cd",
-                "name": "main"
-            },
-            "1a711710-6c26-49dc-8ae0-43ae1692624c": {
-                "data": {
-                    "category": "verticals",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                2466.6690329793787,
-                                0.0,
-                                0.0
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                0.0,
-                                1.0
-                            ],
-                            "yaxis": [
-                                1.0,
-                                6.123233995736766e-17,
-                                -6.123233995736766e-17
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "96822132-e051-46ec-a130-9c926a436660"
-                    },
-                    "height": 120,
-                    "length": 2000.0,
-                    "width": 60
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "1a711710-6c26-49dc-8ae0-43ae1692624c",
-                "name": "verticals"
-            },
-            "203d7dd5-1e80-4f15-9b36-fc4b925d79a1": {
-                "data": {
-                    "category": "main",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                0.0,
-                                -2000.0,
-                                2000.0
-                            ],
-                            "xaxis": [
-                                1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "yaxis": [
-                                0.0,
-                                1.0,
-                                0.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "933cef40-8b18-4d85-b167-9726e922ba12"
-                    },
-                    "height": 120,
-                    "length": 3000.0,
-                    "width": 120
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "203d7dd5-1e80-4f15-9b36-fc4b925d79a1",
-                "name": "main"
-            },
-            "2181217f-7468-4cdd-ba5d-a2203d39f36b": {
-                "data": {
-                    "category": "main",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                0.0,
-                                0.0,
-                                2000.0
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                0.0,
-                                -1.0
-                            ],
-                            "yaxis": [
-                                0.0,
-                                1.0,
-                                0.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "d6d4065d-f8a7-43f0-b23e-debb0153c388"
-                    },
-                    "height": 120,
-                    "length": 2000.0,
-                    "width": 120
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "2181217f-7468-4cdd-ba5d-a2203d39f36b",
-                "name": "main"
-            },
-            "251f3ab6-5580-4d40-9219-ff11788f2d30": {
-                "data": {
-                    "category": "verticals",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                497.9030250550997,
-                                0.0,
-                                0.0
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                0.0,
-                                1.0
-                            ],
-                            "yaxis": [
-                                1.0,
-                                6.123233995736766e-17,
-                                -6.123233995736766e-17
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "c44f27cd-d756-4688-b48b-80e13a7106a6"
-                    },
-                    "height": 120,
-                    "length": 2000.0,
-                    "width": 60
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "251f3ab6-5580-4d40-9219-ff11788f2d30",
-                "name": "verticals"
-            },
-            "2748d58b-7ad2-40fd-ac6a-0855a497a000": {
-                "data": {
-                    "category": "main",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "xaxis": [
-                                1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "yaxis": [
-                                0.0,
-                                1.0,
-                                0.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "4fba13f2-fd68-4bde-9111-e84026d4c460"
-                    },
-                    "height": 120,
-                    "length": 3000.0,
-                    "width": 120
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "2748d58b-7ad2-40fd-ac6a-0855a497a000",
-                "name": "main"
-            },
-            "28984213-5f27-4ef5-8d12-a4dab0091968": {
-                "data": {
-                    "category": "main",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                0.0,
-                                0.0,
-                                0.0
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                -1.0,
-                                0.0
-                            ],
-                            "yaxis": [
-                                1.0,
-                                6.123233995736766e-17,
-                                0.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "f4820bf0-d04e-4775-af47-47fc19d65e19"
-                    },
-                    "height": 120,
-                    "length": 1500.0,
-                    "width": 120
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "28984213-5f27-4ef5-8d12-a4dab0091968",
-                "name": "main"
-            },
-            "45078bb4-7729-4624-9966-b8609ddf1afd": {
-                "data": {
-                    "category": "verticals",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                1500.0,
-                                0.0,
-                                1599.5716131249412
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                0.0,
-                                1.0
-                            ],
-                            "yaxis": [
-                                1.0,
-                                6.123233995736766e-17,
-                                -6.123233995736766e-17
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "4916fb37-c24d-4819-af73-afaf3c8b9a0f"
-                    },
-                    "height": 120,
-                    "length": 400.4283868750588,
-                    "width": 60
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "45078bb4-7729-4624-9966-b8609ddf1afd",
-                "name": "verticals"
-            },
-            "503cf99d-5860-4e4e-a792-fab1d00a91ee": {
-                "data": {
-                    "category": "floor",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                1500.0,
-                                0.0,
-                                0.0
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                -1.0,
-                                0.0
-                            ],
-                            "yaxis": [
-                                1.0,
-                                6.123233995736766e-17,
-                                0.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "fbfaf12b-81ab-413d-ae45-cc77b79b79ed"
-                    },
-                    "height": 120,
-                    "length": 1500.0,
-                    "width": 60
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "503cf99d-5860-4e4e-a792-fab1d00a91ee",
-                "name": "floor"
-            },
-            "50940319-a44b-4eb5-be67-14933c16f538": {
+            "03285a2b-8eae-408e-8358-67c487c1c107": {
                 "data": {
                     "category": "support",
                     "features": [],
@@ -354,17 +24,17 @@
                             ]
                         },
                         "dtype": "compas.geometry/Frame",
-                        "guid": "c659fbd1-089e-48b2-9771-58eaccef1b28"
+                        "guid": "702a5e2d-ecf6-4bc0-9ad2-bd19c5f67875"
                     },
                     "height": 120,
                     "length": 1500.0,
                     "width": 120
                 },
                 "dtype": "compas_timber.elements/Beam",
-                "guid": "50940319-a44b-4eb5-be67-14933c16f538",
+                "guid": "03285a2b-8eae-408e-8358-67c487c1c107",
                 "name": "support"
             },
-            "6a981e44-1623-49dc-b475-bf029f0c47bd": {
+            "0a04cf8c-a620-4200-a218-006461b51686": {
                 "data": {
                     "category": "window",
                     "features": [],
@@ -373,7 +43,7 @@
                             "point": [
                                 2004.984213989657,
                                 0.0,
-                                1599.5716131249412
+                                1000.0
                             ],
                             "xaxis": [
                                 -1.0,
@@ -387,262 +57,31 @@
                             ]
                         },
                         "dtype": "compas.geometry/Frame",
-                        "guid": "89913086-eb6a-40c3-b089-c46b782ebd84"
+                        "guid": "f222a0a9-b97d-4720-b06f-dbc438573fd0"
                     },
                     "height": 120,
                     "length": 1507.0811889345573,
                     "width": 120
                 },
                 "dtype": "compas_timber.elements/Beam",
-                "guid": "6a981e44-1623-49dc-b475-bf029f0c47bd",
+                "guid": "0a04cf8c-a620-4200-a218-006461b51686",
                 "name": "window"
             },
-            "6b029936-f988-407f-8b8e-8b4473795e0a": {
+            "1e88ad95-f487-4600-a5ef-8320662a903c": {
                 "data": {
-                    "category": "main",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                3000.0,
-                                0.0,
-                                0.0
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                0.0,
-                                1.0
-                            ],
-                            "yaxis": [
-                                1.2246467991473532e-16,
-                                -1.0,
-                                -7.498798913309288e-33
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "90dfebc3-7293-4f12-9243-c6ceca477f69"
-                    },
-                    "height": 120,
-                    "length": 2000.0,
-                    "width": 120
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "6b029936-f988-407f-8b8e-8b4473795e0a",
-                "name": "main"
-            },
-            "83d65f37-b71c-4774-8704-53520465b4b6": {
-                "data": {
-                    "category": "verticals",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                1500.0,
-                                0.0,
-                                0.0
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                0.0,
-                                1.0
-                            ],
-                            "yaxis": [
-                                1.0,
-                                6.123233995736766e-17,
-                                -6.123233995736766e-17
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "0a59ee86-4c52-4ed0-9f5f-bcc239b50f45"
-                    },
-                    "height": 120,
-                    "length": 1000.0,
-                    "width": 60
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "83d65f37-b71c-4774-8704-53520465b4b6",
-                "name": "verticals"
-            },
-            "895beb30-28c4-4794-98e0-06d24a086217": {
-                "data": {
-                    "category": "verticals",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                1022.8270086729294,
-                                0.0,
-                                0.0
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                0.0,
-                                1.0
-                            ],
-                            "yaxis": [
-                                1.0,
-                                6.123233995736766e-17,
-                                -6.123233995736766e-17
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "59bea50a-f2c8-4098-b348-a318c637b2c8"
-                    },
-                    "height": 120,
-                    "length": 1000.0000000000001,
-                    "width": 60
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "895beb30-28c4-4794-98e0-06d24a086217",
-                "name": "verticals"
-            },
-            "928eb8b5-bea9-4504-832f-318c3231854a": {
-                "data": {
-                    "category": "verticals",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                1022.8270086729295,
-                                0.0,
-                                1599.5716131249415
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                0.0,
-                                1.0
-                            ],
-                            "yaxis": [
-                                1.0,
-                                6.123233995736766e-17,
-                                -6.123233995736766e-17
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "8c5551bd-48a7-43be-91a4-0671278a9b18"
-                    },
-                    "height": 120,
-                    "length": 400.42838687505855,
-                    "width": 60
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "928eb8b5-bea9-4504-832f-318c3231854a",
-                "name": "verticals"
-            },
-            "934feddd-8db9-4d08-9ad0-083bba29a35f": {
-                "data": {
-                    "category": "main",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                3000.0,
-                                0.0,
-                                2000.0
-                            ],
-                            "xaxis": [
-                                -1.0,
-                                1.2246467991473532e-16,
-                                0.0
-                            ],
-                            "yaxis": [
-                                -1.2246467991473532e-16,
-                                -1.0,
-                                0.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "9999be09-a2c4-40df-9c36-3cb8334b775a"
-                    },
-                    "height": 120,
-                    "length": 3000.0,
-                    "width": 120
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "934feddd-8db9-4d08-9ad0-083bba29a35f",
-                "name": "main"
-            },
-            "960cda32-1a88-46a1-b360-1cd586c88067": {
-                "data": {
-                    "category": "main",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                3000.0,
-                                0.0,
-                                2000.0
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                -1.0,
-                                0.0
-                            ],
-                            "yaxis": [
-                                1.0,
-                                6.123233995736766e-17,
-                                0.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "80c20b15-e83d-4f3a-bc16-191ad7423d79"
-                    },
-                    "height": 120,
-                    "length": 2000.0,
-                    "width": 120
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "960cda32-1a88-46a1-b360-1cd586c88067",
-                "name": "main"
-            },
-            "9d51b9d4-721d-4579-b6ad-41228650cb5c": {
-                "data": {
-                    "category": "ceiling",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                1723.1898512721714,
-                                -1234.4051008146666,
-                                2000.0
-                            ],
-                            "xaxis": [
-                                0.9099084796184219,
-                                0.4148090629657119,
-                                0.0
-                            ],
-                            "yaxis": [
-                                -0.4148090629657119,
-                                0.9099084796184219,
-                                0.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "935ff816-7add-41a5-acd8-0f069695f000"
-                    },
-                    "height": 120,
-                    "length": 1403.2292008788293,
-                    "width": 60
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "9d51b9d4-721d-4579-b6ad-41228650cb5c",
-                "name": "ceiling"
-            },
-            "a1a31d0f-d10f-4f4a-9c70-77ce34f62795": {
-                "data": {
-                    "category": "main",
+                    "category": "support",
                     "features": [],
                     "frame": {
                         "data": {
                             "point": [
                                 0.0,
-                                -1500.0,
-                                0.0
+                                -500.0,
+                                1500.0
                             ],
                             "xaxis": [
-                                1.0,
+                                6.123233995736766e-17,
                                 0.0,
-                                0.0
+                                -1.0
                             ],
                             "yaxis": [
                                 0.0,
@@ -651,50 +90,17 @@
                             ]
                         },
                         "dtype": "compas.geometry/Frame",
-                        "guid": "b172d635-1f83-4e3c-9c84-8eea44c7114e"
-                    },
-                    "height": 120,
-                    "length": 3000.0,
-                    "width": 120
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "a1a31d0f-d10f-4f4a-9c70-77ce34f62795",
-                "name": "main"
-            },
-            "b30d063f-6537-477a-aa64-f5ff59f4a947": {
-                "data": {
-                    "category": "main",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                3000.0,
-                                0.0,
-                                0.0
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                -1.0,
-                                0.0
-                            ],
-                            "yaxis": [
-                                1.0,
-                                6.123233995736766e-17,
-                                0.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "ae7d699c-a277-4df8-995c-94645e09b9e9"
+                        "guid": "37b88de4-6e04-423b-b674-8a23beef237e"
                     },
                     "height": 120,
                     "length": 1500.0,
                     "width": 120
                 },
                 "dtype": "compas_timber.elements/Beam",
-                "guid": "b30d063f-6537-477a-aa64-f5ff59f4a947",
-                "name": "main"
+                "guid": "1e88ad95-f487-4600-a5ef-8320662a903c",
+                "name": "support"
             },
-            "c1c7146e-c7b9-4912-a0cd-09d68222b617": {
+            "28828f51-d0f8-4d8f-840c-9565ff4e684d": {
                 "data": {
                     "category": "ceiling",
                     "features": [],
@@ -717,116 +123,50 @@
                             ]
                         },
                         "dtype": "compas.geometry/Frame",
-                        "guid": "c5736a02-4cea-40c7-a248-53a1adbd896a"
+                        "guid": "ed2db781-4505-4f03-922c-0073d3a9c5e5"
                     },
                     "height": 120,
                     "length": 1731.9273049064166,
                     "width": 60
                 },
                 "dtype": "compas_timber.elements/Beam",
-                "guid": "c1c7146e-c7b9-4912-a0cd-09d68222b617",
+                "guid": "28828f51-d0f8-4d8f-840c-9565ff4e684d",
                 "name": "ceiling"
             },
-            "c760f2d8-37d6-41bd-8ccd-a03f4fd1e968": {
+            "2b5dd74c-1ce8-4234-9416-ed44da6a0c15": {
                 "data": {
-                    "category": "window",
+                    "category": "ceiling",
                     "features": [],
                     "frame": {
                         "data": {
                             "point": [
-                                2004.984213989657,
-                                0.0,
-                                1000.0
+                                1723.1898512721714,
+                                -1234.4051008146666,
+                                2000.0
                             ],
                             "xaxis": [
-                                -1.0,
-                                1.2246467991473532e-16,
-                                1.5087022325849322e-16
+                                0.9099084796184219,
+                                0.41480906296571185,
+                                0.0
                             ],
                             "yaxis": [
-                                -1.2246467991473532e-16,
-                                -1.0,
+                                -0.41480906296571185,
+                                0.9099084796184219,
                                 0.0
                             ]
                         },
                         "dtype": "compas.geometry/Frame",
-                        "guid": "036bd781-2728-44b6-8edd-1766307bbef4"
+                        "guid": "716972cf-f74f-43bb-875b-21cfc79a5011"
                     },
                     "height": 120,
-                    "length": 1507.0811889345573,
-                    "width": 120
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "c760f2d8-37d6-41bd-8ccd-a03f4fd1e968",
-                "name": "window"
-            },
-            "c8c6c5b4-a35c-4175-92e7-65c6fed4a00b": {
-                "data": {
-                    "category": "floor",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                2004.984213989657,
-                                0.0,
-                                0.0
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                -1.0,
-                                0.0
-                            ],
-                            "yaxis": [
-                                1.0,
-                                6.123233995736766e-17,
-                                0.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "9a123fea-c574-44ac-b29f-29c50eeb4be6"
-                    },
-                    "height": 120,
-                    "length": 1500.0,
+                    "length": 1403.2292008788293,
                     "width": 60
                 },
                 "dtype": "compas_timber.elements/Beam",
-                "guid": "c8c6c5b4-a35c-4175-92e7-65c6fed4a00b",
-                "name": "floor"
+                "guid": "2b5dd74c-1ce8-4234-9416-ed44da6a0c15",
+                "name": "ceiling"
             },
-            "cf11abdc-899c-42ca-bed1-d6f9e6a450ca": {
-                "data": {
-                    "category": "verticals",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                2004.984213989657,
-                                0.0,
-                                0.0
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                0.0,
-                                1.0
-                            ],
-                            "yaxis": [
-                                1.0,
-                                6.123233995736766e-17,
-                                -6.123233995736766e-17
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "7f3fd576-3fdb-4fca-8bb5-6d5e801fbd91"
-                    },
-                    "height": 120,
-                    "length": 2000.0,
-                    "width": 60
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "cf11abdc-899c-42ca-bed1-d6f9e6a450ca",
-                "name": "verticals"
-            },
-            "de24c9aa-92d2-422e-bdf6-09e47d7649c0": {
+            "2dcaa239-4558-414d-a0e7-2c75568d590c": {
                 "data": {
                     "category": "support",
                     "features": [],
@@ -849,116 +189,17 @@
                             ]
                         },
                         "dtype": "compas.geometry/Frame",
-                        "guid": "7d93c16c-7b6a-4909-8b22-d8ef7af97c55"
+                        "guid": "483a629f-708e-4584-93ee-b17f976c7905"
                     },
                     "height": 120,
                     "length": 1414.213562373095,
                     "width": 120
                 },
                 "dtype": "compas_timber.elements/Beam",
-                "guid": "de24c9aa-92d2-422e-bdf6-09e47d7649c0",
+                "guid": "2dcaa239-4558-414d-a0e7-2c75568d590c",
                 "name": "support"
             },
-            "e62615e3-3d55-4988-9b4c-3706f41ad351": {
-                "data": {
-                    "category": "support",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                0.0,
-                                0.0,
-                                1000.0
-                            ],
-                            "xaxis": [
-                                4.329780281177466e-17,
-                                -0.7071067811865475,
-                                0.7071067811865476
-                            ],
-                            "yaxis": [
-                                1.0,
-                                6.123233995736766e-17,
-                                0.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "9dec46bb-851d-4bc9-a7a9-fc23df7d56da"
-                    },
-                    "height": 120,
-                    "length": 1414.213562373095,
-                    "width": 120
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "e62615e3-3d55-4988-9b4c-3706f41ad351",
-                "name": "support"
-            },
-            "efde03ed-a40a-4212-85d2-9a5477e828b3": {
-                "data": {
-                    "category": "support",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                0.0,
-                                -500.0,
-                                1500.0
-                            ],
-                            "xaxis": [
-                                6.123233995736766e-17,
-                                0.0,
-                                -1.0
-                            ],
-                            "yaxis": [
-                                0.0,
-                                1.0,
-                                0.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "aeb85b35-aaec-4658-a051-852cd520b488"
-                    },
-                    "height": 120,
-                    "length": 1500.0,
-                    "width": 120
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "efde03ed-a40a-4212-85d2-9a5477e828b3",
-                "name": "support"
-            },
-            "f4c08ca9-60ea-48a3-a981-a4e587da6809": {
-                "data": {
-                    "category": "floor",
-                    "features": [],
-                    "frame": {
-                        "data": {
-                            "point": [
-                                2466.6690329793787,
-                                0.0,
-                                0.0
-                            ],
-                            "xaxis": [
-                                2.83276944882399e-16,
-                                -1.0,
-                                0.0
-                            ],
-                            "yaxis": [
-                                1.0,
-                                2.83276944882399e-16,
-                                0.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Frame",
-                        "guid": "b8973de2-7ba7-49f6-9672-0130a22f7245"
-                    },
-                    "height": 120,
-                    "length": 1500.0,
-                    "width": 60
-                },
-                "dtype": "compas_timber.elements/Beam",
-                "guid": "f4c08ca9-60ea-48a3-a981-a4e587da6809",
-                "name": "floor"
-            },
-            "faee9be6-610d-4c46-86d0-01c4d4609bb1": {
+            "4974254b-9a12-4d3e-b83e-6251ab157f8f": {
                 "data": {
                     "category": "floor",
                     "features": [],
@@ -981,17 +222,116 @@
                             ]
                         },
                         "dtype": "compas.geometry/Frame",
-                        "guid": "c1e3a56b-b7c1-4c42-9869-b6017ae80b72"
+                        "guid": "7b5930ca-0406-4122-a4b4-02289bf737c3"
                     },
                     "height": 120,
                     "length": 1500.0,
                     "width": 60
                 },
                 "dtype": "compas_timber.elements/Beam",
-                "guid": "faee9be6-610d-4c46-86d0-01c4d4609bb1",
+                "guid": "4974254b-9a12-4d3e-b83e-6251ab157f8f",
                 "name": "floor"
             },
-            "ffde3ca4-8413-4b8a-8a78-d36e230b7adf": {
+            "4fc6b138-6bee-4808-8d9c-824de512490d": {
+                "data": {
+                    "category": "support",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                0.0,
+                                0.0,
+                                1000.0
+                            ],
+                            "xaxis": [
+                                4.329780281177466e-17,
+                                -0.7071067811865475,
+                                0.7071067811865476
+                            ],
+                            "yaxis": [
+                                1.0,
+                                6.123233995736766e-17,
+                                0.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "53f0e012-0a86-4228-8f63-8a60120d3177"
+                    },
+                    "height": 120,
+                    "length": 1414.213562373095,
+                    "width": 120
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "4fc6b138-6bee-4808-8d9c-824de512490d",
+                "name": "support"
+            },
+            "52c72e39-f5ad-4de6-a423-77b11aa36e20": {
+                "data": {
+                    "category": "main",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                3000.0,
+                                0.0,
+                                0.0
+                            ],
+                            "xaxis": [
+                                6.123233995736766e-17,
+                                -1.0,
+                                0.0
+                            ],
+                            "yaxis": [
+                                1.0,
+                                6.123233995736766e-17,
+                                0.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "82b8b9a2-e027-481c-9530-945fa24bdb53"
+                    },
+                    "height": 120,
+                    "length": 1500.0,
+                    "width": 120
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "52c72e39-f5ad-4de6-a423-77b11aa36e20",
+                "name": "main"
+            },
+            "642120b1-28c3-4762-8607-e889f56645f9": {
+                "data": {
+                    "category": "verticals",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                1022.8270086729294,
+                                0.0,
+                                0.0
+                            ],
+                            "xaxis": [
+                                6.123233995736766e-17,
+                                0.0,
+                                1.0
+                            ],
+                            "yaxis": [
+                                1.0,
+                                6.123233995736766e-17,
+                                -6.123233995736766e-17
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "41462975-61a0-497a-a54a-0581505e377b"
+                    },
+                    "height": 120,
+                    "length": 1000.0000000000001,
+                    "width": 60
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "642120b1-28c3-4762-8607-e889f56645f9",
+                "name": "verticals"
+            },
+            "658a71ec-3e5e-4f60-a468-39ec51dd47cd": {
                 "data": {
                     "category": "floor",
                     "features": [],
@@ -1014,15 +354,675 @@
                             ]
                         },
                         "dtype": "compas.geometry/Frame",
-                        "guid": "598f77af-58fd-4ed3-b53b-c2567c83ca78"
+                        "guid": "c305062d-159e-4dba-9569-de98735de874"
                     },
                     "height": 120,
                     "length": 1500.0,
                     "width": 60
                 },
                 "dtype": "compas_timber.elements/Beam",
-                "guid": "ffde3ca4-8413-4b8a-8a78-d36e230b7adf",
+                "guid": "658a71ec-3e5e-4f60-a468-39ec51dd47cd",
                 "name": "floor"
+            },
+            "68aa3b3a-9ac4-4e38-a91b-a665dc0cd250": {
+                "data": {
+                    "category": "main",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                3000.0,
+                                0.0,
+                                2000.0
+                            ],
+                            "xaxis": [
+                                6.123233995736766e-17,
+                                -1.0,
+                                0.0
+                            ],
+                            "yaxis": [
+                                1.0,
+                                6.123233995736766e-17,
+                                0.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "fa489549-6d8b-4301-9ae5-b69cbd364a52"
+                    },
+                    "height": 120,
+                    "length": 2000.0,
+                    "width": 120
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "68aa3b3a-9ac4-4e38-a91b-a665dc0cd250",
+                "name": "main"
+            },
+            "6f516961-c0c9-4264-8749-716cd22a985f": {
+                "data": {
+                    "category": "main",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                0.0,
+                                0.0,
+                                2000.0
+                            ],
+                            "xaxis": [
+                                6.123233995736766e-17,
+                                -1.0,
+                                0.0
+                            ],
+                            "yaxis": [
+                                1.0,
+                                6.123233995736766e-17,
+                                0.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "be08acf2-3667-4385-8244-ad8040760d3d"
+                    },
+                    "height": 120,
+                    "length": 2000.0,
+                    "width": 120
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "6f516961-c0c9-4264-8749-716cd22a985f",
+                "name": "main"
+            },
+            "6f955f15-b316-4918-8764-9e4106dda755": {
+                "data": {
+                    "category": "main",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "xaxis": [
+                                6.123233995736766e-17,
+                                -1.0,
+                                0.0
+                            ],
+                            "yaxis": [
+                                1.0,
+                                6.123233995736766e-17,
+                                0.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "2bae61eb-0273-456c-88d7-220c32715075"
+                    },
+                    "height": 120,
+                    "length": 1500.0,
+                    "width": 120
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "6f955f15-b316-4918-8764-9e4106dda755",
+                "name": "main"
+            },
+            "74381909-2c04-4510-b880-17df88cd93e1": {
+                "data": {
+                    "category": "verticals",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                2466.6690329793787,
+                                0.0,
+                                0.0
+                            ],
+                            "xaxis": [
+                                6.123233995736766e-17,
+                                0.0,
+                                1.0
+                            ],
+                            "yaxis": [
+                                1.0,
+                                6.123233995736766e-17,
+                                -6.123233995736766e-17
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "b97b1b24-3274-4244-9782-cf77c340d632"
+                    },
+                    "height": 120,
+                    "length": 2000.0,
+                    "width": 60
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "74381909-2c04-4510-b880-17df88cd93e1",
+                "name": "verticals"
+            },
+            "7ac92736-9a70-4979-8441-430e924ab9d9": {
+                "data": {
+                    "category": "main",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                0.0,
+                                0.0,
+                                2000.0
+                            ],
+                            "xaxis": [
+                                6.123233995736766e-17,
+                                0.0,
+                                -1.0
+                            ],
+                            "yaxis": [
+                                0.0,
+                                1.0,
+                                0.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "e5cbe66f-da9e-4713-b2e1-a2f7c3d91534"
+                    },
+                    "height": 120,
+                    "length": 2000.0,
+                    "width": 120
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "7ac92736-9a70-4979-8441-430e924ab9d9",
+                "name": "main"
+            },
+            "7aedfe70-6276-4029-aaa8-9892bf0e736f": {
+                "data": {
+                    "category": "verticals",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                1500.0,
+                                0.0,
+                                0.0
+                            ],
+                            "xaxis": [
+                                6.123233995736766e-17,
+                                0.0,
+                                1.0
+                            ],
+                            "yaxis": [
+                                1.0,
+                                6.123233995736766e-17,
+                                -6.123233995736766e-17
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "dd90767f-7733-437e-86e2-7a0349db3a3e"
+                    },
+                    "height": 120,
+                    "length": 1000.0,
+                    "width": 60
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "7aedfe70-6276-4029-aaa8-9892bf0e736f",
+                "name": "verticals"
+            },
+            "950b5119-3208-4291-be1d-c77e1e9d6fa6": {
+                "data": {
+                    "category": "floor",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                2004.984213989657,
+                                0.0,
+                                0.0
+                            ],
+                            "xaxis": [
+                                6.123233995736766e-17,
+                                -1.0,
+                                0.0
+                            ],
+                            "yaxis": [
+                                1.0,
+                                6.123233995736766e-17,
+                                0.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "b816dff5-1695-470c-8cb8-de1ce487a96e"
+                    },
+                    "height": 120,
+                    "length": 1500.0,
+                    "width": 60
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "950b5119-3208-4291-be1d-c77e1e9d6fa6",
+                "name": "floor"
+            },
+            "9b4340ab-e094-48a2-823a-2b464c54c41c": {
+                "data": {
+                    "category": "main",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                0.0,
+                                -2000.0,
+                                2000.0
+                            ],
+                            "xaxis": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "yaxis": [
+                                0.0,
+                                1.0,
+                                0.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "98457302-1285-4f33-83ab-76d810448a49"
+                    },
+                    "height": 120,
+                    "length": 3000.0,
+                    "width": 120
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "9b4340ab-e094-48a2-823a-2b464c54c41c",
+                "name": "main"
+            },
+            "9ce9f96e-1547-4e44-b74d-4605672b54e2": {
+                "data": {
+                    "category": "verticals",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                1500.0,
+                                0.0,
+                                1599.5716131249412
+                            ],
+                            "xaxis": [
+                                6.123233995736766e-17,
+                                0.0,
+                                1.0
+                            ],
+                            "yaxis": [
+                                1.0,
+                                6.123233995736766e-17,
+                                -6.123233995736766e-17
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "c1c86145-0ac9-4843-bdc5-a6f323679d1b"
+                    },
+                    "height": 120,
+                    "length": 400.4283868750588,
+                    "width": 60
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "9ce9f96e-1547-4e44-b74d-4605672b54e2",
+                "name": "verticals"
+            },
+            "a58f3f5a-c3eb-40e2-a967-e4d7cc7795c8": {
+                "data": {
+                    "category": "main",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                3000.0,
+                                0.0,
+                                0.0
+                            ],
+                            "xaxis": [
+                                6.123233995736766e-17,
+                                0.0,
+                                1.0
+                            ],
+                            "yaxis": [
+                                1.2246467991473532e-16,
+                                -1.0,
+                                -7.498798913309288e-33
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "5fe44394-9357-4397-8ab7-31ac50119430"
+                    },
+                    "height": 120,
+                    "length": 2000.0,
+                    "width": 120
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "a58f3f5a-c3eb-40e2-a967-e4d7cc7795c8",
+                "name": "main"
+            },
+            "af5b648d-a596-4317-a730-218c28434b39": {
+                "data": {
+                    "category": "verticals",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                1022.8270086729295,
+                                0.0,
+                                1599.5716131249415
+                            ],
+                            "xaxis": [
+                                6.123233995736766e-17,
+                                0.0,
+                                1.0
+                            ],
+                            "yaxis": [
+                                1.0,
+                                6.123233995736766e-17,
+                                -6.123233995736766e-17
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "f5152cb4-6c1b-40b6-9919-d07cb737eede"
+                    },
+                    "height": 120,
+                    "length": 400.42838687505855,
+                    "width": 60
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "af5b648d-a596-4317-a730-218c28434b39",
+                "name": "verticals"
+            },
+            "bdb24d25-87c7-431f-ad70-8fc2ce5e770d": {
+                "data": {
+                    "category": "main",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                0.0,
+                                -1500.0,
+                                0.0
+                            ],
+                            "xaxis": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "yaxis": [
+                                0.0,
+                                1.0,
+                                0.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "84150b6d-01fe-4bb2-9613-a706cae3bd9b"
+                    },
+                    "height": 120,
+                    "length": 3000.0,
+                    "width": 120
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "bdb24d25-87c7-431f-ad70-8fc2ce5e770d",
+                "name": "main"
+            },
+            "c32d947d-70b8-4e4c-8a8f-6667e567f511": {
+                "data": {
+                    "category": "verticals",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                2004.984213989657,
+                                0.0,
+                                0.0
+                            ],
+                            "xaxis": [
+                                6.123233995736766e-17,
+                                0.0,
+                                1.0
+                            ],
+                            "yaxis": [
+                                1.0,
+                                6.123233995736766e-17,
+                                -6.123233995736766e-17
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "f56c94bc-9ed8-407b-a9dd-f825be16651a"
+                    },
+                    "height": 120,
+                    "length": 2000.0,
+                    "width": 60
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "c32d947d-70b8-4e4c-8a8f-6667e567f511",
+                "name": "verticals"
+            },
+            "cef865a8-469f-45ea-96fe-43d6f896ac29": {
+                "data": {
+                    "category": "main",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                3000.0,
+                                0.0,
+                                2000.0
+                            ],
+                            "xaxis": [
+                                -1.0,
+                                1.2246467991473532e-16,
+                                0.0
+                            ],
+                            "yaxis": [
+                                -1.2246467991473532e-16,
+                                -1.0,
+                                0.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "8c349bb3-2044-412b-8c25-acced851e22f"
+                    },
+                    "height": 120,
+                    "length": 3000.0,
+                    "width": 120
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "cef865a8-469f-45ea-96fe-43d6f896ac29",
+                "name": "main"
+            },
+            "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0": {
+                "data": {
+                    "category": "main",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "xaxis": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "yaxis": [
+                                0.0,
+                                1.0,
+                                0.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "925b4c99-f4d0-4021-b44b-8884d9a82c26"
+                    },
+                    "height": 120,
+                    "length": 3000.0,
+                    "width": 120
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0",
+                "name": "main"
+            },
+            "d4c95d21-c986-4ec8-9c7f-1dc3cc35844b": {
+                "data": {
+                    "category": "ceiling",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                1059.3096199336605,
+                                0.0,
+                                2000.0
+                            ],
+                            "xaxis": [
+                                0.4736575925664665,
+                                -0.8807090808003171,
+                                0.0
+                            ],
+                            "yaxis": [
+                                0.8807090808003171,
+                                0.4736575925664665,
+                                0.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "4989d3f5-cd00-4582-92d5-6d1b32268972"
+                    },
+                    "height": 120,
+                    "length": 2270.897443435649,
+                    "width": 60
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "d4c95d21-c986-4ec8-9c7f-1dc3cc35844b",
+                "name": "ceiling"
+            },
+            "d5f30507-f7fb-4a0b-9c91-492f725364ca": {
+                "data": {
+                    "category": "window",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                2004.984213989657,
+                                0.0,
+                                1599.5716131249412
+                            ],
+                            "xaxis": [
+                                -1.0,
+                                1.2246467991473532e-16,
+                                1.5087022325849322e-16
+                            ],
+                            "yaxis": [
+                                -1.2246467991473532e-16,
+                                -1.0,
+                                0.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "f6d47294-d8d0-4910-899c-aea393dccd90"
+                    },
+                    "height": 120,
+                    "length": 1507.0811889345573,
+                    "width": 120
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "d5f30507-f7fb-4a0b-9c91-492f725364ca",
+                "name": "window"
+            },
+            "dd34a65b-c4c1-41ea-a7cc-c68bf32f0889": {
+                "data": {
+                    "category": "floor",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                2466.6690329793787,
+                                0.0,
+                                0.0
+                            ],
+                            "xaxis": [
+                                2.83276944882399e-16,
+                                -1.0,
+                                0.0
+                            ],
+                            "yaxis": [
+                                1.0,
+                                2.83276944882399e-16,
+                                0.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "164a4735-5e69-4b65-b048-695ca4aa9ca0"
+                    },
+                    "height": 120,
+                    "length": 1500.0,
+                    "width": 60
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "dd34a65b-c4c1-41ea-a7cc-c68bf32f0889",
+                "name": "floor"
+            },
+            "e4db5300-d801-4945-a8f3-896a2666016f": {
+                "data": {
+                    "category": "floor",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                1500.0,
+                                0.0,
+                                0.0
+                            ],
+                            "xaxis": [
+                                6.123233995736766e-17,
+                                -1.0,
+                                0.0
+                            ],
+                            "yaxis": [
+                                1.0,
+                                6.123233995736766e-17,
+                                0.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "6627d7d4-a35d-4a53-9efd-872a2cec3b5a"
+                    },
+                    "height": 120,
+                    "length": 1500.0,
+                    "width": 60
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "e4db5300-d801-4945-a8f3-896a2666016f",
+                "name": "floor"
+            },
+            "ec1d8453-49fc-4d85-b51e-233fdd02df57": {
+                "data": {
+                    "category": "verticals",
+                    "features": [],
+                    "frame": {
+                        "data": {
+                            "point": [
+                                497.9030250550997,
+                                0.0,
+                                0.0
+                            ],
+                            "xaxis": [
+                                6.123233995736766e-17,
+                                0.0,
+                                1.0
+                            ],
+                            "yaxis": [
+                                1.0,
+                                6.123233995736766e-17,
+                                -6.123233995736766e-17
+                            ]
+                        },
+                        "dtype": "compas.geometry/Frame",
+                        "guid": "4bef1b55-2e3a-4b92-b8c9-7e1b3cd5bffd"
+                    },
+                    "height": 120,
+                    "length": 2000.0,
+                    "width": 60
+                },
+                "dtype": "compas_timber.elements/Beam",
+                "guid": "ec1d8453-49fc-4d85-b51e-233fdd02df57",
+                "name": "verticals"
             }
         },
         "graph": {
@@ -1047,8 +1047,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "6a981e44-1623-49dc-b475-bf029f0c47bd",
-                                    "cf11abdc-899c-42ca-bed1-d6f9e6a450ca"
+                                    "d5f30507-f7fb-4a0b-9c91-492f725364ca",
+                                    "c32d947d-70b8-4e4c-8a8f-6667e567f511"
                                 ],
                                 "location": {
                                     "data": [
@@ -1057,22 +1057,22 @@
                                         1599.5716131249412
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "db532b08-29df-48c2-a1fa-5402d1aa5a37"
+                                    "guid": "e55dc9c8-4086-43e6-bf66-df3a14409e9f"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "f411efab-12a0-4221-bb3a-ebad20a129fe"
+                            "guid": "d46fc8c4-3dce-4486-8536-d74141fa620b"
                         },
-                        "joints": "2d1bd73d-a062-4634-9677-7ec4e30e6ed3"
+                        "joints": "87e54758-8c36-4e58-b74b-9173224bf640"
                     },
                     "11": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "6a981e44-1623-49dc-b475-bf029f0c47bd",
-                                    "251f3ab6-5580-4d40-9219-ff11788f2d30"
+                                    "d5f30507-f7fb-4a0b-9c91-492f725364ca",
+                                    "ec1d8453-49fc-4d85-b51e-233fdd02df57"
                                 ],
                                 "location": {
                                     "data": [
@@ -1081,15 +1081,15 @@
                                         1599.5716131249415
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "0e1b2331-d10d-4965-b820-241b72d88e01"
+                                    "guid": "f5f8ef5f-265d-44c0-9b32-da29f5652b65"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "148a5c41-3002-4d7b-bb11-abb435747cb7"
+                            "guid": "824b4f64-e39b-420a-ba11-496485836e3b"
                         },
-                        "joints": "fe3cfd97-9633-4b44-92f3-b88b262c8d14"
+                        "joints": "fa96313f-8abb-4372-a3e0-d36526780352"
                     }
                 },
                 "1": {
@@ -1097,8 +1097,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "c760f2d8-37d6-41bd-8ccd-a03f4fd1e968",
-                                    "cf11abdc-899c-42ca-bed1-d6f9e6a450ca"
+                                    "0a04cf8c-a620-4200-a218-006461b51686",
+                                    "c32d947d-70b8-4e4c-8a8f-6667e567f511"
                                 ],
                                 "location": {
                                     "data": [
@@ -1107,22 +1107,22 @@
                                         1000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "65bf6dd6-ad80-44c0-8041-35e70ea0e10d"
+                                    "guid": "36f60ba8-b20c-4da6-841b-f1fd0e94c0f2"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "a6e899e7-e759-4e3b-929b-59806c8c6c2a"
+                            "guid": "ba64ab39-a190-486a-a14c-f1bb84dbc2ce"
                         },
-                        "joints": "1888ab1e-c84b-4196-b275-07332b5f86db"
+                        "joints": "d2718915-58db-4754-902f-2ef0c7e2fd8d"
                     },
                     "11": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "c760f2d8-37d6-41bd-8ccd-a03f4fd1e968",
-                                    "251f3ab6-5580-4d40-9219-ff11788f2d30"
+                                    "0a04cf8c-a620-4200-a218-006461b51686",
+                                    "ec1d8453-49fc-4d85-b51e-233fdd02df57"
                                 ],
                                 "location": {
                                     "data": [
@@ -1131,15 +1131,15 @@
                                         1000.0000000000002
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "7e376bf1-f1c9-459a-ba6e-468841fe29a1"
+                                    "guid": "4d7d274b-e7dc-4021-a3d6-ca80c5e206c6"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "303abcaf-dd82-4d57-9e66-fd04f1de8443"
+                            "guid": "fe624303-19f3-453f-82fd-29f9335a2d32"
                         },
-                        "joints": "dcf4f14f-a8db-4046-81a3-707dd8df1607"
+                        "joints": "d269adf8-f5a1-4d2e-b7a3-e9acca518ff7"
                     }
                 },
                 "10": {
@@ -1147,8 +1147,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "cf11abdc-899c-42ca-bed1-d6f9e6a450ca",
-                                    "2748d58b-7ad2-40fd-ac6a-0855a497a000"
+                                    "c32d947d-70b8-4e4c-8a8f-6667e567f511",
+                                    "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
                                 ],
                                 "location": {
                                     "data": [
@@ -1157,22 +1157,22 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "511848fa-d2ad-45fe-a9a2-0bf69cc3716d"
+                                    "guid": "e8754b11-3cc6-4ee0-9f2a-53cf790321c1"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "7fe8cc16-bf07-4879-bce3-6e79b7899772"
+                            "guid": "a1c8e128-41ad-483a-a965-cadcc83dfe52"
                         },
-                        "joints": "3b279fff-3586-4c7c-8a6a-84f00ebff59c"
+                        "joints": "517939aa-d8f7-437a-9df8-36489ad4f631"
                     },
                     "20": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "cf11abdc-899c-42ca-bed1-d6f9e6a450ca",
-                                    "934feddd-8db9-4d08-9ad0-083bba29a35f"
+                                    "c32d947d-70b8-4e4c-8a8f-6667e567f511",
+                                    "cef865a8-469f-45ea-96fe-43d6f896ac29"
                                 ],
                                 "location": {
                                     "data": [
@@ -1181,39 +1181,15 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "eb2d452d-e051-40da-8de3-a270b5052fa8"
+                                    "guid": "db7391c7-a7b7-43ea-8aeb-d83422116cde"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "6e907866-d3c1-468e-a565-bca235715a95"
+                            "guid": "b74da4bf-b37f-46e6-aaa4-15bcfb39799b"
                         },
-                        "joints": "f10ac188-9751-47e8-b748-619a214808ae"
-                    },
-                    "29": {
-                        "candidates": {
-                            "data": {
-                                "element_guids": [
-                                    "cf11abdc-899c-42ca-bed1-d6f9e6a450ca",
-                                    "c8c6c5b4-a35c-4175-92e7-65c6fed4a00b"
-                                ],
-                                "location": {
-                                    "data": [
-                                        2004.984213989657,
-                                        0.0,
-                                        0.0
-                                    ],
-                                    "dtype": "compas.geometry/Point",
-                                    "guid": "f2e76c4a-45f2-497c-b038-7255aeb8ad18"
-                                },
-                                "name": "JointCandidate",
-                                "topology": 2
-                            },
-                            "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "c8aae531-abd0-465e-8c5a-42b019f37c37"
-                        },
-                        "joints": "4a27615b-e103-432b-8a4d-195c55182d3e"
+                        "joints": "addcbf2f-d7bc-44f6-96c3-d7bfe1d5a13e"
                     }
                 },
                 "11": {
@@ -1221,8 +1197,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "251f3ab6-5580-4d40-9219-ff11788f2d30",
-                                    "2748d58b-7ad2-40fd-ac6a-0855a497a000"
+                                    "ec1d8453-49fc-4d85-b51e-233fdd02df57",
+                                    "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
                                 ],
                                 "location": {
                                     "data": [
@@ -1231,22 +1207,22 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "db934a23-a4a3-4742-9fab-bbac0d7c8b18"
+                                    "guid": "849f886c-fbb6-492a-9ae2-74dd9295d362"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "94f29756-ee17-4d16-afae-2be95bad5fc6"
+                            "guid": "a034ce77-d6a9-42d1-8f2c-fc1cdbc5850c"
                         },
-                        "joints": "a705487b-651f-4d60-9e62-b92a924d618e"
+                        "joints": "057190ba-7cc4-45b5-945a-4bfcd5992a40"
                     },
                     "20": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "251f3ab6-5580-4d40-9219-ff11788f2d30",
-                                    "934feddd-8db9-4d08-9ad0-083bba29a35f"
+                                    "ec1d8453-49fc-4d85-b51e-233fdd02df57",
+                                    "cef865a8-469f-45ea-96fe-43d6f896ac29"
                                 ],
                                 "location": {
                                     "data": [
@@ -1255,15 +1231,39 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "88194208-77b8-45b9-81cc-e0a8f6d9773b"
+                                    "guid": "028a16c5-f23f-4560-b0f6-6cd422aea056"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "8648ac8d-cdb3-4b30-9773-53a5d75420f7"
+                            "guid": "f8d5cc4a-f01f-4e70-a78f-f67da358ea18"
                         },
-                        "joints": "b4e1d8b9-0c43-454d-88e5-b6b4537540cd"
+                        "joints": "8d82b795-d624-4c1b-960e-46a3de6e42c8"
+                    },
+                    "26": {
+                        "candidates": {
+                            "data": {
+                                "element_guids": [
+                                    "ec1d8453-49fc-4d85-b51e-233fdd02df57",
+                                    "4974254b-9a12-4d3e-b83e-6251ab157f8f"
+                                ],
+                                "location": {
+                                    "data": [
+                                        497.9030250550997,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "dtype": "compas.geometry/Point",
+                                    "guid": "2fbb0b50-b3a7-44f6-87b1-2ea6da45fc3a"
+                                },
+                                "name": "JointCandidate",
+                                "topology": 2
+                            },
+                            "dtype": "compas_timber.connections/JointCandidate",
+                            "guid": "295463e2-2460-45aa-b64b-92b71bf9a691"
+                        },
+                        "joints": "dce492e9-4568-499f-acbc-626752ed3e6c"
                     }
                 },
                 "12": {
@@ -1271,8 +1271,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "83d65f37-b71c-4774-8704-53520465b4b6",
-                                    "c760f2d8-37d6-41bd-8ccd-a03f4fd1e968"
+                                    "7aedfe70-6276-4029-aaa8-9892bf0e736f",
+                                    "0a04cf8c-a620-4200-a218-006461b51686"
                                 ],
                                 "location": {
                                     "data": [
@@ -1281,22 +1281,22 @@
                                         1000.0000000000002
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "3320686e-9dd9-4d65-b158-e4287a81f174"
+                                    "guid": "04d5870f-effa-4d44-9de2-d9cba6a71e3a"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "a4085fe8-bb16-4772-8c14-ee62880f73ca"
+                            "guid": "8336a249-b64e-484e-a071-98acace91ba1"
                         },
-                        "joints": "8731467d-54d4-4660-af3c-e8b90fcd353c"
+                        "joints": "814cec8a-db4c-4e7f-9cea-206b344c8105"
                     },
                     "18": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "83d65f37-b71c-4774-8704-53520465b4b6",
-                                    "2748d58b-7ad2-40fd-ac6a-0855a497a000"
+                                    "7aedfe70-6276-4029-aaa8-9892bf0e736f",
+                                    "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
                                 ],
                                 "location": {
                                     "data": [
@@ -1305,39 +1305,15 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "1a194f7b-7751-4c7c-aee3-850b8ecb364a"
+                                    "guid": "3cf612d5-bba2-49fa-a2cf-61e2c19ce500"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "56f48adc-f4cb-4c7f-bade-1f88d9ed8d45"
+                            "guid": "531f4af0-845c-4595-874c-b99a82605b45"
                         },
-                        "joints": "361fc0ac-b87b-44d9-b2b1-464266a3f422"
-                    },
-                    "28": {
-                        "candidates": {
-                            "data": {
-                                "element_guids": [
-                                    "83d65f37-b71c-4774-8704-53520465b4b6",
-                                    "503cf99d-5860-4e4e-a792-fab1d00a91ee"
-                                ],
-                                "location": {
-                                    "data": [
-                                        1500.0,
-                                        0.0,
-                                        0.0
-                                    ],
-                                    "dtype": "compas.geometry/Point",
-                                    "guid": "dfa7820b-9959-4c2f-98b4-2cfe9efa18b1"
-                                },
-                                "name": "JointCandidate",
-                                "topology": 2
-                            },
-                            "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "95403f92-23fc-402c-8c8e-21d6d94365ec"
-                        },
-                        "joints": "2b369c3c-69bd-4148-aa3e-4f149090ce0c"
+                        "joints": "2a0ed14b-c0db-42a6-a603-2314a76cea8b"
                     }
                 },
                 "13": {
@@ -1345,8 +1321,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "895beb30-28c4-4794-98e0-06d24a086217",
-                                    "c760f2d8-37d6-41bd-8ccd-a03f4fd1e968"
+                                    "642120b1-28c3-4762-8607-e889f56645f9",
+                                    "0a04cf8c-a620-4200-a218-006461b51686"
                                 ],
                                 "location": {
                                     "data": [
@@ -1355,22 +1331,22 @@
                                         1000.0000000000001
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "c5b6b182-697d-4bb9-9918-019ee5471fe1"
+                                    "guid": "69c1f5d7-34a9-4565-b654-a9ed2ae52811"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "75e41d79-456b-40ba-9972-c89369162eb8"
+                            "guid": "ea9d013d-ca47-40c6-9243-711166099268"
                         },
-                        "joints": "66ba2ace-22e7-476a-a184-1dd21ef31ef0"
+                        "joints": "72e95bc5-e969-4470-adc6-5e83384a1ec9"
                     },
                     "18": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "895beb30-28c4-4794-98e0-06d24a086217",
-                                    "2748d58b-7ad2-40fd-ac6a-0855a497a000"
+                                    "642120b1-28c3-4762-8607-e889f56645f9",
+                                    "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
                                 ],
                                 "location": {
                                     "data": [
@@ -1379,22 +1355,22 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "db4c0c55-6818-4c44-ae98-8bae4be3d886"
+                                    "guid": "9df46c70-7959-46d0-8d05-06a40d00cb66"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "1f377656-5674-4493-8240-4e311a0395ca"
+                            "guid": "4b642541-4956-4eb3-b841-265d2faadae9"
                         },
-                        "joints": "37ff331e-bbdc-4d34-9375-9f6bca34a594"
+                        "joints": "6c85e7df-fa5c-4e0b-808d-efdcb55a8af3"
                     },
                     "27": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "895beb30-28c4-4794-98e0-06d24a086217",
-                                    "ffde3ca4-8413-4b8a-8a78-d36e230b7adf"
+                                    "642120b1-28c3-4762-8607-e889f56645f9",
+                                    "658a71ec-3e5e-4f60-a468-39ec51dd47cd"
                                 ],
                                 "location": {
                                     "data": [
@@ -1403,15 +1379,15 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "933b3136-8267-423a-a234-ee775a0f55dd"
+                                    "guid": "2e8e9d70-11a0-47ce-af13-b68cb174be6b"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 2
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "ec597ad0-93a1-440f-84f9-06ae7f6aeb7f"
+                            "guid": "069c2c63-cb9d-4d84-9a95-a46fb3c0a6c8"
                         },
-                        "joints": "27868fe2-e4c4-4cf8-a1d9-e4080f91a7d7"
+                        "joints": "4201b9d2-ca1a-4670-b6c3-9cd7c6526c7d"
                     }
                 },
                 "14": {
@@ -1419,8 +1395,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "45078bb4-7729-4624-9966-b8609ddf1afd",
-                                    "6a981e44-1623-49dc-b475-bf029f0c47bd"
+                                    "9ce9f96e-1547-4e44-b74d-4605672b54e2",
+                                    "d5f30507-f7fb-4a0b-9c91-492f725364ca"
                                 ],
                                 "location": {
                                     "data": [
@@ -1429,22 +1405,22 @@
                                         1599.5716131249412
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "03e9e512-0285-42af-958f-058694cbe055"
+                                    "guid": "8d36ed4f-6e8d-4d1c-8305-d65615452a54"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "e5ffaa4c-356d-4481-8dc7-9beaf5e2be89"
+                            "guid": "8e6f7a11-a460-493c-af9b-2d354cce9579"
                         },
-                        "joints": "da3b4544-3a7a-47f5-a240-4dd4717654a8"
+                        "joints": "232646db-d2e8-4006-915d-312811f10986"
                     },
                     "20": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "45078bb4-7729-4624-9966-b8609ddf1afd",
-                                    "934feddd-8db9-4d08-9ad0-083bba29a35f"
+                                    "9ce9f96e-1547-4e44-b74d-4605672b54e2",
+                                    "cef865a8-469f-45ea-96fe-43d6f896ac29"
                                 ],
                                 "location": {
                                     "data": [
@@ -1453,15 +1429,15 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "4bfe18ea-2dff-4aca-88d6-d020682d5372"
+                                    "guid": "489ea0c6-c972-47d6-8770-972a04940ea5"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "830c0fb9-bd92-46fd-8838-72b4ee45c1b6"
+                            "guid": "7555b76f-6af9-469b-9aa8-32ec5d82a5dc"
                         },
-                        "joints": "c2e2433b-803f-4cdf-99c3-9e7b3ea8e348"
+                        "joints": "ee843a2f-8a9c-497c-9ba7-2f3afd7c5545"
                     }
                 },
                 "15": {
@@ -1469,8 +1445,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "928eb8b5-bea9-4504-832f-318c3231854a",
-                                    "6a981e44-1623-49dc-b475-bf029f0c47bd"
+                                    "af5b648d-a596-4317-a730-218c28434b39",
+                                    "d5f30507-f7fb-4a0b-9c91-492f725364ca"
                                 ],
                                 "location": {
                                     "data": [
@@ -1479,22 +1455,22 @@
                                         1599.5716131249415
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "4c2845b7-f9aa-4208-925f-cf09372d4e88"
+                                    "guid": "8f588ad8-0526-4cf8-b25c-d19ac59263c4"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "2dc73bd9-4b86-4165-8402-1f5fcadbe325"
+                            "guid": "4b664827-f0fe-40e7-9521-bcbb62023f51"
                         },
-                        "joints": "1dc4d268-f00f-4ab6-9f61-76410aa5be55"
+                        "joints": "66bcfab9-b7f8-41e7-9840-1b370a08f193"
                     },
                     "20": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "928eb8b5-bea9-4504-832f-318c3231854a",
-                                    "934feddd-8db9-4d08-9ad0-083bba29a35f"
+                                    "af5b648d-a596-4317-a730-218c28434b39",
+                                    "cef865a8-469f-45ea-96fe-43d6f896ac29"
                                 ],
                                 "location": {
                                     "data": [
@@ -1503,24 +1479,125 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "dde1ec06-4ab8-404f-93f8-e6e3b0e49b51"
+                                    "guid": "333a3523-252f-4ee2-8811-fada826cac11"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "73ca0a4a-35ef-4cd5-aba8-509332c7209d"
+                            "guid": "06425f33-2003-4c6a-9e88-5b551f064b6d"
                         },
-                        "joints": "c6544be0-0c36-4095-a24b-bb626d733516"
+                        "joints": "571d146a-814e-4bb6-8c99-95577ac22b3b"
                     }
                 },
-                "16": {
+                "16": {},
+                "17": {
+                    "18": {
+                        "candidates": {
+                            "data": {
+                                "element_guids": [
+                                    "52c72e39-f5ad-4de6-a423-77b11aa36e20",
+                                    "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                                ],
+                                "location": {
+                                    "data": [
+                                        3000.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "dtype": "compas.geometry/Point",
+                                    "guid": "1366f1ac-ea22-4c92-8727-7ea0c23dd914"
+                                },
+                                "name": "JointCandidate",
+                                "topology": 2
+                            },
+                            "dtype": "compas_timber.connections/JointCandidate",
+                            "guid": "60d1e60c-b141-487a-bd71-c7ad17c1f52b"
+                        },
+                        "joints": "8f7f7882-5255-4398-91e9-e36aeeefc1ac"
+                    },
                     "19": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "960cda32-1a88-46a1-b360-1cd586c88067",
-                                    "6b029936-f988-407f-8b8e-8b4473795e0a"
+                                    "52c72e39-f5ad-4de6-a423-77b11aa36e20",
+                                    "a58f3f5a-c3eb-40e2-a967-e4d7cc7795c8"
+                                ],
+                                "location": {
+                                    "data": [
+                                        3000.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "dtype": "compas.geometry/Point",
+                                    "guid": "a8d91d1f-383a-4c53-b131-413c861c1d7c"
+                                },
+                                "name": "JointCandidate",
+                                "topology": 2
+                            },
+                            "dtype": "compas_timber.connections/JointCandidate",
+                            "guid": "dad7d22e-21f4-4556-890a-9bbdffb75ad6"
+                        },
+                        "joints": "63d1cce4-9fd0-4ba4-b127-d6ab3cfa1cb3"
+                    },
+                    "25": {
+                        "candidates": {
+                            "data": {
+                                "element_guids": [
+                                    "52c72e39-f5ad-4de6-a423-77b11aa36e20",
+                                    "bdb24d25-87c7-431f-ad70-8fc2ce5e770d"
+                                ],
+                                "location": {
+                                    "data": [
+                                        3000.0,
+                                        -1500.0,
+                                        0.0
+                                    ],
+                                    "dtype": "compas.geometry/Point",
+                                    "guid": "ddce5496-bc71-4d9f-af59-0950f3ca017d"
+                                },
+                                "name": "JointCandidate",
+                                "topology": 2
+                            },
+                            "dtype": "compas_timber.connections/JointCandidate",
+                            "guid": "dd779cb8-07da-4a09-9bad-d3dce864373f"
+                        },
+                        "joints": "ef8660b1-be64-4aa4-83d1-431d275f0dda"
+                    }
+                },
+                "18": {
+                    "24": {
+                        "candidates": {
+                            "data": {
+                                "element_guids": [
+                                    "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0",
+                                    "6f955f15-b316-4918-8764-9e4106dda755"
+                                ],
+                                "location": {
+                                    "data": [
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "dtype": "compas.geometry/Point",
+                                    "guid": "c4c20444-e6b1-422d-a7bd-a54fb4ab707f"
+                                },
+                                "name": "JointCandidate",
+                                "topology": 2
+                            },
+                            "dtype": "compas_timber.connections/JointCandidate",
+                            "guid": "8a712c88-9f59-4c62-b680-3c072c6c9bcb"
+                        },
+                        "joints": "a212de9f-93cd-43ab-b716-12279a4cfecf"
+                    }
+                },
+                "19": {
+                    "16": {
+                        "candidates": {
+                            "data": {
+                                "element_guids": [
+                                    "a58f3f5a-c3eb-40e2-a967-e4d7cc7795c8",
+                                    "68aa3b3a-9ac4-4e38-a91b-a665dc0cd250"
                                 ],
                                 "location": {
                                     "data": [
@@ -1529,22 +1606,46 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "a2bd38ab-6e75-4409-b4ab-074ba4b3eb2a"
+                                    "guid": "723fac0a-550a-444d-bb96-68174f6762ad"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 2
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "b2ceb84f-e57d-4ebc-bed7-a30107f377aa"
+                            "guid": "4d73f66d-c65b-4b90-b030-c58424417039"
                         },
-                        "joints": "bb78a305-5d14-4eba-9efb-b93eb285a793"
+                        "joints": "681e8a9d-2b06-48b2-b80c-3747ec20b2e2"
+                    },
+                    "18": {
+                        "candidates": {
+                            "data": {
+                                "element_guids": [
+                                    "a58f3f5a-c3eb-40e2-a967-e4d7cc7795c8",
+                                    "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                                ],
+                                "location": {
+                                    "data": [
+                                        3000.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "dtype": "compas.geometry/Point",
+                                    "guid": "3405611e-b361-4e33-a5a1-f4843a17f6a1"
+                                },
+                                "name": "JointCandidate",
+                                "topology": 2
+                            },
+                            "dtype": "compas_timber.connections/JointCandidate",
+                            "guid": "f8f02c75-e447-4f0b-a250-a825c35e5767"
+                        },
+                        "joints": "b8eefed5-0c66-4f67-a23f-1c447428f175"
                     },
                     "20": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "960cda32-1a88-46a1-b360-1cd586c88067",
-                                    "934feddd-8db9-4d08-9ad0-083bba29a35f"
+                                    "a58f3f5a-c3eb-40e2-a967-e4d7cc7795c8",
+                                    "cef865a8-469f-45ea-96fe-43d6f896ac29"
                                 ],
                                 "location": {
                                     "data": [
@@ -1553,140 +1654,15 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "2306715f-91d1-4ce6-ab86-9a5a7f38255f"
+                                    "guid": "6451abdf-abb6-49c4-af81-94a328cb6c58"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 2
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "a190848c-9e97-46b4-9028-083a6bd75a14"
+                            "guid": "9a8230f9-2b96-40a0-b1ad-b4a61f93833b"
                         },
-                        "joints": "bf4e75d8-5864-443b-8ff5-7fe7412694ce"
-                    },
-                    "23": {
-                        "candidates": {
-                            "data": {
-                                "element_guids": [
-                                    "960cda32-1a88-46a1-b360-1cd586c88067",
-                                    "203d7dd5-1e80-4f15-9b36-fc4b925d79a1"
-                                ],
-                                "location": {
-                                    "data": [
-                                        3000.0,
-                                        -2000.0,
-                                        2000.0
-                                    ],
-                                    "dtype": "compas.geometry/Point",
-                                    "guid": "c077c0f4-eb2b-4f49-bba1-24aaef972736"
-                                },
-                                "name": "JointCandidate",
-                                "topology": 2
-                            },
-                            "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "fcb9c01e-9120-4006-a2d1-357c035f0f1c"
-                        },
-                        "joints": "0a1d3c43-510c-4160-a198-281446778233"
-                    }
-                },
-                "17": {},
-                "18": {
-                    "17": {
-                        "candidates": {
-                            "data": {
-                                "element_guids": [
-                                    "2748d58b-7ad2-40fd-ac6a-0855a497a000",
-                                    "b30d063f-6537-477a-aa64-f5ff59f4a947"
-                                ],
-                                "location": {
-                                    "data": [
-                                        3000.0,
-                                        0.0,
-                                        0.0
-                                    ],
-                                    "dtype": "compas.geometry/Point",
-                                    "guid": "2bba6f50-4ce7-4108-9d18-9c192cbaa8d8"
-                                },
-                                "name": "JointCandidate",
-                                "topology": 2
-                            },
-                            "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "4fd0ad75-7c2c-4dd2-81c2-f6679e9f4309"
-                        },
-                        "joints": "08c5e6e9-b512-45a1-9719-6899032325e2"
-                    },
-                    "19": {
-                        "candidates": {
-                            "data": {
-                                "element_guids": [
-                                    "2748d58b-7ad2-40fd-ac6a-0855a497a000",
-                                    "6b029936-f988-407f-8b8e-8b4473795e0a"
-                                ],
-                                "location": {
-                                    "data": [
-                                        3000.0,
-                                        0.0,
-                                        0.0
-                                    ],
-                                    "dtype": "compas.geometry/Point",
-                                    "guid": "17a9b65a-e8cf-4639-8d19-76a1048742c9"
-                                },
-                                "name": "JointCandidate",
-                                "topology": 2
-                            },
-                            "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "b501af6d-7032-4752-a640-c2b79687c9b6"
-                        },
-                        "joints": "1f311f4e-33f0-4ae8-b70f-a262c71f29b8"
-                    },
-                    "21": {
-                        "candidates": {
-                            "data": {
-                                "element_guids": [
-                                    "2748d58b-7ad2-40fd-ac6a-0855a497a000",
-                                    "2181217f-7468-4cdd-ba5d-a2203d39f36b"
-                                ],
-                                "location": {
-                                    "data": [
-                                        0.0,
-                                        0.0,
-                                        0.0
-                                    ],
-                                    "dtype": "compas.geometry/Point",
-                                    "guid": "8c8600df-37fc-415b-88a0-5a562fbdbf79"
-                                },
-                                "name": "JointCandidate",
-                                "topology": 2
-                            },
-                            "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "c20c8ba7-8f5b-4668-8021-2512769bfa79"
-                        },
-                        "joints": "a293493b-5391-469c-9107-13e9776d0b93"
-                    }
-                },
-                "19": {
-                    "17": {
-                        "candidates": {
-                            "data": {
-                                "element_guids": [
-                                    "6b029936-f988-407f-8b8e-8b4473795e0a",
-                                    "b30d063f-6537-477a-aa64-f5ff59f4a947"
-                                ],
-                                "location": {
-                                    "data": [
-                                        3000.0,
-                                        0.0,
-                                        0.0
-                                    ],
-                                    "dtype": "compas.geometry/Point",
-                                    "guid": "6aecdfe2-f695-47bb-a255-cdaf8a538c1b"
-                                },
-                                "name": "JointCandidate",
-                                "topology": 2
-                            },
-                            "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "073868b3-3163-4764-ac07-a210a39bd167"
-                        },
-                        "joints": "20ddc08d-2526-44e4-9763-aa1dce9602ec"
+                        "joints": "6ba114a7-ec65-4e48-9daa-9922dfc71fcb"
                     }
                 },
                 "2": {
@@ -1694,8 +1670,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "060875a1-a057-4dc8-9684-e7f233f521d2",
-                                    "934feddd-8db9-4d08-9ad0-083bba29a35f"
+                                    "d4c95d21-c986-4ec8-9c7f-1dc3cc35844b",
+                                    "cef865a8-469f-45ea-96fe-43d6f896ac29"
                                 ],
                                 "location": {
                                     "data": [
@@ -1704,22 +1680,22 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "2bbf76bd-6087-402e-aed9-f5e68aa34679"
+                                    "guid": "fc09222c-a5e6-48a4-a38b-c9db277ff5f0"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "f46f825e-3513-4924-b2e3-e488d5ec70dc"
+                            "guid": "74e6b5aa-dbb0-436d-963d-cf50e99e435b"
                         },
-                        "joints": "c9615d1e-533d-4ff3-8f35-47a42732b470"
+                        "joints": "d4c4cd08-5658-4445-8786-1e5010141db5"
                     },
                     "23": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "060875a1-a057-4dc8-9684-e7f233f521d2",
-                                    "203d7dd5-1e80-4f15-9b36-fc4b925d79a1"
+                                    "d4c95d21-c986-4ec8-9c7f-1dc3cc35844b",
+                                    "9b4340ab-e094-48a2-823a-2b464c54c41c"
                                 ],
                                 "location": {
                                     "data": [
@@ -1728,24 +1704,24 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "7b45c850-ec5b-4f23-99d5-ea4cdb5c4ee5"
+                                    "guid": "2e82ff35-8fc8-45a4-828e-2c34b52c47c5"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "eca62ec3-e3f2-4367-9067-b2cd30b0edaa"
+                            "guid": "0048c619-bde3-4086-9d16-9db9fd963b33"
                         },
-                        "joints": "02bc75a6-40ab-4363-8054-fe9d216c30fd"
+                        "joints": "40c79a5e-68f1-491a-9d25-5450624219a9"
                     }
                 },
                 "20": {
-                    "19": {
+                    "16": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "934feddd-8db9-4d08-9ad0-083bba29a35f",
-                                    "6b029936-f988-407f-8b8e-8b4473795e0a"
+                                    "cef865a8-469f-45ea-96fe-43d6f896ac29",
+                                    "68aa3b3a-9ac4-4e38-a91b-a665dc0cd250"
                                 ],
                                 "location": {
                                     "data": [
@@ -1754,22 +1730,48 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "669e73c8-900e-4e3a-9ffe-494c0f88f66c"
+                                    "guid": "9e6580fb-5e96-45f0-bf20-b50978a599e2"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 2
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "db7cc739-4a2e-409a-9eee-6774a4320a07"
+                            "guid": "2d6517b1-4a6b-4843-8fbd-854b7828aab3"
                         },
-                        "joints": "3418f09f-a1db-4f4d-ac5b-c25f36031a5b"
-                    },
-                    "21": {
+                        "joints": "f5f139aa-88e4-470a-9ea5-68812f99c724"
+                    }
+                },
+                "21": {
+                    "18": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "934feddd-8db9-4d08-9ad0-083bba29a35f",
-                                    "2181217f-7468-4cdd-ba5d-a2203d39f36b"
+                                    "7ac92736-9a70-4979-8441-430e924ab9d9",
+                                    "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                                ],
+                                "location": {
+                                    "data": [
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "dtype": "compas.geometry/Point",
+                                    "guid": "70ce5927-437f-401d-aa3e-72a1e25b2790"
+                                },
+                                "name": "JointCandidate",
+                                "topology": 2
+                            },
+                            "dtype": "compas_timber.connections/JointCandidate",
+                            "guid": "fb877592-5e0f-496f-96a0-c3b28c8bdfde"
+                        },
+                        "joints": "92248235-687b-4e41-9de0-98308be5deb6"
+                    },
+                    "20": {
+                        "candidates": {
+                            "data": {
+                                "element_guids": [
+                                    "7ac92736-9a70-4979-8441-430e924ab9d9",
+                                    "cef865a8-469f-45ea-96fe-43d6f896ac29"
                                 ],
                                 "location": {
                                     "data": [
@@ -1778,22 +1780,22 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "b332413a-cbd6-4f0f-9ed5-b92f2bbf97df"
+                                    "guid": "8943e6bb-d9b6-4c22-8b1e-7d00e2f20ae8"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 2
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "6e41bf6a-cdde-4382-9aa3-5f7c348c6247"
+                            "guid": "8ac7aeaf-fcad-4db2-9ca3-167a41f6e10e"
                         },
-                        "joints": "1e534e87-ba2a-4607-9551-115c36486213"
+                        "joints": "f3f1f701-ef1b-4ffc-ab45-ddc1949ebf6c"
                     },
                     "22": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "934feddd-8db9-4d08-9ad0-083bba29a35f",
-                                    "0e918642-9d6b-4437-845a-03a8b85f59cd"
+                                    "7ac92736-9a70-4979-8441-430e924ab9d9",
+                                    "6f516961-c0c9-4264-8749-716cd22a985f"
                                 ],
                                 "location": {
                                     "data": [
@@ -1802,25 +1804,48 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "be29f179-e5a1-4fcc-aafe-ec84476683eb"
+                                    "guid": "caa9eae4-34de-4e0e-b132-2165b12f9ef3"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 2
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "1fe879ab-c583-499a-b4d1-76c0ac672ddb"
+                            "guid": "8675f047-203b-41dc-80dc-aa67296e57ad"
                         },
-                        "joints": "a08a9d6d-6e4b-451c-8b06-78a6ae81dd48"
+                        "joints": "2676a4b1-a3e5-44fa-8000-bd3f3a28f59a"
+                    },
+                    "24": {
+                        "candidates": {
+                            "data": {
+                                "element_guids": [
+                                    "7ac92736-9a70-4979-8441-430e924ab9d9",
+                                    "6f955f15-b316-4918-8764-9e4106dda755"
+                                ],
+                                "location": {
+                                    "data": [
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "dtype": "compas.geometry/Point",
+                                    "guid": "13857a50-fea0-4a98-8048-b2ed31184ba3"
+                                },
+                                "name": "JointCandidate",
+                                "topology": 2
+                            },
+                            "dtype": "compas_timber.connections/JointCandidate",
+                            "guid": "3c42be47-2ca3-4534-a9b8-36eaf9d4bf7d"
+                        },
+                        "joints": "270a9dc5-0b20-4bdd-8e07-6f09343ccd1f"
                     }
                 },
-                "21": {},
                 "22": {
-                    "21": {
+                    "20": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "0e918642-9d6b-4437-845a-03a8b85f59cd",
-                                    "2181217f-7468-4cdd-ba5d-a2203d39f36b"
+                                    "6f516961-c0c9-4264-8749-716cd22a985f",
+                                    "cef865a8-469f-45ea-96fe-43d6f896ac29"
                                 ],
                                 "location": {
                                     "data": [
@@ -1829,22 +1854,48 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "82ab7c2e-aa77-4612-965b-e28d4f240f57"
+                                    "guid": "4211ddc5-c97b-4ce1-ab2c-568bfbdf47fa"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 2
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "d5f34e1c-f59c-4a9f-913e-e0ade80202d9"
+                            "guid": "239fa02e-d5af-4f5d-a0b3-60fc1494bde3"
                         },
-                        "joints": "868403be-44d4-4c51-b759-9adc6a5c8d8b"
-                    },
-                    "23": {
+                        "joints": "36264ef0-59e7-47c6-b5f0-dfc657d89f9f"
+                    }
+                },
+                "23": {
+                    "16": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "0e918642-9d6b-4437-845a-03a8b85f59cd",
-                                    "203d7dd5-1e80-4f15-9b36-fc4b925d79a1"
+                                    "9b4340ab-e094-48a2-823a-2b464c54c41c",
+                                    "68aa3b3a-9ac4-4e38-a91b-a665dc0cd250"
+                                ],
+                                "location": {
+                                    "data": [
+                                        3000.0,
+                                        -2000.0,
+                                        2000.0
+                                    ],
+                                    "dtype": "compas.geometry/Point",
+                                    "guid": "cbeb72a0-9c57-4412-afe2-d694e8a2c0f7"
+                                },
+                                "name": "JointCandidate",
+                                "topology": 2
+                            },
+                            "dtype": "compas_timber.connections/JointCandidate",
+                            "guid": "9b44d54f-a93f-4e40-9cc8-db9f79800448"
+                        },
+                        "joints": "9428126e-681b-460b-a160-7bd0ece34b1a"
+                    },
+                    "22": {
+                        "candidates": {
+                            "data": {
+                                "element_guids": [
+                                    "9b4340ab-e094-48a2-823a-2b464c54c41c",
+                                    "6f516961-c0c9-4264-8749-716cd22a985f"
                                 ],
                                 "location": {
                                     "data": [
@@ -1853,149 +1904,51 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "d97d2144-8755-4738-ae55-44e3b1ec14e0"
+                                    "guid": "1205afbe-56de-42e1-8f1a-eebac53fcd99"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 2
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "2c77fe90-39a9-4744-b2e1-2302fcc692aa"
+                            "guid": "d1e5ba5c-8be0-458b-9519-626fcd54071a"
                         },
-                        "joints": "de53b7ac-5c43-4d21-8882-413843dadc97"
+                        "joints": "2a51c995-a4c0-4183-8920-a1b4a487cd0c"
                     }
                 },
-                "23": {},
-                "24": {
-                    "18": {
-                        "candidates": {
-                            "data": {
-                                "element_guids": [
-                                    "28984213-5f27-4ef5-8d12-a4dab0091968",
-                                    "2748d58b-7ad2-40fd-ac6a-0855a497a000"
-                                ],
-                                "location": {
-                                    "data": [
-                                        0.0,
-                                        0.0,
-                                        0.0
-                                    ],
-                                    "dtype": "compas.geometry/Point",
-                                    "guid": "ab1b7f9e-f17d-4936-ad68-5abfe4c9498d"
-                                },
-                                "name": "JointCandidate",
-                                "topology": 2
-                            },
-                            "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "8035309d-f0a3-4364-a6ca-06608c66b59f"
-                        },
-                        "joints": "629f0d7f-eac7-4910-80fb-630aab313ca5"
-                    },
-                    "21": {
-                        "candidates": {
-                            "data": {
-                                "element_guids": [
-                                    "28984213-5f27-4ef5-8d12-a4dab0091968",
-                                    "2181217f-7468-4cdd-ba5d-a2203d39f36b"
-                                ],
-                                "location": {
-                                    "data": [
-                                        0.0,
-                                        0.0,
-                                        0.0
-                                    ],
-                                    "dtype": "compas.geometry/Point",
-                                    "guid": "1d6858dc-c4c4-446c-b164-1ddf793abb14"
-                                },
-                                "name": "JointCandidate",
-                                "topology": 2
-                            },
-                            "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "82f96b60-14e5-4ed7-906e-e32f509f3be2"
-                        },
-                        "joints": "a34d2752-1f7c-4e11-96bb-dc1368e41a78"
-                    },
-                    "25": {
-                        "candidates": {
-                            "data": {
-                                "element_guids": [
-                                    "28984213-5f27-4ef5-8d12-a4dab0091968",
-                                    "a1a31d0f-d10f-4f4a-9c70-77ce34f62795"
-                                ],
-                                "location": {
-                                    "data": [
-                                        0.0,
-                                        -1500.0,
-                                        0.0
-                                    ],
-                                    "dtype": "compas.geometry/Point",
-                                    "guid": "0e21cc3b-47d7-4ba1-b486-767164122b78"
-                                },
-                                "name": "JointCandidate",
-                                "topology": 2
-                            },
-                            "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "45e1542c-fdd2-49b2-b583-142ac36579e3"
-                        },
-                        "joints": "25f2444d-357a-4013-b979-a857ef670a7b"
-                    }
-                },
+                "24": {},
                 "25": {
-                    "17": {
+                    "24": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "a1a31d0f-d10f-4f4a-9c70-77ce34f62795",
-                                    "b30d063f-6537-477a-aa64-f5ff59f4a947"
+                                    "bdb24d25-87c7-431f-ad70-8fc2ce5e770d",
+                                    "6f955f15-b316-4918-8764-9e4106dda755"
                                 ],
                                 "location": {
                                     "data": [
-                                        3000.0,
+                                        0.0,
                                         -1500.0,
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "0c827360-26cc-4fa6-8eb2-56a7b20ac23e"
+                                    "guid": "e6dbc50f-df24-433b-8244-fd83dbf794d2"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 2
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "230faeba-5ed3-42cd-b737-980dbc2edb32"
+                            "guid": "b093bc53-f877-47ea-952b-fa938252a1cf"
                         },
-                        "joints": "4b195a59-9a57-4c18-9841-e5f212d9f355"
+                        "joints": "403a1481-44e8-4f8f-bd22-5ca611324e79"
                     }
                 },
                 "26": {
-                    "11": {
-                        "candidates": {
-                            "data": {
-                                "element_guids": [
-                                    "faee9be6-610d-4c46-86d0-01c4d4609bb1",
-                                    "251f3ab6-5580-4d40-9219-ff11788f2d30"
-                                ],
-                                "location": {
-                                    "data": [
-                                        497.9030250550997,
-                                        0.0,
-                                        0.0
-                                    ],
-                                    "dtype": "compas.geometry/Point",
-                                    "guid": "c8d45472-2486-4b0d-9d99-aef861f15d95"
-                                },
-                                "name": "JointCandidate",
-                                "topology": 2
-                            },
-                            "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "0ba1f856-15f8-4784-8dbf-73488495ecb4"
-                        },
-                        "joints": "85b1ac7a-e7fd-4858-9560-4b65b75b4397"
-                    },
                     "18": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "faee9be6-610d-4c46-86d0-01c4d4609bb1",
-                                    "2748d58b-7ad2-40fd-ac6a-0855a497a000"
+                                    "4974254b-9a12-4d3e-b83e-6251ab157f8f",
+                                    "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
                                 ],
                                 "location": {
                                     "data": [
@@ -2004,22 +1957,22 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "ea66bc6d-4d42-401e-bdae-f01a65439814"
+                                    "guid": "175a4a38-0fa3-4e51-8424-203479c5a94a"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "901d3b70-d2fd-48b5-84bd-f2b0097fa1e9"
+                            "guid": "118aba2d-51c6-403b-9dac-5018e89d393c"
                         },
-                        "joints": "e10c33cd-285b-4f33-8ac3-a28c8fb02830"
+                        "joints": "483b2ee1-54d5-4267-a743-1ace60dc0fdb"
                     },
                     "25": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "faee9be6-610d-4c46-86d0-01c4d4609bb1",
-                                    "a1a31d0f-d10f-4f4a-9c70-77ce34f62795"
+                                    "4974254b-9a12-4d3e-b83e-6251ab157f8f",
+                                    "bdb24d25-87c7-431f-ad70-8fc2ce5e770d"
                                 ],
                                 "location": {
                                     "data": [
@@ -2028,15 +1981,15 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "210306d0-555e-4507-bdde-e94e4faa8763"
+                                    "guid": "6a021aaa-3bbe-49c1-80d3-2a7878f32239"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "5b8d1123-36f8-48e2-b4b4-08a261dd4098"
+                            "guid": "ead2ff75-6602-4d5d-bbdb-ed2777e402aa"
                         },
-                        "joints": "6570040e-5937-48db-89be-5a5720de0274"
+                        "joints": "7d418d75-0768-443e-9642-a1a80662e056"
                     }
                 },
                 "27": {
@@ -2044,8 +1997,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "ffde3ca4-8413-4b8a-8a78-d36e230b7adf",
-                                    "2748d58b-7ad2-40fd-ac6a-0855a497a000"
+                                    "658a71ec-3e5e-4f60-a468-39ec51dd47cd",
+                                    "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
                                 ],
                                 "location": {
                                     "data": [
@@ -2054,22 +2007,22 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "88c9ea45-c8f2-48e8-8c1b-98b321e19c02"
+                                    "guid": "e3773281-e1d8-483b-a399-b7d01e873dcc"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "8b05de6b-90da-4d5b-beb0-0b40cb89e1f4"
+                            "guid": "24c6bea9-1716-43b3-b988-e5d27ee56f93"
                         },
-                        "joints": "c2fd93df-565e-4d35-9a9a-5d7814efcc31"
+                        "joints": "ab44195a-0827-4527-b065-36740b894749"
                     },
                     "25": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "ffde3ca4-8413-4b8a-8a78-d36e230b7adf",
-                                    "a1a31d0f-d10f-4f4a-9c70-77ce34f62795"
+                                    "658a71ec-3e5e-4f60-a468-39ec51dd47cd",
+                                    "bdb24d25-87c7-431f-ad70-8fc2ce5e770d"
                                 ],
                                 "location": {
                                     "data": [
@@ -2078,24 +2031,24 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "76509785-0081-4a06-8a49-f41228c1326c"
+                                    "guid": "c8c3017c-df98-4e73-ae1e-743554a30efb"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "a29f5d8b-f78a-4127-a65b-68a2805bd9fd"
+                            "guid": "e736033d-002e-4bef-88c1-0bd02c5156bd"
                         },
-                        "joints": "8603f5fa-a0c0-4001-a27e-7d2938afdf5b"
+                        "joints": "882b1985-7fe2-44a3-b70d-f4b480376b95"
                     }
                 },
                 "28": {
-                    "18": {
+                    "12": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "503cf99d-5860-4e4e-a792-fab1d00a91ee",
-                                    "2748d58b-7ad2-40fd-ac6a-0855a497a000"
+                                    "e4db5300-d801-4945-a8f3-896a2666016f",
+                                    "7aedfe70-6276-4029-aaa8-9892bf0e736f"
                                 ],
                                 "location": {
                                     "data": [
@@ -2104,22 +2057,46 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "b4b855e4-7fc2-4bd2-9b8d-45a67dd63095"
+                                    "guid": "1bc81090-16c3-46e2-883e-6aff6d8ef98e"
+                                },
+                                "name": "JointCandidate",
+                                "topology": 2
+                            },
+                            "dtype": "compas_timber.connections/JointCandidate",
+                            "guid": "28f9ffa4-e08a-4e86-ad3d-a385e314870c"
+                        },
+                        "joints": "8a8c7548-6b7d-45fc-b244-eadbae2bae78"
+                    },
+                    "18": {
+                        "candidates": {
+                            "data": {
+                                "element_guids": [
+                                    "e4db5300-d801-4945-a8f3-896a2666016f",
+                                    "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                                ],
+                                "location": {
+                                    "data": [
+                                        1500.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "dtype": "compas.geometry/Point",
+                                    "guid": "cb80829f-a06f-4224-ba51-b27f6ac6269c"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "67627947-8c2c-4161-be76-cf4aa913f7d7"
+                            "guid": "4e6f3a22-e230-4e7c-97e6-f64c3ccb2bd8"
                         },
-                        "joints": "af52f5af-7e49-4c5d-9990-6e6856a2d527"
+                        "joints": "dd98e610-e922-4ac5-984d-b47bf926bf06"
                     },
                     "25": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "503cf99d-5860-4e4e-a792-fab1d00a91ee",
-                                    "a1a31d0f-d10f-4f4a-9c70-77ce34f62795"
+                                    "e4db5300-d801-4945-a8f3-896a2666016f",
+                                    "bdb24d25-87c7-431f-ad70-8fc2ce5e770d"
                                 ],
                                 "location": {
                                     "data": [
@@ -2128,24 +2105,24 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "7fcb529f-338f-43f4-b5a3-7016ce57967b"
+                                    "guid": "b9d2bc56-dcd5-4c81-ae2c-62cd2a4c2480"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "b5930e24-603e-441a-96b1-2d6f0d7fcbaf"
+                            "guid": "dbb8ac09-566d-48a8-8b12-d33fe0c2b738"
                         },
-                        "joints": "8c05e29f-cfdf-42fc-b8e3-90b8df8f03aa"
+                        "joints": "9a43ec98-28ee-43dc-b13c-e0bb945ce192"
                     }
                 },
                 "29": {
-                    "18": {
+                    "10": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "c8c6c5b4-a35c-4175-92e7-65c6fed4a00b",
-                                    "2748d58b-7ad2-40fd-ac6a-0855a497a000"
+                                    "950b5119-3208-4291-be1d-c77e1e9d6fa6",
+                                    "c32d947d-70b8-4e4c-8a8f-6667e567f511"
                                 ],
                                 "location": {
                                     "data": [
@@ -2154,22 +2131,46 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "fde06ead-5807-4a3c-b6a7-ae0f90a5f633"
+                                    "guid": "5f105904-edee-4e6f-a7d7-01a3995eb24b"
+                                },
+                                "name": "JointCandidate",
+                                "topology": 2
+                            },
+                            "dtype": "compas_timber.connections/JointCandidate",
+                            "guid": "472ce581-4eed-4083-9a20-7079a567d9ac"
+                        },
+                        "joints": "3b5ba8d0-78d2-4f82-9d83-de9615267b10"
+                    },
+                    "18": {
+                        "candidates": {
+                            "data": {
+                                "element_guids": [
+                                    "950b5119-3208-4291-be1d-c77e1e9d6fa6",
+                                    "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                                ],
+                                "location": {
+                                    "data": [
+                                        2004.984213989657,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "dtype": "compas.geometry/Point",
+                                    "guid": "55063dd3-dd98-4788-ada8-f924ab1d6f02"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "719629e8-2fda-477d-800a-810d98d3944f"
+                            "guid": "ace5d51e-0629-4dbc-9258-c3d1bdba5270"
                         },
-                        "joints": "1a7e970c-5a20-45d0-bdba-5807b28bf44d"
+                        "joints": "e45e1cba-2825-45a4-a4d8-dd3473db205d"
                     },
                     "25": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "c8c6c5b4-a35c-4175-92e7-65c6fed4a00b",
-                                    "a1a31d0f-d10f-4f4a-9c70-77ce34f62795"
+                                    "950b5119-3208-4291-be1d-c77e1e9d6fa6",
+                                    "bdb24d25-87c7-431f-ad70-8fc2ce5e770d"
                                 ],
                                 "location": {
                                     "data": [
@@ -2178,15 +2179,15 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "f423d90d-1d1d-4468-8512-087fd1cb4f4a"
+                                    "guid": "8c69d69f-90dc-4348-9369-1b148d8f4201"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "f6cfaa0b-d59e-4373-98a7-b9af2cb88dd0"
+                            "guid": "a4f9f5b2-255b-438a-9a06-30c12ad3b618"
                         },
-                        "joints": "fd699378-d651-4aac-881a-f42e06d25d50"
+                        "joints": "3eaccaaf-801c-4ad4-bea6-934d44d92352"
                     }
                 },
                 "3": {
@@ -2194,8 +2195,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "9d51b9d4-721d-4579-b6ad-41228650cb5c",
-                                    "960cda32-1a88-46a1-b360-1cd586c88067"
+                                    "2b5dd74c-1ce8-4234-9416-ed44da6a0c15",
+                                    "68aa3b3a-9ac4-4e38-a91b-a665dc0cd250"
                                 ],
                                 "location": {
                                     "data": [
@@ -2204,22 +2205,22 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "d6db4a0a-2e57-4cd7-a459-bb738c9a91f0"
+                                    "guid": "358487cb-9a8e-446a-99c6-ab63a6de887c"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "aaa799a5-cc37-4c04-bda7-172ad5847058"
+                            "guid": "47e8f9b9-c111-425d-a37f-81f5485a35ce"
                         },
-                        "joints": "ffdecf18-dd0c-471b-bf1d-11e140b4f8a8"
+                        "joints": "8797c0a1-f4c4-4d6a-a957-cc32025327c6"
                     },
                     "2": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "9d51b9d4-721d-4579-b6ad-41228650cb5c",
-                                    "060875a1-a057-4dc8-9684-e7f233f521d2"
+                                    "2b5dd74c-1ce8-4234-9416-ed44da6a0c15",
+                                    "d4c95d21-c986-4ec8-9c7f-1dc3cc35844b"
                                 ],
                                 "location": {
                                     "data": [
@@ -2228,15 +2229,15 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "6d94f37d-066f-47c4-bf55-ef6c41db2e55"
+                                    "guid": "bbfbeee1-d765-43f0-ae17-65b586675b56"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "8fc8329d-cc88-40c2-9f9d-7c4b4c322bd1"
+                            "guid": "8b4376c0-530c-4b2f-90db-1dd8f7202105"
                         },
-                        "joints": "2440fdf2-40cf-485b-8187-94fb649d05b1"
+                        "joints": "168b0610-b2db-46f5-858f-f2f3c70975cb"
                     }
                 },
                 "30": {
@@ -2244,8 +2245,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "f4c08ca9-60ea-48a3-a981-a4e587da6809",
-                                    "2748d58b-7ad2-40fd-ac6a-0855a497a000"
+                                    "dd34a65b-c4c1-41ea-a7cc-c68bf32f0889",
+                                    "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
                                 ],
                                 "location": {
                                     "data": [
@@ -2254,22 +2255,22 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "a66d3b80-35b6-4820-9749-88d8decdabe6"
+                                    "guid": "950713aa-bdd8-4a57-b876-76eed7d6af9b"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "2d4f5cc3-5d8e-43c7-8998-542ab9b9d20f"
+                            "guid": "17df5270-6489-4d48-ba20-766b0eb7f3c1"
                         },
-                        "joints": "15717d35-c63e-4a77-9a8b-be311679910f"
+                        "joints": "f1304850-71db-42f5-874f-45ab0d6afae4"
                     },
                     "25": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "f4c08ca9-60ea-48a3-a981-a4e587da6809",
-                                    "a1a31d0f-d10f-4f4a-9c70-77ce34f62795"
+                                    "dd34a65b-c4c1-41ea-a7cc-c68bf32f0889",
+                                    "bdb24d25-87c7-431f-ad70-8fc2ce5e770d"
                                 ],
                                 "location": {
                                     "data": [
@@ -2278,39 +2279,15 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "769fb5ce-af4c-4081-8be6-b28cad650b4b"
+                                    "guid": "c31b1ad5-7d2a-48de-a8ae-070daa7269bd"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "2dd5e977-6084-41f6-933c-e67578ae7155"
+                            "guid": "2a3adb23-9531-4f94-9294-1f31abde277f"
                         },
-                        "joints": "1a012363-30df-46f5-a7f0-bd08c5383b22"
-                    },
-                    "9": {
-                        "candidates": {
-                            "data": {
-                                "element_guids": [
-                                    "f4c08ca9-60ea-48a3-a981-a4e587da6809",
-                                    "1a711710-6c26-49dc-8ae0-43ae1692624c"
-                                ],
-                                "location": {
-                                    "data": [
-                                        2466.6690329793787,
-                                        0.0,
-                                        0.0
-                                    ],
-                                    "dtype": "compas.geometry/Point",
-                                    "guid": "8ce08cbb-808b-4edb-9457-3edb54fba5bb"
-                                },
-                                "name": "JointCandidate",
-                                "topology": 2
-                            },
-                            "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "732ecd50-9d2f-4c24-9ccc-7101b12387cb"
-                        },
-                        "joints": "8e8e190e-7886-4eee-80eb-221ec4e7a3ab"
+                        "joints": "85c2c832-7b8f-41d1-848f-c6696dd11a38"
                     }
                 },
                 "4": {
@@ -2318,8 +2295,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "c1c7146e-c7b9-4912-a0cd-09d68222b617",
-                                    "060875a1-a057-4dc8-9684-e7f233f521d2"
+                                    "28828f51-d0f8-4d8f-840c-9565ff4e684d",
+                                    "d4c95d21-c986-4ec8-9c7f-1dc3cc35844b"
                                 ],
                                 "location": {
                                     "data": [
@@ -2328,22 +2305,22 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "d7a155ca-ac49-46fd-9fca-e0e0179aecec"
+                                    "guid": "bd28e9d3-c45e-4200-a222-dd212839ba6a"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "8c1871f0-203e-45f8-912f-978330c02091"
+                            "guid": "130b54bf-9b36-46ab-890d-31f78477c359"
                         },
-                        "joints": "0f65c7ee-12aa-4fe8-80ab-7852d6d1f777"
+                        "joints": "65778f0c-373f-4d93-aa98-633d7320cd2e"
                     },
                     "22": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "c1c7146e-c7b9-4912-a0cd-09d68222b617",
-                                    "0e918642-9d6b-4437-845a-03a8b85f59cd"
+                                    "28828f51-d0f8-4d8f-840c-9565ff4e684d",
+                                    "6f516961-c0c9-4264-8749-716cd22a985f"
                                 ],
                                 "location": {
                                     "data": [
@@ -2352,15 +2329,15 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "0f14d322-fffc-4851-8a60-cb2c6a7d17f4"
+                                    "guid": "01137a18-5053-4a7d-b91c-0871658637be"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "f4141d96-05e2-4b96-9249-c94fe1727ee1"
+                            "guid": "0a9d4ee7-349c-45fd-b228-cb67e835fb60"
                         },
-                        "joints": "3b60c84b-8616-4549-8723-2ef954b7ad52"
+                        "joints": "d8d77265-0255-4ce9-830c-2bcf7d909047"
                     }
                 },
                 "5": {
@@ -2368,8 +2345,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "de24c9aa-92d2-422e-bdf6-09e47d7649c0",
-                                    "960cda32-1a88-46a1-b360-1cd586c88067"
+                                    "2dcaa239-4558-414d-a0e7-2c75568d590c",
+                                    "68aa3b3a-9ac4-4e38-a91b-a665dc0cd250"
                                 ],
                                 "location": {
                                     "data": [
@@ -2378,22 +2355,22 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "ec66994d-6c25-4778-b068-7f9105e8874d"
+                                    "guid": "ea61bb34-7d11-4aee-9074-fcfbd4c94956"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "ce625282-df37-4a13-bcee-686a3a5bb39a"
+                            "guid": "694a3c72-7686-44d0-ae38-7943386633bd"
                         },
-                        "joints": "052285d3-bb66-4d1f-8208-578bee961691"
+                        "joints": "f4db0896-7e14-48e5-a0c8-59d13709e6c4"
                     },
                     "19": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "de24c9aa-92d2-422e-bdf6-09e47d7649c0",
-                                    "6b029936-f988-407f-8b8e-8b4473795e0a"
+                                    "2dcaa239-4558-414d-a0e7-2c75568d590c",
+                                    "a58f3f5a-c3eb-40e2-a967-e4d7cc7795c8"
                                 ],
                                 "location": {
                                     "data": [
@@ -2402,15 +2379,15 @@
                                         1000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "3b01959e-3437-47d8-9c12-3da14e81b3d0"
+                                    "guid": "463e247c-ce74-451c-b63a-dcba406a0fa8"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "10af9a96-6993-4af7-9ce7-4bb28b265270"
+                            "guid": "8cd36a88-4bc9-4626-b566-94391ffb6e88"
                         },
-                        "joints": "efb7d750-984c-42cf-9e61-1f42d1a607ca"
+                        "joints": "357a8264-8202-466f-b82b-b7b3c237c9e0"
                     }
                 },
                 "6": {
@@ -2418,8 +2395,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "e62615e3-3d55-4988-9b4c-3706f41ad351",
-                                    "2181217f-7468-4cdd-ba5d-a2203d39f36b"
+                                    "4fc6b138-6bee-4808-8d9c-824de512490d",
+                                    "7ac92736-9a70-4979-8441-430e924ab9d9"
                                 ],
                                 "location": {
                                     "data": [
@@ -2428,22 +2405,22 @@
                                         1000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "6827d0ce-ec96-4bde-bd57-ff43c1f6bbe3"
+                                    "guid": "f55f8f61-490a-4022-ad5c-fdb9f9eacacf"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "41bf4274-abff-45d5-b524-b8d0a994b05f"
+                            "guid": "dbd25adf-f5e0-4bff-ac07-28f37320077d"
                         },
-                        "joints": "ae00bde6-38fb-4078-a8a2-208a26346fff"
+                        "joints": "6759b913-e2e8-4672-8619-b516b874f39d"
                     },
                     "22": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "e62615e3-3d55-4988-9b4c-3706f41ad351",
-                                    "0e918642-9d6b-4437-845a-03a8b85f59cd"
+                                    "4fc6b138-6bee-4808-8d9c-824de512490d",
+                                    "6f516961-c0c9-4264-8749-716cd22a985f"
                                 ],
                                 "location": {
                                     "data": [
@@ -2452,15 +2429,15 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "3ef7ef36-b592-4a0f-8455-67e074b6d470"
+                                    "guid": "29acd981-4161-48df-8208-c89063567980"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "3261a02a-2aa3-4e26-b7e8-d3fde496ee87"
+                            "guid": "eaf93096-f928-4c5e-886f-b9514342df55"
                         },
-                        "joints": "9aeaa88d-4a64-4019-ac61-fed7dbfcc0fd"
+                        "joints": "b20cc6a9-3a5f-42d8-bb22-d2dd02f27ff3"
                     }
                 },
                 "7": {
@@ -2468,8 +2445,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "50940319-a44b-4eb5-be67-14933c16f538",
-                                    "b30d063f-6537-477a-aa64-f5ff59f4a947"
+                                    "03285a2b-8eae-408e-8358-67c487c1c107",
+                                    "52c72e39-f5ad-4de6-a423-77b11aa36e20"
                                 ],
                                 "location": {
                                     "data": [
@@ -2478,22 +2455,22 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "c828c4af-5db1-4267-83da-10bb7d635526"
+                                    "guid": "2036cf9b-b7f6-49d8-b63c-dad6f65b8211"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "3fa30228-d724-4dc5-b514-73794b79d7b8"
+                            "guid": "2cfa8c86-07f1-4231-a2b6-957088f64600"
                         },
-                        "joints": "c4351495-45cd-4979-a3f0-43d3ae1a4b9a"
+                        "joints": "82c99c59-1552-45e9-a5e1-4530387eb7ee"
                     },
                     "5": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "50940319-a44b-4eb5-be67-14933c16f538",
-                                    "de24c9aa-92d2-422e-bdf6-09e47d7649c0"
+                                    "03285a2b-8eae-408e-8358-67c487c1c107",
+                                    "2dcaa239-4558-414d-a0e7-2c75568d590c"
                                 ],
                                 "location": {
                                     "data": [
@@ -2502,15 +2479,15 @@
                                         1500.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "916c9ce4-1568-4b95-aacd-7a975c9cd6cb"
+                                    "guid": "2199e0a2-1b60-4ef8-a55b-299cbaa98b1d"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "51be9181-95b2-49d1-89e9-f1873482ae25"
+                            "guid": "f638634d-f063-4a2f-ab10-a982e36203fe"
                         },
-                        "joints": "dbe830ab-0e20-40a8-9c3e-646be9a2197a"
+                        "joints": "35c5f2b2-7957-4eb0-8a41-bbad8ca134d0"
                     }
                 },
                 "8": {
@@ -2518,8 +2495,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "efde03ed-a40a-4212-85d2-9a5477e828b3",
-                                    "28984213-5f27-4ef5-8d12-a4dab0091968"
+                                    "1e88ad95-f487-4600-a5ef-8320662a903c",
+                                    "6f955f15-b316-4918-8764-9e4106dda755"
                                 ],
                                 "location": {
                                     "data": [
@@ -2528,22 +2505,22 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "e51fa614-548d-4f96-aaae-a093f5752b95"
+                                    "guid": "1cdc4bac-fd64-42d5-842d-af13d0265374"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "4d82b186-70f4-4214-a35f-d5ddac312fab"
+                            "guid": "571c9603-dcfe-421a-a61e-138985f2fdfd"
                         },
-                        "joints": "b5517df1-1bbd-42e9-88ee-651b6c1acec3"
+                        "joints": "d76fe391-9519-4603-be97-3b0522d5bb32"
                     },
                     "6": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "efde03ed-a40a-4212-85d2-9a5477e828b3",
-                                    "e62615e3-3d55-4988-9b4c-3706f41ad351"
+                                    "1e88ad95-f487-4600-a5ef-8320662a903c",
+                                    "4fc6b138-6bee-4808-8d9c-824de512490d"
                                 ],
                                 "location": {
                                     "data": [
@@ -2552,15 +2529,15 @@
                                         1500.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "56aaf03b-af5c-462c-9943-cec6533c0cae"
+                                    "guid": "eef43cff-9f70-41e1-9232-e00857eedd05"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "089ac5f3-7ced-46bc-b068-63da22472969"
+                            "guid": "a103d3d6-f2d6-4cd3-9490-2579d07b7817"
                         },
-                        "joints": "29a87550-1240-435f-af98-0c5c19b36f30"
+                        "joints": "133b8358-ecf2-4089-a933-8c60493e6bb2"
                     }
                 },
                 "9": {
@@ -2568,8 +2545,8 @@
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "1a711710-6c26-49dc-8ae0-43ae1692624c",
-                                    "2748d58b-7ad2-40fd-ac6a-0855a497a000"
+                                    "74381909-2c04-4510-b880-17df88cd93e1",
+                                    "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
                                 ],
                                 "location": {
                                     "data": [
@@ -2578,22 +2555,22 @@
                                         0.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "5fde406f-4b3d-446f-8aec-56aede73e118"
+                                    "guid": "f6d14d15-ecad-4390-9735-b28aef8c9306"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "73b6295b-8ed3-4690-9b86-e2278b6641f4"
+                            "guid": "70c4a19c-45a5-40f1-b407-e7bda71857c5"
                         },
-                        "joints": "21bb24e2-b0ea-4c1b-9d4a-f3c994b0247b"
+                        "joints": "f1b21dcd-a086-4cf7-9eb4-7861f9e75d70"
                     },
                     "20": {
                         "candidates": {
                             "data": {
                                 "element_guids": [
-                                    "1a711710-6c26-49dc-8ae0-43ae1692624c",
-                                    "934feddd-8db9-4d08-9ad0-083bba29a35f"
+                                    "74381909-2c04-4510-b880-17df88cd93e1",
+                                    "cef865a8-469f-45ea-96fe-43d6f896ac29"
                                 ],
                                 "location": {
                                     "data": [
@@ -2602,725 +2579,157 @@
                                         2000.0
                                     ],
                                     "dtype": "compas.geometry/Point",
-                                    "guid": "185d8dc2-5ae4-4186-91e6-9467b52893cb"
+                                    "guid": "8b0aa8aa-982e-4602-adaa-a4cf6f234ee0"
                                 },
                                 "name": "JointCandidate",
                                 "topology": 3
                             },
                             "dtype": "compas_timber.connections/JointCandidate",
-                            "guid": "8ebc2abc-c571-4556-ac3b-2f98f2913091"
+                            "guid": "667b50af-3906-4c84-8620-a571e470c871"
                         },
-                        "joints": "98567214-63d5-4b99-8129-2a0479ec535f"
+                        "joints": "e9aa6c5e-9c2f-461e-b48e-d5cd0b5a52b6"
+                    },
+                    "30": {
+                        "candidates": {
+                            "data": {
+                                "element_guids": [
+                                    "74381909-2c04-4510-b880-17df88cd93e1",
+                                    "dd34a65b-c4c1-41ea-a7cc-c68bf32f0889"
+                                ],
+                                "location": {
+                                    "data": [
+                                        2466.6690329793787,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "dtype": "compas.geometry/Point",
+                                    "guid": "9ad6641d-9fde-4eaf-a610-8edae7cc25f5"
+                                },
+                                "name": "JointCandidate",
+                                "topology": 2
+                            },
+                            "dtype": "compas_timber.connections/JointCandidate",
+                            "guid": "de654d64-7817-4eb6-a294-02c2bb32c630"
+                        },
+                        "joints": "e1ba83da-e73c-484d-a5c4-e23ec6516aa5"
                     }
                 }
             },
             "max_node": 30,
             "node": {
                 "0": {
-                    "element": "6a981e44-1623-49dc-b475-bf029f0c47bd"
+                    "element": "d5f30507-f7fb-4a0b-9c91-492f725364ca"
                 },
                 "1": {
-                    "element": "c760f2d8-37d6-41bd-8ccd-a03f4fd1e968"
+                    "element": "0a04cf8c-a620-4200-a218-006461b51686"
                 },
                 "10": {
-                    "element": "cf11abdc-899c-42ca-bed1-d6f9e6a450ca"
+                    "element": "c32d947d-70b8-4e4c-8a8f-6667e567f511"
                 },
                 "11": {
-                    "element": "251f3ab6-5580-4d40-9219-ff11788f2d30"
+                    "element": "ec1d8453-49fc-4d85-b51e-233fdd02df57"
                 },
                 "12": {
-                    "element": "83d65f37-b71c-4774-8704-53520465b4b6"
+                    "element": "7aedfe70-6276-4029-aaa8-9892bf0e736f"
                 },
                 "13": {
-                    "element": "895beb30-28c4-4794-98e0-06d24a086217"
+                    "element": "642120b1-28c3-4762-8607-e889f56645f9"
                 },
                 "14": {
-                    "element": "45078bb4-7729-4624-9966-b8609ddf1afd"
+                    "element": "9ce9f96e-1547-4e44-b74d-4605672b54e2"
                 },
                 "15": {
-                    "element": "928eb8b5-bea9-4504-832f-318c3231854a"
+                    "element": "af5b648d-a596-4317-a730-218c28434b39"
                 },
                 "16": {
-                    "element": "960cda32-1a88-46a1-b360-1cd586c88067"
+                    "element": "68aa3b3a-9ac4-4e38-a91b-a665dc0cd250"
                 },
                 "17": {
-                    "element": "b30d063f-6537-477a-aa64-f5ff59f4a947"
+                    "element": "52c72e39-f5ad-4de6-a423-77b11aa36e20"
                 },
                 "18": {
-                    "element": "2748d58b-7ad2-40fd-ac6a-0855a497a000"
+                    "element": "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
                 },
                 "19": {
-                    "element": "6b029936-f988-407f-8b8e-8b4473795e0a"
+                    "element": "a58f3f5a-c3eb-40e2-a967-e4d7cc7795c8"
                 },
                 "2": {
-                    "element": "060875a1-a057-4dc8-9684-e7f233f521d2"
+                    "element": "d4c95d21-c986-4ec8-9c7f-1dc3cc35844b"
                 },
                 "20": {
-                    "element": "934feddd-8db9-4d08-9ad0-083bba29a35f"
+                    "element": "cef865a8-469f-45ea-96fe-43d6f896ac29"
                 },
                 "21": {
-                    "element": "2181217f-7468-4cdd-ba5d-a2203d39f36b"
+                    "element": "7ac92736-9a70-4979-8441-430e924ab9d9"
                 },
                 "22": {
-                    "element": "0e918642-9d6b-4437-845a-03a8b85f59cd"
+                    "element": "6f516961-c0c9-4264-8749-716cd22a985f"
                 },
                 "23": {
-                    "element": "203d7dd5-1e80-4f15-9b36-fc4b925d79a1"
+                    "element": "9b4340ab-e094-48a2-823a-2b464c54c41c"
                 },
                 "24": {
-                    "element": "28984213-5f27-4ef5-8d12-a4dab0091968"
+                    "element": "6f955f15-b316-4918-8764-9e4106dda755"
                 },
                 "25": {
-                    "element": "a1a31d0f-d10f-4f4a-9c70-77ce34f62795"
+                    "element": "bdb24d25-87c7-431f-ad70-8fc2ce5e770d"
                 },
                 "26": {
-                    "element": "faee9be6-610d-4c46-86d0-01c4d4609bb1"
+                    "element": "4974254b-9a12-4d3e-b83e-6251ab157f8f"
                 },
                 "27": {
-                    "element": "ffde3ca4-8413-4b8a-8a78-d36e230b7adf"
+                    "element": "658a71ec-3e5e-4f60-a468-39ec51dd47cd"
                 },
                 "28": {
-                    "element": "503cf99d-5860-4e4e-a792-fab1d00a91ee"
+                    "element": "e4db5300-d801-4945-a8f3-896a2666016f"
                 },
                 "29": {
-                    "element": "c8c6c5b4-a35c-4175-92e7-65c6fed4a00b"
+                    "element": "950b5119-3208-4291-be1d-c77e1e9d6fa6"
                 },
                 "3": {
-                    "element": "9d51b9d4-721d-4579-b6ad-41228650cb5c"
+                    "element": "2b5dd74c-1ce8-4234-9416-ed44da6a0c15"
                 },
                 "30": {
-                    "element": "f4c08ca9-60ea-48a3-a981-a4e587da6809"
+                    "element": "dd34a65b-c4c1-41ea-a7cc-c68bf32f0889"
                 },
                 "4": {
-                    "element": "c1c7146e-c7b9-4912-a0cd-09d68222b617"
+                    "element": "28828f51-d0f8-4d8f-840c-9565ff4e684d"
                 },
                 "5": {
-                    "element": "de24c9aa-92d2-422e-bdf6-09e47d7649c0"
+                    "element": "2dcaa239-4558-414d-a0e7-2c75568d590c"
                 },
                 "6": {
-                    "element": "e62615e3-3d55-4988-9b4c-3706f41ad351"
+                    "element": "4fc6b138-6bee-4808-8d9c-824de512490d"
                 },
                 "7": {
-                    "element": "50940319-a44b-4eb5-be67-14933c16f538"
+                    "element": "03285a2b-8eae-408e-8358-67c487c1c107"
                 },
                 "8": {
-                    "element": "efde03ed-a40a-4212-85d2-9a5477e828b3"
+                    "element": "1e88ad95-f487-4600-a5ef-8320662a903c"
                 },
                 "9": {
-                    "element": "1a711710-6c26-49dc-8ae0-43ae1692624c"
+                    "element": "74381909-2c04-4510-b880-17df88cd93e1"
                 }
             }
         },
         "joints": {
-            "02bc75a6-40ab-4363-8054-fe9d216c30fd": {
+            "057190ba-7cc4-45b5-945a-4bfcd5992a40": {
                 "data": {
                     "back_plane": {
                         "data": {
                             "normal": [
-                                0.8807090808003171,
-                                0.4736575925664665,
-                                0.0
-                            ],
-                            "point": [
-                                1085.73089235767,
-                                14.209727776994336,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "b724b62c-9337-4f0c-97fd-084af7d31c3d"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
                                 -1.0,
-                                0.0
-                            ],
-                            "point": [
-                                0.0,
-                                -1940.0,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "2d585718-25ea-47cd-970d-f6600c54c677"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "060875a1-a057-4dc8-9684-e7f233f521d2",
-                        "203d7dd5-1e80-4f15-9b36-fc4b925d79a1"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "02bc75a6-40ab-4363-8054-fe9d216c30fd"
-            },
-            "052285d3-bb66-4d1f-8208-578bee961691": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                0.7071067811865476,
-                                0.7071067811865475
-                            ],
-                            "point": [
-                                3060.0,
-                                -957.573593128807,
-                                2042.426406871193
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "c482caac-da10-4428-a6e8-6050ea828045"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "point": [
-                                3060.0,
-                                3.67394039744206e-15,
-                                1940.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "123a42c3-267b-4ab9-b98f-d2ef1efd9079"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "de24c9aa-92d2-422e-bdf6-09e47d7649c0",
-                        "960cda32-1a88-46a1-b360-1cd586c88067"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "052285d3-bb66-4d1f-8208-578bee961691"
-            },
-            "08c5e6e9-b512-45a1-9719-6899032325e2": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                1.0,
-                                -0.0
-                            ],
-                            "point": [
-                                -60.0,
-                                60.0,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "94db419e-a577-4b18-9464-356c063808c8"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
-                                0.0,
-                                -0.0
-                            ],
-                            "point": [
-                                2940.0,
-                                60.00000000000001,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "7fff9fc2-e610-4f5a-82a9-cc570ed17b75"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "2748d58b-7ad2-40fd-ac6a-0855a497a000",
-                        "b30d063f-6537-477a-aa64-f5ff59f4a947"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "08c5e6e9-b512-45a1-9719-6899032325e2"
-            },
-            "0a1d3c43-510c-4160-a198-281446778233": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
                                 0.0,
                                 0.0
                             ],
                             "point": [
-                                3060.0,
-                                3.67394039744206e-15,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "2c1225c1-ab7c-4528-92c8-ea20ded0dd37"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -1.0,
-                                0.0
-                            ],
-                            "point": [
-                                0.0,
-                                -1940.0,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "f854bde7-79a5-4ec2-a932-9159a0adc6cb"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "960cda32-1a88-46a1-b360-1cd586c88067",
-                        "203d7dd5-1e80-4f15-9b36-fc4b925d79a1"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "0a1d3c43-510c-4160-a198-281446778233"
-            },
-            "0f65c7ee-12aa-4fe8-80ab-7852d6d1f777": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -0.6293936263837255,
-                                0.7770866509389691,
-                                0.0
-                            ],
-                            "point": [
-                                1326.9757802479705,
-                                -509.4887372116664,
-                                1940.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "d5165535-3996-462b-96d5-651c14e4ccd1"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.8807090808003171,
-                                0.4736575925664665,
-                                -0.0
-                            ],
-                            "point": [
-                                1032.8883475096509,
-                                -14.209727776993661,
-                                1940.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "83a1fdf5-4bcf-4b61-89d2-31357e990baf"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "c1c7146e-c7b9-4912-a0cd-09d68222b617",
-                        "060875a1-a057-4dc8-9684-e7f233f521d2"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "0f65c7ee-12aa-4fe8-80ab-7852d6d1f777"
-            },
-            "15717d35-c63e-4a77-9a8b-be311679910f": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                2496.669032979379,
-                                8.49830834647197e-15,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "4806cd96-d5a6-4731-b69c-203a5260184f"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                1.0,
-                                -0.0
-                            ],
-                            "point": [
-                                -60.0,
-                                -60.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "67b3aebd-049f-450c-ac4b-0a975991b9f5"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "f4c08ca9-60ea-48a3-a981-a4e587da6809",
-                        "2748d58b-7ad2-40fd-ac6a-0855a497a000"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "15717d35-c63e-4a77-9a8b-be311679910f"
-            },
-            "1888ab1e-c84b-4196-b275-07332b5f86db": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.5087022325849322e-16,
-                                1.8493982216179916e-32,
-                                -1.0
-                            ],
-                            "point": [
-                                2004.984213989657,
-                                -60.00000000000009,
-                                940.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "deacd63d-e25e-476a-974f-251a4959dc06"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
-                                -0.0,
-                                0.0
-                            ],
-                            "point": [
-                                1974.984213989657,
+                                467.90302505509976,
                                 -60.0,
                                 -1.8369701987210304e-15
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "ba78f610-9a3a-40b3-8ad7-cbfbd7112c21"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "c760f2d8-37d6-41bd-8ccd-a03f4fd1e968",
-                        "cf11abdc-899c-42ca-bed1-d6f9e6a450ca"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "1888ab1e-c84b-4196-b275-07332b5f86db"
-            },
-            "1a012363-30df-46f5-a7f0-bd08c5383b22": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                2496.669032979379,
-                                8.49830834647197e-15,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "1df4066f-84fc-413c-b917-5b3d88e91f3b"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -1.0,
-                                0.0
-                            ],
-                            "point": [
-                                -60.0,
-                                -1440.0,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "e3d78d96-9acb-4862-8dce-000b71b0668f"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "f4c08ca9-60ea-48a3-a981-a4e587da6809",
-                        "a1a31d0f-d10f-4f4a-9c70-77ce34f62795"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "1a012363-30df-46f5-a7f0-bd08c5383b22"
-            },
-            "1a7e970c-5a20-45d0-bdba-5807b28bf44d": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                2034.984213989657,
-                                60.0,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "46e5b61a-defe-4edf-b920-2625d5ffe451"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                1.0,
-                                -0.0
-                            ],
-                            "point": [
-                                -60.0,
-                                -60.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "9ca1a63b-e457-41bf-b0b4-ca442748e8b9"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "c8c6c5b4-a35c-4175-92e7-65c6fed4a00b",
-                        "2748d58b-7ad2-40fd-ac6a-0855a497a000"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "1a7e970c-5a20-45d0-bdba-5807b28bf44d"
-            },
-            "1dc4d268-f00f-4ab6-9f61-76410aa5be55": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                992.8270086729294,
-                                -60.0,
-                                1599.5716131249415
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "168a00b4-b566-41eb-b965-f1b0aa5e291b"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                -0.0,
-                                0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                2004.984213989657,
-                                59.99999999999991,
-                                1659.5716131249415
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "700dbb51-8914-4874-81e4-057f6f491464"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "928eb8b5-bea9-4504-832f-318c3231854a",
-                        "6a981e44-1623-49dc-b475-bf029f0c47bd"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "1dc4d268-f00f-4ab6-9f61-76410aa5be55"
-            },
-            "1e534e87-ba2a-4607-9551-115c36486213": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "point": [
-                                3060.0,
-                                59.999999999999815,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "7cae66b7-b6fb-4d57-81c8-021d5e96a704"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                0.0,
-                                -6.032910020604624e-17
-                            ],
-                            "point": [
-                                59.999999999999936,
-                                -60.0,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "36f20d0d-3c1f-4218-98cd-a48933529db9"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "934feddd-8db9-4d08-9ad0-083bba29a35f",
-                        "2181217f-7468-4cdd-ba5d-a2203d39f36b"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "1e534e87-ba2a-4607-9551-115c36486213"
-            },
-            "1f311f4e-33f0-4ae8-b70f-a262c71f29b8": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                -60.0,
-                                60.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "d49020fe-d8d1-4f37-a344-c50535473e39"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
-                                1.1842378929335003e-16,
-                                -0.0
-                            ],
-                            "point": [
-                                2940.0,
-                                -60.00000000000001,
-                                3.673940397442059e-15
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "3f0ef4e3-d48d-41c8-99be-140206125a6f"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "2748d58b-7ad2-40fd-ac6a-0855a497a000",
-                        "6b029936-f988-407f-8b8e-8b4473795e0a"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "1f311f4e-33f0-4ae8-b70f-a262c71f29b8"
-            },
-            "20ddc08d-2526-44e4-9763-aa1dce9602ec": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.1842378929335003e-16,
-                                1.0,
-                                0.0
-                            ],
-                            "point": [
-                                2940.0,
-                                59.99999999999999,
-                                -59.99999999999999
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "0e0894f8-f199-4cb6-ae3e-2b93d38814bf"
+                        "guid": "5174c8b6-6663-4cb5-861f-0023c013bb24"
                     },
                     "butt_plane": {
                         "data": {
@@ -3330,229 +2739,30 @@
                                 -1.0
                             ],
                             "point": [
-                                2940.0,
-                                3.67394039744206e-15,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "e759f925-ff01-4b02-99ea-92853d0f4e81"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "6b029936-f988-407f-8b8e-8b4473795e0a",
-                        "b30d063f-6537-477a-aa64-f5ff59f4a947"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "20ddc08d-2526-44e4-9763-aa1dce9602ec"
-            },
-            "21bb24e2-b0ea-4c1b-9d4a-f3c994b0247b": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
-                                -0.0,
-                                0.0
-                            ],
-                            "point": [
-                                2496.6690329793787,
-                                60.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "687fdb05-13e9-43e1-8818-1ecf715fd88d"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
                                 0.0,
-                                -0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                -60.0,
                                 -60.0,
                                 60.0
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "088ce2f7-d732-4775-be61-22eddd3485e9"
+                        "guid": "4db8cb99-7e7a-47b4-89f2-584557d3d7f3"
                     },
                     "conical_tool": false,
                     "element_guids": [
-                        "1a711710-6c26-49dc-8ae0-43ae1692624c",
-                        "2748d58b-7ad2-40fd-ac6a-0855a497a000"
+                        "ec1d8453-49fc-4d85-b51e-233fdd02df57",
+                        "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
                     ],
                     "force_pocket": false,
                     "location": null,
                     "mill_depth": null,
-                    "modify_cross": true,
+                    "modify_cross": false,
                     "name": "TButtJoint",
                     "topology": 0
                 },
                 "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "21bb24e2-b0ea-4c1b-9d4a-f3c994b0247b"
+                "guid": "057190ba-7cc4-45b5-945a-4bfcd5992a40"
             },
-            "2440fdf2-40cf-485b-8187-94fb649d05b1": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.41480906296571196,
-                                -0.9099084796184219,
-                                0.0
-                            ],
-                            "point": [
-                                1735.6341231611425,
-                                -1261.7023552032194,
-                                1940.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "9223499d-c965-4940-8e78-466c7f7dc342"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                -0.8807090808003171,
-                                -0.4736575925664665,
-                                0.0
-                            ],
-                            "point": [
-                                1085.73089235767,
-                                14.209727776994336,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "c6c79187-45e0-46c1-bb8e-037e64956f33"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "9d51b9d4-721d-4579-b6ad-41228650cb5c",
-                        "060875a1-a057-4dc8-9684-e7f233f521d2"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "2440fdf2-40cf-485b-8187-94fb649d05b1"
-            },
-            "25f2444d-357a-4013-b979-a857ef670a7b": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                -5.684341886080802e-17,
-                                0.0
-                            ],
-                            "point": [
-                                -60.00000000000004,
-                                -3.1472698658549016e-15,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "47e5c340-5d6e-4beb-8bfd-30598d448219"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -1.0,
-                                0.0
-                            ],
-                            "point": [
-                                0.0,
-                                -1440.0,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "4b5f9cf8-9b81-42a1-bf2f-c71f07bd8288"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "28984213-5f27-4ef5-8d12-a4dab0091968",
-                        "a1a31d0f-d10f-4f4a-9c70-77ce34f62795"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "25f2444d-357a-4013-b979-a857ef670a7b"
-            },
-            "27868fe2-e4c4-4cf8-a1d9-e4080f91a7d7": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                1.0,
-                                -0.0
-                            ],
-                            "point": [
-                                992.8270086729294,
-                                60.0,
-                                -1.8369701987210304e-15
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "0e586079-e958-4994-826c-baa2525ad4f3"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                992.8270086729294,
-                                1.83697019872103e-15,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "2210a887-d70b-4e90-b8e9-ac31eb13288d"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "895beb30-28c4-4794-98e0-06d24a086217",
-                        "ffde3ca4-8413-4b8a-8a78-d36e230b7adf"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "27868fe2-e4c4-4cf8-a1d9-e4080f91a7d7"
-            },
-            "29a87550-1240-435f-af98-0c5c19b36f30": {
+            "133b8358-ecf2-4089-a933-8c60493e6bb2": {
                 "data": {
                     "back_plane": {
                         "data": {
@@ -3568,7 +2778,7 @@
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "20274d0e-2365-4ff2-a166-6f6257d1a8a3"
+                        "guid": "1e632aec-0a3b-42fa-a78d-b1c0a0d854e9"
                     },
                     "butt_plane": {
                         "data": {
@@ -3584,1705 +2794,42 @@
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "12acaba6-cecc-42ea-8a42-2da5a06f752d"
+                        "guid": "4e01401b-257b-4c2c-9e1c-652b89e06ff9"
                     },
                     "conical_tool": false,
                     "element_guids": [
-                        "efde03ed-a40a-4212-85d2-9a5477e828b3",
-                        "e62615e3-3d55-4988-9b4c-3706f41ad351"
+                        "1e88ad95-f487-4600-a5ef-8320662a903c",
+                        "4fc6b138-6bee-4808-8d9c-824de512490d"
                     ],
                     "force_pocket": false,
                     "location": null,
                     "mill_depth": null,
-                    "modify_cross": true,
+                    "modify_cross": false,
                     "name": "TButtJoint",
                     "topology": 0
                 },
                 "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "29a87550-1240-435f-af98-0c5c19b36f30"
+                "guid": "133b8358-ecf2-4089-a933-8c60493e6bb2"
             },
-            "2b369c3c-69bd-4148-aa3e-4f149090ce0c": {
+            "168b0610-b2db-46f5-858f-f2f3c70975cb": {
                 "data": {
                     "back_plane": {
                         "data": {
                             "normal": [
-                                0.0,
-                                1.0,
-                                -0.0
-                            ],
-                            "point": [
-                                1470.0,
-                                60.0,
-                                -1.8369701987210304e-15
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "87618161-e523-4b0c-a46e-b23b1257214b"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                1470.0,
-                                1.83697019872103e-15,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "c0dc3a9b-48fc-4bc5-9a11-1eb774b1efde"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "83d65f37-b71c-4774-8704-53520465b4b6",
-                        "503cf99d-5860-4e4e-a792-fab1d00a91ee"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "2b369c3c-69bd-4148-aa3e-4f149090ce0c"
-            },
-            "2d1bd73d-a062-4634-9677-7ec4e30e6ed3": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "point": [
-                                2004.984213989657,
-                                59.99999999999991,
-                                1659.5716131249415
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "4925214f-4195-4ade-961c-3303cf87b9e0"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
-                                -0.0,
+                                0.41480906296571196,
+                                -0.9099084796184219,
                                 0.0
                             ],
                             "point": [
-                                1974.984213989657,
-                                -60.0,
-                                -1.8369701987210304e-15
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "a8e9333f-6c5d-467e-b28e-3deeb4bd56bd"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "6a981e44-1623-49dc-b475-bf029f0c47bd",
-                        "cf11abdc-899c-42ca-bed1-d6f9e6a450ca"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "2d1bd73d-a062-4634-9677-7ec4e30e6ed3"
-            },
-            "3418f09f-a1db-4f4d-ac5b-c25f36031a5b": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "point": [
-                                3060.0,
-                                59.999999999999815,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "e6c43402-01fb-4496-b6c9-4ea94441023b"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
-                                1.1842378929335003e-16,
-                                -0.0
-                            ],
-                            "point": [
-                                2940.0,
-                                -60.00000000000001,
-                                3.673940397442059e-15
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "6aded834-4595-476f-8ad5-f8141a5831e9"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "934feddd-8db9-4d08-9ad0-083bba29a35f",
-                        "6b029936-f988-407f-8b8e-8b4473795e0a"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "3418f09f-a1db-4f4d-ac5b-c25f36031a5b"
-            },
-            "361fc0ac-b87b-44d9-b2b1-464266a3f422": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                1470.0,
-                                -60.0,
-                                -1.8369701987210304e-15
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "c66c2cc1-f6b1-4575-96b0-183f20b7085d"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                0.0,
-                                -60.0,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "542fa7ed-77e5-46ea-a8ec-7fc5d437a7d0"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "83d65f37-b71c-4774-8704-53520465b4b6",
-                        "2748d58b-7ad2-40fd-ac6a-0855a497a000"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "361fc0ac-b87b-44d9-b2b1-464266a3f422"
-            },
-            "37ff331e-bbdc-4d34-9375-9f6bca34a594": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                992.8270086729294,
-                                -60.0,
-                                -1.8369701987210304e-15
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "d4e9faa5-0f59-45a0-a376-b02c4777800c"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                -60.0,
-                                -60.0,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "17202eaa-0100-4280-80f0-c909ff661771"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "895beb30-28c4-4794-98e0-06d24a086217",
-                        "2748d58b-7ad2-40fd-ac6a-0855a497a000"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "37ff331e-bbdc-4d34-9375-9f6bca34a594"
-            },
-            "3b279fff-3586-4c7c-8a6a-84f00ebff59c": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
-                                -0.0,
-                                0.0
-                            ],
-                            "point": [
-                                2034.984213989657,
-                                60.0,
-                                -1.8369701987210304e-15
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "e00c6443-67e0-48d8-bc41-15eb6a79606f"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                -60.0,
-                                -60.0,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "f4b89da6-b13a-4dfe-9121-15d8a043f586"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "cf11abdc-899c-42ca-bed1-d6f9e6a450ca",
-                        "2748d58b-7ad2-40fd-ac6a-0855a497a000"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "3b279fff-3586-4c7c-8a6a-84f00ebff59c"
-            },
-            "3b60c84b-8616-4549-8723-2ef954b7ad52": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.6293936263837255,
-                                -0.7770866509389691,
-                                0.0
-                            ],
-                            "point": [
-                                1364.739397830994,
-                                -556.1139362680045,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "ffeb7bd4-76ea-4fc6-80a0-ffaa50a9f6f0"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                -6.394884621840901e-17,
-                                0.0
-                            ],
-                            "point": [
-                                59.999999999999936,
-                                3.67394039744206e-15,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "6223ee8c-100c-4de2-b025-6d0cd814eaac"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "c1c7146e-c7b9-4912-a0cd-09d68222b617",
-                        "0e918642-9d6b-4437-845a-03a8b85f59cd"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "3b60c84b-8616-4549-8723-2ef954b7ad52"
-            },
-            "4a27615b-e103-432b-8a4d-195c55182d3e": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                1.0,
-                                -0.0
-                            ],
-                            "point": [
-                                1974.984213989657,
-                                60.0,
-                                -1.8369701987210304e-15
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "65e73a77-5d2a-4d14-a647-7ad34cd42cf3"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                1974.984213989657,
-                                1.83697019872103e-15,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "4302e0e2-8cd8-4a2c-9ee8-ea55c4f4dea1"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "cf11abdc-899c-42ca-bed1-d6f9e6a450ca",
-                        "c8c6c5b4-a35c-4175-92e7-65c6fed4a00b"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "4a27615b-e103-432b-8a4d-195c55182d3e"
-            },
-            "4b195a59-9a57-4c18-9841-e5f212d9f355": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -1.0,
-                                0.0
-                            ],
-                            "point": [
-                                -60.0,
-                                -1560.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "ed8d6c7c-259d-4ae8-b9a9-7398612a20a2"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
-                                0.0,
-                                -0.0
-                            ],
-                            "point": [
-                                2940.0,
-                                60.00000000000001,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "17502a20-283d-478e-be7b-36bb7010537d"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "a1a31d0f-d10f-4f4a-9c70-77ce34f62795",
-                        "b30d063f-6537-477a-aa64-f5ff59f4a947"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "4b195a59-9a57-4c18-9841-e5f212d9f355"
-            },
-            "629f0d7f-eac7-4910-80fb-630aab313ca5": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                -5.684341886080802e-17,
-                                0.0
-                            ],
-                            "point": [
-                                -60.00000000000004,
-                                -3.1472698658549016e-15,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "bf8d8145-8336-44c7-8cb3-7f4d365428f0"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                1.0,
-                                -0.0
-                            ],
-                            "point": [
-                                0.0,
-                                -60.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "c3cfccc2-c0f7-4c44-94e4-e4aeb48c6abf"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "28984213-5f27-4ef5-8d12-a4dab0091968",
-                        "2748d58b-7ad2-40fd-ac6a-0855a497a000"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "629f0d7f-eac7-4910-80fb-630aab313ca5"
-            },
-            "6570040e-5937-48db-89be-5a5720de0274": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                -7.579122514774402e-17,
-                                0.0
-                            ],
-                            "point": [
-                                467.90302505509965,
-                                -2.7105033101436113e-15,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "f38a4311-cafe-436a-8c96-74a5f06acfc8"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -1.0,
-                                0.0
-                            ],
-                            "point": [
-                                -60.0,
-                                -1440.0,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "bb99cc01-4137-4641-a6f1-9a0f14c4ab71"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "faee9be6-610d-4c46-86d0-01c4d4609bb1",
-                        "a1a31d0f-d10f-4f4a-9c70-77ce34f62795"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "6570040e-5937-48db-89be-5a5720de0274"
-            },
-            "66ba2ace-22e7-476a-a184-1dd21ef31ef0": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                992.8270086729294,
-                                -60.0,
-                                -1.8369701987210304e-15
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "6b46040c-8a29-44d8-be1f-0ed6e5d1427e"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                1.5087022325849322e-16,
-                                -1.8493982216179916e-32,
-                                1.0
-                            ],
-                            "point": [
-                                2004.984213989657,
-                                -60.00000000000009,
-                                940.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "6f1fb72d-5705-491c-9a12-45cd153f42dc"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "895beb30-28c4-4794-98e0-06d24a086217",
-                        "c760f2d8-37d6-41bd-8ccd-a03f4fd1e968"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "66ba2ace-22e7-476a-a184-1dd21ef31ef0"
-            },
-            "85b1ac7a-e7fd-4858-9560-4b65b75b4397": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                527.9030250550996,
-                                1.83697019872103e-15,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "733a6efb-08f2-4cd2-a14e-1fc2a366a75f"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                1.0,
-                                -0.0
-                            ],
-                            "point": [
-                                527.9030250550998,
-                                -60.0,
-                                -1.8369701987210304e-15
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "15247a71-e00f-450a-8b35-ac66e5bdd470"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "faee9be6-610d-4c46-86d0-01c4d4609bb1",
-                        "251f3ab6-5580-4d40-9219-ff11788f2d30"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "85b1ac7a-e7fd-4858-9560-4b65b75b4397"
-            },
-            "8603f5fa-a0c0-4001-a27e-7d2938afdf5b": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                992.8270086729294,
-                                60.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "6a389482-614a-4556-a65a-659b4260ab3c"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -1.0,
-                                0.0
-                            ],
-                            "point": [
-                                0.0,
-                                -1440.0,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "167549d3-1e2c-4087-9611-eaae8c4944f8"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "ffde3ca4-8413-4b8a-8a78-d36e230b7adf",
-                        "a1a31d0f-d10f-4f4a-9c70-77ce34f62795"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "8603f5fa-a0c0-4001-a27e-7d2938afdf5b"
-            },
-            "868403be-44d4-4c51-b759-9adc6a5c8d8b": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "point": [
-                                -60.000000000000064,
-                                60.00000000000023,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "1f096ca1-a574-4a55-af26-dc167e42ca7b"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                -0.0,
-                                1.0,
-                                0.0
-                            ],
-                            "point": [
-                                -60.000000000000064,
-                                -60.0,
-                                2000.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "23dfff7d-4d44-4197-8d4f-942843d2986e"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "0e918642-9d6b-4437-845a-03a8b85f59cd",
-                        "2181217f-7468-4cdd-ba5d-a2203d39f36b"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "868403be-44d4-4c51-b759-9adc6a5c8d8b"
-            },
-            "8731467d-54d4-4660-af3c-e8b90fcd353c": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
-                                -0.0,
-                                0.0
-                            ],
-                            "point": [
-                                1530.0,
-                                60.0,
-                                -1.8369701987210304e-15
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "ebaa51d0-46f0-4458-96eb-8ed4ce501c08"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                1.5087022325849322e-16,
-                                -1.8493982216179916e-32,
-                                1.0
-                            ],
-                            "point": [
-                                2004.984213989657,
-                                -60.00000000000009,
-                                940.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "4df905de-53c3-4f8f-bce5-ff680c3279ca"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "83d65f37-b71c-4774-8704-53520465b4b6",
-                        "c760f2d8-37d6-41bd-8ccd-a03f4fd1e968"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "8731467d-54d4-4660-af3c-e8b90fcd353c"
-            },
-            "8c05e29f-cfdf-42fc-b8e3-90b8df8f03aa": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                1470.0,
-                                60.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "90dd8577-612f-4887-8927-2f4c98eb08ed"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -1.0,
-                                0.0
-                            ],
-                            "point": [
-                                -60.0,
-                                -1440.0,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "2d3b442c-f934-4f60-82a2-fd20a1202eab"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "503cf99d-5860-4e4e-a792-fab1d00a91ee",
-                        "a1a31d0f-d10f-4f4a-9c70-77ce34f62795"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "8c05e29f-cfdf-42fc-b8e3-90b8df8f03aa"
-            },
-            "8e8e190e-7886-4eee-80eb-221ec4e7a3ab": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -0.0,
-                                -0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                2496.669032979379,
-                                8.49830834647197e-15,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "fabbae2a-e472-46a5-9226-03a19c92a29e"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                1.0,
-                                -0.0
-                            ],
-                            "point": [
-                                2496.669032979379,
-                                -60.0,
-                                -1.8369701987210304e-15
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "39c96070-4299-490c-b231-68f9629cfc85"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "f4c08ca9-60ea-48a3-a981-a4e587da6809",
-                        "1a711710-6c26-49dc-8ae0-43ae1692624c"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "8e8e190e-7886-4eee-80eb-221ec4e7a3ab"
-            },
-            "98567214-63d5-4b99-8129-2a0479ec535f": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
-                                -0.0,
-                                0.0
-                            ],
-                            "point": [
-                                2496.6690329793787,
-                                60.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "c4c06f3f-4630-4a60-84a0-85883ae63ba0"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -0.0,
-                                1.0
-                            ],
-                            "point": [
-                                3060.0,
-                                -60.000000000000185,
+                                1735.6341231611425,
+                                -1261.7023552032194,
                                 1940.0
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "4971fba1-47a1-4403-a141-679486c2d6c4"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "1a711710-6c26-49dc-8ae0-43ae1692624c",
-                        "934feddd-8db9-4d08-9ad0-083bba29a35f"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "98567214-63d5-4b99-8129-2a0479ec535f"
-            },
-            "9aeaa88d-4a64-4019-ac61-fed7dbfcc0fd": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -5.921189464667503e-17,
-                                0.7071067811865476,
-                                0.7071067811865475
-                            ],
-                            "point": [
-                                -60.000000000000036,
-                                42.42640687119285,
-                                1042.4264068711927
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "a75fd081-b990-4bde-b052-15f2c4e65f2a"
+                        "guid": "50b765ca-1d07-4377-9af9-05dae0d61c60"
                     },
                     "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "point": [
-                                59.999999999999936,
-                                60.000000000000234,
-                                1940.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "0f329480-54ff-47fb-a3c3-0ea10305caa6"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "e62615e3-3d55-4988-9b4c-3706f41ad351",
-                        "0e918642-9d6b-4437-845a-03a8b85f59cd"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "9aeaa88d-4a64-4019-ac61-fed7dbfcc0fd"
-            },
-            "a08a9d6d-6e4b-451c-8b06-78a6ae81dd48": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                1.2074582437753336e-16,
-                                1.0,
-                                -0.0
-                            ],
-                            "point": [
-                                3060.0,
-                                59.999999999999815,
-                                1940.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "2c0b186c-ac4f-4528-b0f0-4b53c669f09a"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                -6.394884621840901e-17,
-                                0.0
-                            ],
-                            "point": [
-                                59.999999999999936,
-                                3.67394039744206e-15,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "8d356f8b-580d-4c26-b4f3-2915e4ac56a1"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "934feddd-8db9-4d08-9ad0-083bba29a35f",
-                        "0e918642-9d6b-4437-845a-03a8b85f59cd"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "a08a9d6d-6e4b-451c-8b06-78a6ae81dd48"
-            },
-            "a293493b-5391-469c-9107-13e9776d0b93": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                -60.0,
-                                60.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "d375e2cb-91e6-4980-8f0c-dff684e6e0fa"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                0.0,
-                                -6.032910020604624e-17
-                            ],
-                            "point": [
-                                59.999999999999936,
-                                -60.0,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "17b09ef5-2003-483d-9c9b-5675e0468a6e"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "2748d58b-7ad2-40fd-ac6a-0855a497a000",
-                        "2181217f-7468-4cdd-ba5d-a2203d39f36b"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "a293493b-5391-469c-9107-13e9776d0b93"
-            },
-            "a34d2752-1f7c-4e11-96bb-dc1368e41a78": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                59.99999999999996,
-                                3.67394039744206e-15,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "65305963-ee5c-4798-9649-d6bf9d0a1eb7"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                -0.0,
-                                1.0,
-                                0.0
-                            ],
-                            "point": [
-                                -60.000000000000064,
-                                -60.0,
-                                2000.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "5f2b2e44-445d-4564-9bc3-61fb0db3eeea"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "28984213-5f27-4ef5-8d12-a4dab0091968",
-                        "2181217f-7468-4cdd-ba5d-a2203d39f36b"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "a34d2752-1f7c-4e11-96bb-dc1368e41a78"
-            },
-            "a705487b-651f-4d60-9e62-b92a924d618e": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                467.90302505509976,
-                                -60.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "69cc7d88-c60e-4adb-952a-f1d7df648060"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                -60.0,
-                                -60.0,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "299e8234-d3e6-4b67-96ad-70bb94678aff"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "251f3ab6-5580-4d40-9219-ff11788f2d30",
-                        "2748d58b-7ad2-40fd-ac6a-0855a497a000"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "a705487b-651f-4d60-9e62-b92a924d618e"
-            },
-            "ae00bde6-38fb-4078-a8a2-208a26346fff": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -5.921189464667503e-17,
-                                0.7071067811865476,
-                                0.7071067811865475
-                            ],
-                            "point": [
-                                -60.000000000000036,
-                                42.42640687119285,
-                                1042.4264068711927
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "6987db48-6c53-4abc-8083-38623453b628"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                -0.0,
-                                1.0,
-                                0.0
-                            ],
-                            "point": [
-                                -60.000000000000064,
-                                -60.0,
-                                2000.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "dcc0dede-482a-4601-9f38-eba2902d6d94"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "e62615e3-3d55-4988-9b4c-3706f41ad351",
-                        "2181217f-7468-4cdd-ba5d-a2203d39f36b"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "ae00bde6-38fb-4078-a8a2-208a26346fff"
-            },
-            "af52f5af-7e49-4c5d-9990-6e6856a2d527": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                1470.0,
-                                60.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "52c4fcac-9d12-4732-b5f8-e4b23f2c4c55"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                1.0,
-                                -0.0
-                            ],
-                            "point": [
-                                0.0,
-                                -60.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "4ad194bb-9a30-4e7a-9b15-17f8c7f896ed"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "503cf99d-5860-4e4e-a792-fab1d00a91ee",
-                        "2748d58b-7ad2-40fd-ac6a-0855a497a000"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "af52f5af-7e49-4c5d-9990-6e6856a2d527"
-            },
-            "b4e1d8b9-0c43-454d-88e5-b6b4537540cd": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                467.90302505509976,
-                                -60.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "66ce2b4b-15f5-40d8-a840-8abf369876dd"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -0.0,
-                                1.0
-                            ],
-                            "point": [
-                                3060.0,
-                                -60.000000000000185,
-                                1940.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "60c6d84c-0902-4c55-8621-71e85c7cef6a"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "251f3ab6-5580-4d40-9219-ff11788f2d30",
-                        "934feddd-8db9-4d08-9ad0-083bba29a35f"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "b4e1d8b9-0c43-454d-88e5-b6b4537540cd"
-            },
-            "b5517df1-1bbd-42e9-88ee-651b6c1acec3": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                1.0,
-                                0.0
-                            ],
-                            "point": [
-                                59.99999999999996,
-                                -440.0,
-                                1500.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "c9ed1f14-a08b-4676-912f-c374bac0cb17"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                -60.00000000000004,
-                                -3.1472698658549016e-15,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "676f2510-07e3-41b7-a5c5-b82662adda25"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "efde03ed-a40a-4212-85d2-9a5477e828b3",
-                        "28984213-5f27-4ef5-8d12-a4dab0091968"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "b5517df1-1bbd-42e9-88ee-651b6c1acec3"
-            },
-            "bb78a305-5d14-4eba-9efb-b93eb285a793": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                0.0,
-                                1.0
-                            ],
-                            "point": [
-                                2940.0,
-                                3.67394039744206e-15,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "12d4ba74-de5e-4e0a-afea-49fe951017c4"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                -1.1842378929335003e-16,
-                                1.0,
-                                0.0
-                            ],
-                            "point": [
-                                3060.0,
-                                -59.99999999999999,
-                                3.673940397442059e-15
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "49109fd6-22c0-400e-9491-eb111f0db28f"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "960cda32-1a88-46a1-b360-1cd586c88067",
-                        "6b029936-f988-407f-8b8e-8b4473795e0a"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "bb78a305-5d14-4eba-9efb-b93eb285a793"
-            },
-            "bf4e75d8-5864-443b-8ff5-7fe7412694ce": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                3060.0,
-                                3.67394039744206e-15,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "14f735d8-ca91-44aa-bb76-a9f206fa122c"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                1.2316074086508403e-16,
-                                1.0,
-                                0.0
-                            ],
-                            "point": [
-                                3000.0,
-                                -60.000000000000185,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "6c805413-49e8-4a70-8e0d-c04d723e62c8"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "960cda32-1a88-46a1-b360-1cd586c88067",
-                        "934feddd-8db9-4d08-9ad0-083bba29a35f"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "LButtJoint",
-                    "reject_i": false,
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "bf4e75d8-5864-443b-8ff5-7fe7412694ce"
-            },
-            "c2e2433b-803f-4cdf-99c3-9e7b3ea8e348": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                1.0,
-                                -0.0,
-                                0.0
-                            ],
-                            "point": [
-                                1530.0,
-                                60.0,
-                                1599.571613124941
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "e93891d3-1f09-4c7f-b646-956e6a0cf6e0"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -0.0,
-                                1.0
-                            ],
-                            "point": [
-                                3060.0,
-                                -60.000000000000185,
-                                1940.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "d7a6c685-87d7-441f-8fd1-a38a13376c2b"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "45078bb4-7729-4624-9966-b8609ddf1afd",
-                        "934feddd-8db9-4d08-9ad0-083bba29a35f"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "c2e2433b-803f-4cdf-99c3-9e7b3ea8e348"
-            },
-            "c2fd93df-565e-4d35-9a9a-5d7814efcc31": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                992.8270086729294,
-                                60.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "b86f17f0-5ccb-4a32-a5a6-de6683e2aa80"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                1.0,
-                                -0.0
-                            ],
-                            "point": [
-                                0.0,
-                                -60.0,
-                                -60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "3b568005-bbe7-45a4-9184-6567b79c7f80"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "ffde3ca4-8413-4b8a-8a78-d36e230b7adf",
-                        "2748d58b-7ad2-40fd-ac6a-0855a497a000"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "c2fd93df-565e-4d35-9a9a-5d7814efcc31"
-            },
-            "c4351495-45cd-4979-a3f0-43d3ae1a4b9a": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                1.0,
-                                0.0
-                            ],
-                            "point": [
-                                3060.0,
-                                -440.0,
-                                1500.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "d52ca56a-dd39-4653-8f90-484316d0dc20"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -0.0,
-                                -1.0
-                            ],
-                            "point": [
-                                2940.0,
-                                60.00000000000001,
-                                60.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "811edec6-087d-4eb6-bf1b-95843eb01994"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "50940319-a44b-4eb5-be67-14933c16f538",
-                        "b30d063f-6537-477a-aa64-f5ff59f4a947"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "c4351495-45cd-4979-a3f0-43d3ae1a4b9a"
-            },
-            "c6544be0-0c36-4095-a24b-bb626d733516": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                992.8270086729294,
-                                -60.0,
-                                1599.5716131249415
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "7ef88b3f-df5f-4180-9621-f69dd4cf65ae"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -0.0,
-                                1.0
-                            ],
-                            "point": [
-                                3000.0,
-                                -60.000000000000185,
-                                1940.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "5273136e-c357-4f82-8241-4e279e35d23b"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "928eb8b5-bea9-4504-832f-318c3231854a",
-                        "934feddd-8db9-4d08-9ad0-083bba29a35f"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "c6544be0-0c36-4095-a24b-bb626d733516"
-            },
-            "c9615d1e-533d-4ff3-8f35-47a42732b470": {
-                "data": {
-                    "back_plane": {
                         "data": {
                             "normal": [
                                 -0.8807090808003171,
@@ -5290,46 +2837,30 @@
                                 0.0
                             ],
                             "point": [
-                                1032.8883475096509,
-                                -14.209727776993661,
-                                1940.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "db678b0f-a1be-442e-ac54-8b4c43d09eda"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                1.2074582437753336e-16,
-                                1.0,
-                                0.0
-                            ],
-                            "point": [
-                                3060.0,
-                                -60.000000000000185,
+                                1085.73089235767,
+                                14.209727776994336,
                                 2060.0
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "64c5e3b4-9880-45a7-a842-e98de8025391"
+                        "guid": "2975ba69-3853-4ffe-8cd4-f32276e907ea"
                     },
                     "conical_tool": false,
                     "element_guids": [
-                        "060875a1-a057-4dc8-9684-e7f233f521d2",
-                        "934feddd-8db9-4d08-9ad0-083bba29a35f"
+                        "2b5dd74c-1ce8-4234-9416-ed44da6a0c15",
+                        "d4c95d21-c986-4ec8-9c7f-1dc3cc35844b"
                     ],
                     "force_pocket": false,
                     "location": null,
                     "mill_depth": null,
-                    "modify_cross": true,
+                    "modify_cross": false,
                     "name": "TButtJoint",
                     "topology": 0
                 },
                 "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "c9615d1e-533d-4ff3-8f35-47a42732b470"
+                "guid": "168b0610-b2db-46f5-858f-f2f3c70975cb"
             },
-            "da3b4544-3a7a-47f5-a240-4dd4717654a8": {
+            "232646db-d2e8-4006-915d-312811f10986": {
                 "data": {
                     "back_plane": {
                         "data": {
@@ -5345,7 +2876,7 @@
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "e6291954-97a6-4693-b656-4b65c6d5af5d"
+                        "guid": "2d6e8045-67b2-486b-9e18-52c40afd8080"
                     },
                     "butt_plane": {
                         "data": {
@@ -5361,159 +2892,61 @@
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "27478648-2e36-48c3-9204-8fb75bcd5ad8"
+                        "guid": "17d8f110-0f50-4e09-98c8-85b7a1e85d74"
                     },
                     "conical_tool": false,
                     "element_guids": [
-                        "45078bb4-7729-4624-9966-b8609ddf1afd",
-                        "6a981e44-1623-49dc-b475-bf029f0c47bd"
+                        "9ce9f96e-1547-4e44-b74d-4605672b54e2",
+                        "d5f30507-f7fb-4a0b-9c91-492f725364ca"
                     ],
                     "force_pocket": false,
                     "location": null,
                     "mill_depth": null,
-                    "modify_cross": true,
+                    "modify_cross": false,
                     "name": "TButtJoint",
                     "topology": 0
                 },
                 "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "da3b4544-3a7a-47f5-a240-4dd4717654a8"
+                "guid": "232646db-d2e8-4006-915d-312811f10986"
             },
-            "dbe830ab-0e20-40a8-9c3e-646be9a2197a": {
+            "2676a4b1-a3e5-44fa-8000-bd3f3a28f59a": {
                 "data": {
                     "back_plane": {
                         "data": {
                             "normal": [
                                 0.0,
-                                -1.0,
+                                1.0,
                                 0.0
                             ],
                             "point": [
-                                2940.0,
-                                -560.0,
-                                1500.0
+                                59.999999999999936,
+                                60.0,
+                                2000.0
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "beb39cdc-57e1-41e1-9955-61d186de1219"
+                        "guid": "69b249db-013d-4cfa-bf60-2239980cdf84"
                     },
                     "butt_plane": {
                         "data": {
                             "normal": [
-                                -0.0,
-                                0.7071067811865476,
-                                0.7071067811865475
-                            ],
-                            "point": [
-                                2940.0,
-                                -1042.4264068711927,
-                                1957.5735931288073
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "ef7a9391-3edd-46c9-9ab0-3cd492d52a6b"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "50940319-a44b-4eb5-be67-14933c16f538",
-                        "de24c9aa-92d2-422e-bdf6-09e47d7649c0"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "dbe830ab-0e20-40a8-9c3e-646be9a2197a"
-            },
-            "dcf4f14f-a8db-4046-81a3-707dd8df1607": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                1.5087022325849322e-16,
-                                -1.8493982216179916e-32,
+                                0.0,
+                                0.0,
                                 1.0
                             ],
                             "point": [
-                                2004.984213989657,
-                                59.99999999999991,
-                                1060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "5488fbf3-40d7-4be1-9e3d-4ee07f115264"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                0.0,
-                                0.0
-                            ],
-                            "point": [
-                                527.9030250550998,
-                                60.0,
-                                -1.8369701987210304e-15
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "f7b9e23c-9a78-498f-b060-74305efd6992"
-                    },
-                    "conical_tool": false,
-                    "element_guids": [
-                        "c760f2d8-37d6-41bd-8ccd-a03f4fd1e968",
-                        "251f3ab6-5580-4d40-9219-ff11788f2d30"
-                    ],
-                    "force_pocket": false,
-                    "location": null,
-                    "mill_depth": null,
-                    "modify_cross": true,
-                    "name": "TButtJoint",
-                    "topology": 0
-                },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "dcf4f14f-a8db-4046-81a3-707dd8df1607"
-            },
-            "de53b7ac-5c43-4d21-8882-413843dadc97": {
-                "data": {
-                    "back_plane": {
-                        "data": {
-                            "normal": [
-                                -1.0,
-                                -6.208625846447478e-17,
-                                0.0
-                            ],
-                            "point": [
-                                -60.000000000000064,
-                                60.00000000000023,
+                                59.999999999999936,
+                                3.67394039744206e-15,
                                 1940.0
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "f042ac9b-2640-4547-9e4f-76d4781d607e"
-                    },
-                    "butt_plane": {
-                        "data": {
-                            "normal": [
-                                0.0,
-                                -1.0,
-                                0.0
-                            ],
-                            "point": [
-                                0.0,
-                                -1940.0,
-                                2060.0
-                            ]
-                        },
-                        "dtype": "compas.geometry/Plane",
-                        "guid": "7605655a-577d-47e0-9a77-486d939ceba9"
+                        "guid": "5aa2a82e-7cce-45d6-b36d-feb61641f3d1"
                     },
                     "conical_tool": false,
                     "element_guids": [
-                        "0e918642-9d6b-4437-845a-03a8b85f59cd",
-                        "203d7dd5-1e80-4f15-9b36-fc4b925d79a1"
+                        "7ac92736-9a70-4979-8441-430e924ab9d9",
+                        "6f516961-c0c9-4264-8749-716cd22a985f"
                     ],
                     "force_pocket": false,
                     "location": null,
@@ -5524,58 +2957,158 @@
                     "topology": 0
                 },
                 "dtype": "compas_timber.connections/LButtJoint",
-                "guid": "de53b7ac-5c43-4d21-8882-413843dadc97"
+                "guid": "2676a4b1-a3e5-44fa-8000-bd3f3a28f59a"
             },
-            "e10c33cd-285b-4f33-8ac3-a28c8fb02830": {
+            "270a9dc5-0b20-4bdd-8e07-6f09343ccd1f": {
                 "data": {
                     "back_plane": {
                         "data": {
                             "normal": [
-                                -1.0,
-                                -7.579122514774402e-17,
+                                0.0,
+                                1.0,
                                 0.0
                             ],
                             "point": [
-                                467.90302505509965,
-                                -2.7105033101436113e-15,
-                                -60.0
+                                59.999999999999936,
+                                60.0,
+                                2000.0
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "e3ffaaf2-eb88-4cc3-bef2-92cd5472c87f"
+                        "guid": "57a7e0b9-a3ca-4627-b19d-15f834faaf89"
                     },
                     "butt_plane": {
                         "data": {
                             "normal": [
                                 0.0,
-                                1.0,
-                                -0.0
+                                -0.0,
+                                -1.0
                             ],
                             "point": [
-                                -60.0,
-                                -60.0,
-                                -60.0
+                                -60.00000000000004,
+                                -3.1472698658549016e-15,
+                                60.0
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "bce19aae-af93-451e-a098-7503b13d459d"
+                        "guid": "9b6ed5f3-cca2-4d0f-a1df-3ed48d040520"
                     },
                     "conical_tool": false,
                     "element_guids": [
-                        "faee9be6-610d-4c46-86d0-01c4d4609bb1",
-                        "2748d58b-7ad2-40fd-ac6a-0855a497a000"
+                        "7ac92736-9a70-4979-8441-430e924ab9d9",
+                        "6f955f15-b316-4918-8764-9e4106dda755"
                     ],
                     "force_pocket": false,
                     "location": null,
                     "mill_depth": null,
                     "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "270a9dc5-0b20-4bdd-8e07-6f09343ccd1f"
+            },
+            "2a0ed14b-c0db-42a6-a603-2314a76cea8b": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                1470.0,
+                                -60.0,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "e0b98485-66b0-4622-b915-1ff15ef36951"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                -1.0
+                            ],
+                            "point": [
+                                -60.0,
+                                -60.0,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "735bcf2d-e48e-4e06-9190-82e0424fda2c"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "7aedfe70-6276-4029-aaa8-9892bf0e736f",
+                        "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
                     "name": "TButtJoint",
                     "topology": 0
                 },
                 "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "e10c33cd-285b-4f33-8ac3-a28c8fb02830"
+                "guid": "2a0ed14b-c0db-42a6-a603-2314a76cea8b"
             },
-            "efb7d750-984c-42cf-9e61-1f42d1a607ca": {
+            "2a51c995-a4c0-4183-8920-a1b4a487cd0c": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -1.0,
+                                0.0
+                            ],
+                            "point": [
+                                0.0,
+                                -2060.0,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "899982a9-3136-4adb-ba1a-77fb58c590c0"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                -6.394884621840901e-17,
+                                0.0
+                            ],
+                            "point": [
+                                59.999999999999936,
+                                3.67394039744206e-15,
+                                2060.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "c906ef78-9d0c-48d8-ab38-0700627d32c9"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "9b4340ab-e094-48a2-823a-2b464c54c41c",
+                        "6f516961-c0c9-4264-8749-716cd22a985f"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "2a51c995-a4c0-4183-8920-a1b4a487cd0c"
+            },
+            "357a8264-8202-466f-b82b-b7b3c237c9e0": {
                 "data": {
                     "back_plane": {
                         "data": {
@@ -5591,7 +3124,7 @@
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "dc7b75ed-18ee-47bd-8684-8896a9345a93"
+                        "guid": "4debd358-1cfb-41e3-b245-c70deb9c033f"
                     },
                     "butt_plane": {
                         "data": {
@@ -5607,73 +3140,173 @@
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "a51ecf37-1ede-46c7-a2b2-b06bfff893c1"
+                        "guid": "0a26e54b-c6b5-4eb9-b8cd-85511904699c"
                     },
                     "conical_tool": false,
                     "element_guids": [
-                        "de24c9aa-92d2-422e-bdf6-09e47d7649c0",
-                        "6b029936-f988-407f-8b8e-8b4473795e0a"
+                        "2dcaa239-4558-414d-a0e7-2c75568d590c",
+                        "a58f3f5a-c3eb-40e2-a967-e4d7cc7795c8"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "357a8264-8202-466f-b82b-b7b3c237c9e0"
+            },
+            "35c5f2b2-7957-4eb0-8a41-bbad8ca134d0": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -1.0,
+                                0.0
+                            ],
+                            "point": [
+                                2940.0,
+                                -560.0,
+                                1500.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "8a458e3e-b179-455e-9f5f-2657930d86a9"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                -0.0,
+                                0.7071067811865476,
+                                0.7071067811865475
+                            ],
+                            "point": [
+                                2940.0,
+                                -1042.4264068711927,
+                                1957.5735931288073
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "4650ea13-17ce-4167-8415-b3cd99341823"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "03285a2b-8eae-408e-8358-67c487c1c107",
+                        "2dcaa239-4558-414d-a0e7-2c75568d590c"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "35c5f2b2-7957-4eb0-8a41-bbad8ca134d0"
+            },
+            "36264ef0-59e7-47c6-b5f0-dfc657d89f9f": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                -6.032910020604624e-17,
+                                0.0
+                            ],
+                            "point": [
+                                -60.000000000000064,
+                                60.0,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "9f098d61-90a5-487f-8db6-16c522e4ef11"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                1.2316074086508403e-16,
+                                1.0,
+                                0.0
+                            ],
+                            "point": [
+                                3000.0,
+                                -60.000000000000185,
+                                2060.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "f060515a-489c-420e-a588-64556f8efcc5"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "6f516961-c0c9-4264-8749-716cd22a985f",
+                        "cef865a8-469f-45ea-96fe-43d6f896ac29"
                     ],
                     "force_pocket": false,
                     "location": null,
                     "mill_depth": null,
                     "modify_cross": true,
-                    "name": "TButtJoint",
+                    "name": "LButtJoint",
+                    "reject_i": false,
                     "topology": 0
                 },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "efb7d750-984c-42cf-9e61-1f42d1a607ca"
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "36264ef0-59e7-47c6-b5f0-dfc657d89f9f"
             },
-            "f10ac188-9751-47e8-b748-619a214808ae": {
+            "3b5ba8d0-78d2-4f82-9d83-de9615267b10": {
                 "data": {
                     "back_plane": {
                         "data": {
                             "normal": [
-                                1.0,
                                 -0.0,
-                                0.0
+                                -0.0,
+                                -1.0
                             ],
                             "point": [
                                 2034.984213989657,
-                                60.0,
-                                -1.8369701987210304e-15
+                                1.83697019872103e-15,
+                                -60.0
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "b252cad8-dc4a-4898-a242-dc936cef5ef4"
+                        "guid": "4a533cc3-a287-46a4-865d-981aac37479c"
                     },
                     "butt_plane": {
                         "data": {
                             "normal": [
                                 0.0,
-                                -0.0,
-                                1.0
+                                1.0,
+                                -0.0
                             ],
                             "point": [
-                                3060.0,
-                                -60.000000000000185,
-                                1940.0
+                                2034.984213989657,
+                                -60.0,
+                                -1.8369701987210304e-15
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "275ec049-3089-4242-839a-d9a4a947f1a1"
+                        "guid": "ba30f319-7125-422c-9664-efeb6fa423ea"
                     },
                     "conical_tool": false,
                     "element_guids": [
-                        "cf11abdc-899c-42ca-bed1-d6f9e6a450ca",
-                        "934feddd-8db9-4d08-9ad0-083bba29a35f"
+                        "950b5119-3208-4291-be1d-c77e1e9d6fa6",
+                        "c32d947d-70b8-4e4c-8a8f-6667e567f511"
                     ],
                     "force_pocket": false,
                     "location": null,
                     "mill_depth": null,
                     "modify_cross": true,
-                    "name": "TButtJoint",
+                    "name": "LButtJoint",
+                    "reject_i": false,
                     "topology": 0
                 },
-                "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "f10ac188-9751-47e8-b748-619a214808ae"
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "3b5ba8d0-78d2-4f82-9d83-de9615267b10"
             },
-            "fd699378-d651-4aac-881a-f42e06d25d50": {
+            "3eaccaaf-801c-4ad4-bea6-934d44d92352": {
                 "data": {
                     "back_plane": {
                         "data": {
@@ -5684,12 +3317,12 @@
                             ],
                             "point": [
                                 2034.984213989657,
-                                60.0,
+                                1.83697019872103e-15,
                                 60.0
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "b371670c-f80b-4964-b977-9fd5f5def877"
+                        "guid": "83e1ab3e-3883-4389-9b4f-17e54bb3388c"
                     },
                     "butt_plane": {
                         "data": {
@@ -5699,37 +3332,448 @@
                                 0.0
                             ],
                             "point": [
-                                -60.0,
+                                0.0,
                                 -1440.0,
                                 60.0
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "bf5c2b63-a4a9-47ca-8f94-709f7d253f60"
+                        "guid": "d4663780-14a1-4046-9945-bd391d188058"
                     },
                     "conical_tool": false,
                     "element_guids": [
-                        "c8c6c5b4-a35c-4175-92e7-65c6fed4a00b",
-                        "a1a31d0f-d10f-4f4a-9c70-77ce34f62795"
+                        "950b5119-3208-4291-be1d-c77e1e9d6fa6",
+                        "bdb24d25-87c7-431f-ad70-8fc2ce5e770d"
                     ],
                     "force_pocket": false,
                     "location": null,
                     "mill_depth": null,
-                    "modify_cross": true,
+                    "modify_cross": false,
                     "name": "TButtJoint",
                     "topology": 0
                 },
                 "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "fd699378-d651-4aac-881a-f42e06d25d50"
+                "guid": "3eaccaaf-801c-4ad4-bea6-934d44d92352"
             },
-            "fe3cfd97-9633-4b44-92f3-b88b262c8d14": {
+            "403a1481-44e8-4f8f-bd22-5ca611324e79": {
                 "data": {
                     "back_plane": {
                         "data": {
                             "normal": [
                                 0.0,
+                                -1.0,
+                                0.0
+                            ],
+                            "point": [
                                 0.0,
+                                -1560.0,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "91643c59-ddc7-4134-8a6c-18efa3d8db9f"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                -6.376665577334232e-17,
+                                0.0
+                            ],
+                            "point": [
+                                59.99999999999995,
+                                60.00000000000001,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "460fbc1e-c345-423f-b6fb-bca70dd160fa"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "bdb24d25-87c7-431f-ad70-8fc2ce5e770d",
+                        "6f955f15-b316-4918-8764-9e4106dda755"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "403a1481-44e8-4f8f-bd22-5ca611324e79"
+            },
+            "40c79a5e-68f1-491a-9d25-5450624219a9": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                0.8807090808003171,
+                                0.4736575925664665,
+                                0.0
+                            ],
+                            "point": [
+                                1085.73089235767,
+                                14.209727776994336,
+                                2060.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "54fbb62f-8a37-47a1-8cf7-43a5ca154825"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -1.0,
+                                0.0
+                            ],
+                            "point": [
+                                0.0,
+                                -1940.0,
+                                2060.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "11f18235-e79a-4d15-b609-4f4686f13a3d"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "d4c95d21-c986-4ec8-9c7f-1dc3cc35844b",
+                        "9b4340ab-e094-48a2-823a-2b464c54c41c"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "40c79a5e-68f1-491a-9d25-5450624219a9"
+            },
+            "4201b9d2-ca1a-4670-b6c3-9cd7c6526c7d": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                1.0,
+                                -0.0
+                            ],
+                            "point": [
+                                992.8270086729294,
+                                60.0,
+                                -1.8369701987210304e-15
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "8e65559d-3d1a-435a-b3b2-46ca384e2427"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                -1.0
+                            ],
+                            "point": [
+                                992.8270086729294,
+                                1.83697019872103e-15,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "23341d60-6aeb-44b9-b9a4-8d3ec9b7e62d"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "642120b1-28c3-4762-8607-e889f56645f9",
+                        "658a71ec-3e5e-4f60-a468-39ec51dd47cd"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "4201b9d2-ca1a-4670-b6c3-9cd7c6526c7d"
+            },
+            "483b2ee1-54d5-4267-a743-1ace60dc0fdb": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                -7.287617802667694e-17,
+                                0.0
+                            ],
+                            "point": [
+                                467.90302505509965,
+                                59.99999999999999,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "60455a26-0197-4f6d-95c4-f83721970362"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                1.0,
+                                -0.0
+                            ],
+                            "point": [
+                                -60.0,
+                                -60.0,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "7011b33b-1540-4904-a7f9-0359aab3ee08"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "4974254b-9a12-4d3e-b83e-6251ab157f8f",
+                        "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "483b2ee1-54d5-4267-a743-1ace60dc0fdb"
+            },
+            "517939aa-d8f7-437a-9df8-36489ad4f631": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                -0.0,
+                                0.0
+                            ],
+                            "point": [
+                                2034.984213989657,
+                                60.0,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "e440fa9b-2f7e-4fea-b11c-d8faa5bb5b95"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                -1.0
+                            ],
+                            "point": [
+                                -60.0,
+                                -60.0,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "2ea2e511-2efd-4a9d-9610-4926c2c77ca6"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "c32d947d-70b8-4e4c-8a8f-6667e567f511",
+                        "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "517939aa-d8f7-437a-9df8-36489ad4f631"
+            },
+            "571d146a-814e-4bb6-8c99-95577ac22b3b": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                992.8270086729294,
+                                -60.0,
+                                1599.5716131249415
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "5535c50b-9586-42ad-8cbe-d0314fee7f5d"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
                                 1.0
+                            ],
+                            "point": [
+                                3000.0,
+                                -60.000000000000185,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "4a7b447b-0117-45da-9674-b14701b0469f"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "af5b648d-a596-4317-a730-218c28434b39",
+                        "cef865a8-469f-45ea-96fe-43d6f896ac29"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "571d146a-814e-4bb6-8c99-95577ac22b3b"
+            },
+            "63d1cce4-9fd0-4ba4-b127-d6ab3cfa1cb3": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -0.0,
+                                -0.0,
+                                -1.0
+                            ],
+                            "point": [
+                                3060.0,
+                                3.67394039744206e-15,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "0538d020-91e3-46d0-83a8-4341bbcabe1b"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                -1.1842378929335003e-16,
+                                1.0,
+                                0.0
+                            ],
+                            "point": [
+                                3060.0,
+                                -59.99999999999999,
+                                3.673940397442059e-15
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "45af81bc-2326-489f-99e1-7cd81752aa37"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "52c72e39-f5ad-4de6-a423-77b11aa36e20",
+                        "a58f3f5a-c3eb-40e2-a967-e4d7cc7795c8"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "63d1cce4-9fd0-4ba4-b127-d6ab3cfa1cb3"
+            },
+            "65778f0c-373f-4d93-aa98-633d7320cd2e": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -0.6293936263837255,
+                                0.7770866509389691,
+                                0.0
+                            ],
+                            "point": [
+                                1326.9757802479705,
+                                -509.4887372116664,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "74517d06-a2e1-41a7-a9b1-cbbbc7b68019"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.8807090808003171,
+                                0.4736575925664665,
+                                -0.0
+                            ],
+                            "point": [
+                                1032.8883475096509,
+                                -14.209727776993661,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "f1ec7a7f-7a2d-49eb-8451-a9228b558215"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "28828f51-d0f8-4d8f-840c-9565ff4e684d",
+                        "d4c95d21-c986-4ec8-9c7f-1dc3cc35844b"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "65778f0c-373f-4d93-aa98-633d7320cd2e"
+            },
+            "66bcfab9-b7f8-41e7-9840-1b370a08f193": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                992.8270086729294,
+                                -60.0,
+                                1599.5716131249415
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "6d4113c9-5007-45cc-8237-3439becd42dd"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                -0.0,
+                                0.0,
+                                -1.0
                             ],
                             "point": [
                                 2004.984213989657,
@@ -5738,9 +3782,175 @@
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "b76d6bf5-337a-4be1-a76c-a4c0eeb27a95"
+                        "guid": "5358c3da-673c-4593-b95a-578745adfc18"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "af5b648d-a596-4317-a730-218c28434b39",
+                        "d5f30507-f7fb-4a0b-9c91-492f725364ca"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "66bcfab9-b7f8-41e7-9840-1b370a08f193"
+            },
+            "6759b913-e2e8-4672-8619-b516b874f39d": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -5.921189464667503e-17,
+                                0.7071067811865476,
+                                0.7071067811865475
+                            ],
+                            "point": [
+                                -60.000000000000036,
+                                42.42640687119285,
+                                1042.4264068711927
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "0e75a836-01a6-4a37-81f2-4daa2841ad47"
                     },
                     "butt_plane": {
+                        "data": {
+                            "normal": [
+                                -0.0,
+                                1.0,
+                                0.0
+                            ],
+                            "point": [
+                                -60.000000000000064,
+                                -60.0,
+                                2000.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "ab59fc36-f474-4dfa-98d8-cc3825ca41b9"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "4fc6b138-6bee-4808-8d9c-824de512490d",
+                        "7ac92736-9a70-4979-8441-430e924ab9d9"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "6759b913-e2e8-4672-8619-b516b874f39d"
+            },
+            "681e8a9d-2b06-48b2-b80c-3747ec20b2e2": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.1842378929335003e-16,
+                                1.0,
+                                0.0
+                            ],
+                            "point": [
+                                2940.0,
+                                59.99999999999999,
+                                -59.99999999999999
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "1e50217b-63f7-4f8f-a843-d1ffa340f98c"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                0.0,
+                                1.0
+                            ],
+                            "point": [
+                                3060.0,
+                                3.67394039744206e-15,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "d3e7a434-2b3a-489f-bb02-abd16f80f61b"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "a58f3f5a-c3eb-40e2-a967-e4d7cc7795c8",
+                        "68aa3b3a-9ac4-4e38-a91b-a665dc0cd250"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "681e8a9d-2b06-48b2-b80c-3747ec20b2e2"
+            },
+            "6ba114a7-ec65-4e48-9daa-9922dfc71fcb": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                1.1842378929335003e-16,
+                                -0.0
+                            ],
+                            "point": [
+                                3060.0,
+                                60.00000000000001,
+                                -59.99999999999999
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "df331ba4-18b5-4a27-9087-12eaaf543758"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                1.0
+                            ],
+                            "point": [
+                                3000.0,
+                                -60.000000000000185,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "7f7b424b-a9e8-47b1-bd01-d463402a13b8"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "a58f3f5a-c3eb-40e2-a967-e4d7cc7795c8",
+                        "cef865a8-469f-45ea-96fe-43d6f896ac29"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "6ba114a7-ec65-4e48-9daa-9922dfc71fcb"
+            },
+            "6c85e7df-fa5c-4e0b-808d-efdcb55a8af3": {
+                "data": {
+                    "back_plane": {
                         "data": {
                             "normal": [
                                 -1.0,
@@ -5748,30 +3958,291 @@
                                 0.0
                             ],
                             "point": [
-                                527.9030250550998,
-                                60.0,
+                                992.8270086729294,
+                                -60.0,
                                 -1.8369701987210304e-15
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "a7a580a7-6bbd-4965-ba5b-f97197eb615b"
+                        "guid": "e23dc55d-fa74-4f49-af4f-823077b59a26"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                -1.0
+                            ],
+                            "point": [
+                                0.0,
+                                -60.0,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "396e95c6-61df-4f2a-b1a2-9d049c1a39ab"
                     },
                     "conical_tool": false,
                     "element_guids": [
-                        "6a981e44-1623-49dc-b475-bf029f0c47bd",
-                        "251f3ab6-5580-4d40-9219-ff11788f2d30"
+                        "642120b1-28c3-4762-8607-e889f56645f9",
+                        "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
                     ],
                     "force_pocket": false,
                     "location": null,
                     "mill_depth": null,
-                    "modify_cross": true,
+                    "modify_cross": false,
                     "name": "TButtJoint",
                     "topology": 0
                 },
                 "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "fe3cfd97-9633-4b44-92f3-b88b262c8d14"
+                "guid": "6c85e7df-fa5c-4e0b-808d-efdcb55a8af3"
             },
-            "ffdecf18-dd0c-471b-bf1d-11e140b4f8a8": {
+            "72e95bc5-e969-4470-adc6-5e83384a1ec9": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                992.8270086729294,
+                                -60.0,
+                                -1.8369701987210304e-15
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "2a9acc2e-6326-43b9-b299-64b70a5dc2ac"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                1.5087022325849322e-16,
+                                -1.8493982216179916e-32,
+                                1.0
+                            ],
+                            "point": [
+                                2004.984213989657,
+                                -60.00000000000009,
+                                940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "f51fb293-70d3-4af3-a71a-94ff047ec0ae"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "642120b1-28c3-4762-8607-e889f56645f9",
+                        "0a04cf8c-a620-4200-a218-006461b51686"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "72e95bc5-e969-4470-adc6-5e83384a1ec9"
+            },
+            "7d418d75-0768-443e-9642-a1a80662e056": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                -7.287617802667694e-17,
+                                0.0
+                            ],
+                            "point": [
+                                467.90302505509965,
+                                59.99999999999999,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "5de0fa11-4c38-48e1-9de6-c105110da2e7"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -1.0,
+                                0.0
+                            ],
+                            "point": [
+                                0.0,
+                                -1440.0,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "8b25a2af-cdad-49d9-8a04-dd8b4c57961b"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "4974254b-9a12-4d3e-b83e-6251ab157f8f",
+                        "bdb24d25-87c7-431f-ad70-8fc2ce5e770d"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "7d418d75-0768-443e-9642-a1a80662e056"
+            },
+            "814cec8a-db4c-4e7f-9cea-206b344c8105": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                -0.0,
+                                0.0
+                            ],
+                            "point": [
+                                1530.0,
+                                60.0,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "f86a8087-b271-4a06-97a7-25e2328f2a03"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                1.5087022325849322e-16,
+                                -1.8493982216179916e-32,
+                                1.0
+                            ],
+                            "point": [
+                                2004.984213989657,
+                                -60.00000000000009,
+                                940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "4ce6775b-1fce-4963-b5e7-680d0ac24d63"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "7aedfe70-6276-4029-aaa8-9892bf0e736f",
+                        "0a04cf8c-a620-4200-a218-006461b51686"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "814cec8a-db4c-4e7f-9cea-206b344c8105"
+            },
+            "82c99c59-1552-45e9-a5e1-4530387eb7ee": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                1.0,
+                                0.0
+                            ],
+                            "point": [
+                                3060.0,
+                                -440.0,
+                                1500.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "e65ae369-115b-40de-b743-8ebb5877e338"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                -1.0
+                            ],
+                            "point": [
+                                2940.0,
+                                3.67394039744206e-15,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "ac718019-f771-4940-9e49-3d26fce006f0"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "03285a2b-8eae-408e-8358-67c487c1c107",
+                        "52c72e39-f5ad-4de6-a423-77b11aa36e20"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "82c99c59-1552-45e9-a5e1-4530387eb7ee"
+            },
+            "85c2c832-7b8f-41d1-848f-c6696dd11a38": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                2496.6690329793787,
+                                60.00000000000001,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "d74df947-c4f6-464b-af16-d78b7e7841c2"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -1.0,
+                                0.0
+                            ],
+                            "point": [
+                                0.0,
+                                -1440.0,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "7ff203f4-360e-4a70-a53e-8a45947537a1"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "dd34a65b-c4c1-41ea-a7cc-c68bf32f0889",
+                        "bdb24d25-87c7-431f-ad70-8fc2ce5e770d"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "85c2c832-7b8f-41d1-848f-c6696dd11a38"
+            },
+            "8797c0a1-f4c4-4d6a-a957-cc32025327c6": {
                 "data": {
                     "back_plane": {
                         "data": {
@@ -5787,7 +4258,353 @@
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "7651eb48-865b-4d7e-a4a5-b896a25b7d18"
+                        "guid": "2da1bce0-a353-4bd9-843a-98b82e7d6bb0"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                0.0,
+                                -0.0
+                            ],
+                            "point": [
+                                2940.0,
+                                60.00000000000001,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "f75ca027-3c31-473f-aee6-a6ffcdaa3beb"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "2b5dd74c-1ce8-4234-9416-ed44da6a0c15",
+                        "68aa3b3a-9ac4-4e38-a91b-a665dc0cd250"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "8797c0a1-f4c4-4d6a-a957-cc32025327c6"
+            },
+            "87e54758-8c36-4e58-b74b-9173224bf640": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                0.0,
+                                1.0
+                            ],
+                            "point": [
+                                2004.984213989657,
+                                59.99999999999991,
+                                1659.5716131249415
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "46cf42fc-830e-4eb4-b50c-9edce35122ec"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                -0.0,
+                                0.0
+                            ],
+                            "point": [
+                                1974.984213989657,
+                                -60.0,
+                                -1.8369701987210304e-15
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "35e4b182-bfe1-4b93-b0b1-7d2f2c90b4a5"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "d5f30507-f7fb-4a0b-9c91-492f725364ca",
+                        "c32d947d-70b8-4e4c-8a8f-6667e567f511"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "87e54758-8c36-4e58-b74b-9173224bf640"
+            },
+            "882b1985-7fe2-44a3-b70d-f4b480376b95": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                992.8270086729294,
+                                60.0,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "edae683e-a8b0-41c3-8ca2-084abfeb0c42"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -1.0,
+                                0.0
+                            ],
+                            "point": [
+                                0.0,
+                                -1440.0,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "83708fbd-e65e-48d8-b3c1-953a1cbba925"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "658a71ec-3e5e-4f60-a468-39ec51dd47cd",
+                        "bdb24d25-87c7-431f-ad70-8fc2ce5e770d"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "882b1985-7fe2-44a3-b70d-f4b480376b95"
+            },
+            "8a8c7548-6b7d-45fc-b244-eadbae2bae78": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -0.0,
+                                -0.0,
+                                -1.0
+                            ],
+                            "point": [
+                                1530.0,
+                                1.83697019872103e-15,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "6fcae923-b4b6-4efb-80b3-832c87d6c142"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                1.0,
+                                -0.0
+                            ],
+                            "point": [
+                                1530.0,
+                                -60.0,
+                                -1.8369701987210304e-15
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "5bdfeb76-284d-4ad1-b018-80c7c5dc49c8"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "e4db5300-d801-4945-a8f3-896a2666016f",
+                        "7aedfe70-6276-4029-aaa8-9892bf0e736f"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "8a8c7548-6b7d-45fc-b244-eadbae2bae78"
+            },
+            "8d82b795-d624-4c1b-960e-46a3de6e42c8": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                467.90302505509976,
+                                -60.0,
+                                -1.8369701987210304e-15
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "2ba91b97-63a1-4848-9e2c-141808a558cc"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                1.0
+                            ],
+                            "point": [
+                                3000.0,
+                                -60.000000000000185,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "5b2951da-b512-4c5f-a2ee-2c1a8817b885"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "ec1d8453-49fc-4d85-b51e-233fdd02df57",
+                        "cef865a8-469f-45ea-96fe-43d6f896ac29"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "8d82b795-d624-4c1b-960e-46a3de6e42c8"
+            },
+            "8f7f7882-5255-4398-91e9-e36aeeefc1ac": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                3060.0,
+                                3.67394039744206e-15,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "8b8122ca-45b3-493c-b07c-893376da78a8"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                1.0,
+                                -0.0
+                            ],
+                            "point": [
+                                -60.0,
+                                -60.0,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "0c4265e3-6036-4103-9314-68fa7f8949f7"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "52c72e39-f5ad-4de6-a423-77b11aa36e20",
+                        "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "8f7f7882-5255-4398-91e9-e36aeeefc1ac"
+            },
+            "92248235-687b-4e41-9de0-98308be5deb6": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                -0.0,
+                                -6.394884621840901e-17
+                            ],
+                            "point": [
+                                -60.000000000000064,
+                                60.0,
+                                2000.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "eca9feaf-2c06-44be-aaad-223ac8bd6910"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                -1.0
+                            ],
+                            "point": [
+                                0.0,
+                                -60.0,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "23ee073a-9060-4a40-ac89-46639319290e"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "7ac92736-9a70-4979-8441-430e924ab9d9",
+                        "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "92248235-687b-4e41-9de0-98308be5deb6"
+            },
+            "9428126e-681b-460b-a160-7bd0ece34b1a": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -1.0,
+                                0.0
+                            ],
+                            "point": [
+                                0.0,
+                                -2060.0,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "d2c4a1d0-1e32-42e2-a0f8-0b65572174ed"
                     },
                     "butt_plane": {
                         "data": {
@@ -5803,22 +4620,1206 @@
                             ]
                         },
                         "dtype": "compas.geometry/Plane",
-                        "guid": "595b4bbf-a392-4a6f-8379-0cf9fa68e665"
+                        "guid": "ef3bab85-d5f0-4294-915d-563250d9476c"
                     },
                     "conical_tool": false,
                     "element_guids": [
-                        "9d51b9d4-721d-4579-b6ad-41228650cb5c",
-                        "960cda32-1a88-46a1-b360-1cd586c88067"
+                        "9b4340ab-e094-48a2-823a-2b464c54c41c",
+                        "68aa3b3a-9ac4-4e38-a91b-a665dc0cd250"
                     ],
                     "force_pocket": false,
                     "location": null,
                     "mill_depth": null,
                     "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "9428126e-681b-460b-a160-7bd0ece34b1a"
+            },
+            "9a43ec98-28ee-43dc-b13c-e0bb945ce192": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                1470.0,
+                                1.83697019872103e-15,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "b3a50b24-9dc2-4baf-a568-519c3962e03b"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -1.0,
+                                0.0
+                            ],
+                            "point": [
+                                0.0,
+                                -1440.0,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "85c5572f-3d85-4761-848d-bab737586db4"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "e4db5300-d801-4945-a8f3-896a2666016f",
+                        "bdb24d25-87c7-431f-ad70-8fc2ce5e770d"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
                     "name": "TButtJoint",
                     "topology": 0
                 },
                 "dtype": "compas_timber.connections/TButtJoint",
-                "guid": "ffdecf18-dd0c-471b-bf1d-11e140b4f8a8"
+                "guid": "9a43ec98-28ee-43dc-b13c-e0bb945ce192"
+            },
+            "a212de9f-93cd-43ab-b716-12279a4cfecf": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                1.0,
+                                -0.0
+                            ],
+                            "point": [
+                                -60.0,
+                                60.0,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "b5af7c6e-affe-44ab-9556-bad966867eab"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                -6.140492778173705e-17,
+                                0.0
+                            ],
+                            "point": [
+                                59.99999999999995,
+                                60.00000000000001,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "a8d716cd-93cb-4e7e-9da9-8ab950e8043a"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0",
+                        "6f955f15-b316-4918-8764-9e4106dda755"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "a212de9f-93cd-43ab-b716-12279a4cfecf"
+            },
+            "ab44195a-0827-4527-b065-36740b894749": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                992.8270086729294,
+                                60.0,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "388f4c91-03c1-47fa-80ed-36c8e366e8a7"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                1.0,
+                                -0.0
+                            ],
+                            "point": [
+                                0.0,
+                                -60.0,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "1a4e15fc-58a3-472e-8e8d-0267de85df31"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "658a71ec-3e5e-4f60-a468-39ec51dd47cd",
+                        "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "ab44195a-0827-4527-b065-36740b894749"
+            },
+            "addcbf2f-d7bc-44f6-96c3-d7bfe1d5a13e": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                -0.0,
+                                0.0
+                            ],
+                            "point": [
+                                2034.984213989657,
+                                60.0,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "9698e749-32be-449e-af78-efc5ffb4123c"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                1.0
+                            ],
+                            "point": [
+                                3060.0,
+                                -60.00000000000019,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "37026099-8dc9-427f-8fbe-183c62801914"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "c32d947d-70b8-4e4c-8a8f-6667e567f511",
+                        "cef865a8-469f-45ea-96fe-43d6f896ac29"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "addcbf2f-d7bc-44f6-96c3-d7bfe1d5a13e"
+            },
+            "b20cc6a9-3a5f-42d8-bb22-d2dd02f27ff3": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -5.921189464667503e-17,
+                                0.7071067811865476,
+                                0.7071067811865475
+                            ],
+                            "point": [
+                                -60.000000000000036,
+                                42.42640687119285,
+                                1042.4264068711927
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "fc1a4906-db3c-410c-ae0a-bcb93e988e62"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                0.0,
+                                1.0
+                            ],
+                            "point": [
+                                59.999999999999936,
+                                60.00000000000001,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "06e3bf60-e7aa-4975-9308-76cb8f29d49f"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "4fc6b138-6bee-4808-8d9c-824de512490d",
+                        "6f516961-c0c9-4264-8749-716cd22a985f"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "b20cc6a9-3a5f-42d8-bb22-d2dd02f27ff3"
+            },
+            "b8eefed5-0c66-4f67-a23f-1c447428f175": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                1.1842378929335003e-16,
+                                -0.0
+                            ],
+                            "point": [
+                                3060.0,
+                                60.00000000000001,
+                                -59.99999999999999
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "24aa74c0-2151-4b7f-9a84-3ceda9013614"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                -1.0
+                            ],
+                            "point": [
+                                0.0,
+                                -60.0,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "0783cb8d-f669-4a2d-9bf9-5305184be1df"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "a58f3f5a-c3eb-40e2-a967-e4d7cc7795c8",
+                        "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "b8eefed5-0c66-4f67-a23f-1c447428f175"
+            },
+            "d269adf8-f5a1-4d2e-b7a3-e9acca518ff7": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                1.5087022325849322e-16,
+                                -1.8493982216179916e-32,
+                                1.0
+                            ],
+                            "point": [
+                                2004.984213989657,
+                                59.99999999999991,
+                                1060.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "b6b262c7-c307-4059-837a-58b7eaeed3d5"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                527.9030250550998,
+                                60.0,
+                                -1.8369701987210304e-15
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "be0c2132-c68b-41bc-aff2-c5d9aa73a499"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "0a04cf8c-a620-4200-a218-006461b51686",
+                        "ec1d8453-49fc-4d85-b51e-233fdd02df57"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "d269adf8-f5a1-4d2e-b7a3-e9acca518ff7"
+            },
+            "d2718915-58db-4754-902f-2ef0c7e2fd8d": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.5087022325849322e-16,
+                                1.8493982216179916e-32,
+                                -1.0
+                            ],
+                            "point": [
+                                2004.984213989657,
+                                -60.00000000000009,
+                                940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "5e389807-2123-42fb-9b79-6604785244f1"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                -0.0,
+                                0.0
+                            ],
+                            "point": [
+                                1974.984213989657,
+                                -60.0,
+                                -1.8369701987210304e-15
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "0b916df8-377a-4d38-a9a8-b305392a180b"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "0a04cf8c-a620-4200-a218-006461b51686",
+                        "c32d947d-70b8-4e4c-8a8f-6667e567f511"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "d2718915-58db-4754-902f-2ef0c7e2fd8d"
+            },
+            "d4c4cd08-5658-4445-8786-1e5010141db5": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -0.8807090808003171,
+                                -0.4736575925664665,
+                                0.0
+                            ],
+                            "point": [
+                                1032.8883475096509,
+                                -14.209727776993661,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "0f364a7e-26dd-4e3d-b1cf-367aa22d7fca"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                1.2316074086508403e-16,
+                                1.0,
+                                0.0
+                            ],
+                            "point": [
+                                3000.0,
+                                -60.000000000000185,
+                                2060.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "8ffd1a72-fc80-4274-aa85-4f718e4ab207"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "d4c95d21-c986-4ec8-9c7f-1dc3cc35844b",
+                        "cef865a8-469f-45ea-96fe-43d6f896ac29"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "d4c4cd08-5658-4445-8786-1e5010141db5"
+            },
+            "d76fe391-9519-4603-be97-3b0522d5bb32": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                1.0,
+                                0.0
+                            ],
+                            "point": [
+                                59.99999999999996,
+                                -440.0,
+                                1500.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "21c19a7f-d453-4e7e-adba-8359f6997d67"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                -1.0
+                            ],
+                            "point": [
+                                -60.00000000000005,
+                                60.0,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "c44517b8-785a-4fe4-8da8-43efc090392c"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "1e88ad95-f487-4600-a5ef-8320662a903c",
+                        "6f955f15-b316-4918-8764-9e4106dda755"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "d76fe391-9519-4603-be97-3b0522d5bb32"
+            },
+            "d8d77265-0255-4ce9-830c-2bcf7d909047": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                0.6293936263837255,
+                                -0.7770866509389691,
+                                0.0
+                            ],
+                            "point": [
+                                1364.739397830994,
+                                -556.1139362680045,
+                                2060.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "1c022f53-cb48-4a2c-882d-4e21d84ea3d3"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                -6.208625846447478e-17,
+                                0.0
+                            ],
+                            "point": [
+                                59.999999999999936,
+                                3.67394039744206e-15,
+                                2060.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "ac3a9bd0-d451-4fb7-b382-b75534d9b9be"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "28828f51-d0f8-4d8f-840c-9565ff4e684d",
+                        "6f516961-c0c9-4264-8749-716cd22a985f"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "d8d77265-0255-4ce9-830c-2bcf7d909047"
+            },
+            "dce492e9-4568-499f-acbc-626752ed3e6c": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                1.0,
+                                -0.0
+                            ],
+                            "point": [
+                                467.90302505509976,
+                                60.0,
+                                -1.8369701987210304e-15
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "ce4fb2bb-e0ad-4e62-ba35-2264930fd7ca"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                -1.0
+                            ],
+                            "point": [
+                                467.90302505509965,
+                                -2.7105033101436113e-15,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "626a7e43-b117-4a2b-9f11-f334c2314a1a"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "ec1d8453-49fc-4d85-b51e-233fdd02df57",
+                        "4974254b-9a12-4d3e-b83e-6251ab157f8f"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "dce492e9-4568-499f-acbc-626752ed3e6c"
+            },
+            "dd98e610-e922-4ac5-984d-b47bf926bf06": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                1470.0,
+                                1.83697019872103e-15,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "8a1e7f8d-a5e4-4276-bd91-0e604633a1d9"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                1.0,
+                                -0.0
+                            ],
+                            "point": [
+                                -60.0,
+                                -60.0,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "b53b1f9f-de8e-4829-99a8-effab1971e26"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "e4db5300-d801-4945-a8f3-896a2666016f",
+                        "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "dd98e610-e922-4ac5-984d-b47bf926bf06"
+            },
+            "e1ba83da-e73c-484d-a5c4-e23ec6516aa5": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                1.0,
+                                -0.0
+                            ],
+                            "point": [
+                                2436.669032979379,
+                                60.0,
+                                -1.8369701987210304e-15
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "f9b2c140-d8cb-493f-8567-6777d33f5bc8"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                -1.0
+                            ],
+                            "point": [
+                                2436.669032979379,
+                                8.49830834647197e-15,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "e77855a5-7e24-4c0b-8cad-d38f6ecff0dc"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "74381909-2c04-4510-b880-17df88cd93e1",
+                        "dd34a65b-c4c1-41ea-a7cc-c68bf32f0889"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "e1ba83da-e73c-484d-a5c4-e23ec6516aa5"
+            },
+            "e45e1cba-2825-45a4-a4d8-dd3473db205d": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                2034.984213989657,
+                                1.83697019872103e-15,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "617976b8-645c-45b0-a10e-66eb45e2da60"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                1.0,
+                                -0.0
+                            ],
+                            "point": [
+                                -60.0,
+                                -60.0,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "c2f39284-95fb-4784-bccc-fccfa17aca77"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "950b5119-3208-4291-be1d-c77e1e9d6fa6",
+                        "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "e45e1cba-2825-45a4-a4d8-dd3473db205d"
+            },
+            "e9aa6c5e-9c2f-461e-b48e-d5cd0b5a52b6": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                -0.0,
+                                0.0
+                            ],
+                            "point": [
+                                2496.669032979379,
+                                60.0,
+                                -1.8369701987210304e-15
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "16e53904-224d-4c3e-8303-63ec0b75bb38"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                1.0
+                            ],
+                            "point": [
+                                3000.0,
+                                -60.000000000000185,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "ccae89f0-b6ac-421a-bb50-91ac9111cc02"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "74381909-2c04-4510-b880-17df88cd93e1",
+                        "cef865a8-469f-45ea-96fe-43d6f896ac29"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "e9aa6c5e-9c2f-461e-b48e-d5cd0b5a52b6"
+            },
+            "ee843a2f-8a9c-497c-9ba7-2f3afd7c5545": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                -0.0,
+                                0.0
+                            ],
+                            "point": [
+                                1530.0,
+                                60.0,
+                                1599.571613124941
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "ef63efdb-489b-4552-ab06-a15bb9fe6d54"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                1.0
+                            ],
+                            "point": [
+                                3000.0,
+                                -60.000000000000185,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "ffac9bf6-c7bf-4edb-a253-38aa899d6561"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "9ce9f96e-1547-4e44-b74d-4605672b54e2",
+                        "cef865a8-469f-45ea-96fe-43d6f896ac29"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "ee843a2f-8a9c-497c-9ba7-2f3afd7c5545"
+            },
+            "ef8660b1-be64-4aa4-83d1-431d275f0dda": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                3060.0,
+                                3.67394039744206e-15,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "25189f6f-f76b-4b1e-a4ed-33c5ee6bd796"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -1.0,
+                                0.0
+                            ],
+                            "point": [
+                                0.0,
+                                -1440.0,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "bf3a7111-8314-48fb-93c3-ac5ca168138c"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "52c72e39-f5ad-4de6-a423-77b11aa36e20",
+                        "bdb24d25-87c7-431f-ad70-8fc2ce5e770d"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "ef8660b1-be64-4aa4-83d1-431d275f0dda"
+            },
+            "f1304850-71db-42f5-874f-45ab0d6afae4": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                2496.6690329793787,
+                                60.00000000000001,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "c3ecaca8-1b92-4b3c-bda5-321c457d7eb3"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                1.0,
+                                -0.0
+                            ],
+                            "point": [
+                                -60.0,
+                                -60.0,
+                                -60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "c8dbe814-915f-4ff0-b094-8b2ce52499d7"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "dd34a65b-c4c1-41ea-a7cc-c68bf32f0889",
+                        "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "f1304850-71db-42f5-874f-45ab0d6afae4"
+            },
+            "f1b21dcd-a086-4cf7-9eb4-7861f9e75d70": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                -0.0,
+                                0.0
+                            ],
+                            "point": [
+                                2496.669032979379,
+                                60.0,
+                                -1.8369701987210304e-15
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "86ae4dac-f51b-420a-bffc-40705431cfc6"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                -1.0
+                            ],
+                            "point": [
+                                0.0,
+                                -60.0,
+                                60.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "778cafa2-56b3-4b46-942d-06eda9511487"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "74381909-2c04-4510-b880-17df88cd93e1",
+                        "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "f1b21dcd-a086-4cf7-9eb4-7861f9e75d70"
+            },
+            "f3f1f701-ef1b-4ffc-ab45-ddc1949ebf6c": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                -0.0,
+                                -6.394884621840901e-17
+                            ],
+                            "point": [
+                                -60.000000000000064,
+                                60.0,
+                                2000.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "b4b38918-76a2-46be-81af-87a81b6bbd4b"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                -0.0,
+                                1.0
+                            ],
+                            "point": [
+                                3000.0,
+                                -60.000000000000185,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "6befd16b-377c-4d4f-8820-ad50a72cfddf"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "7ac92736-9a70-4979-8441-430e924ab9d9",
+                        "cef865a8-469f-45ea-96fe-43d6f896ac29"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "f3f1f701-ef1b-4ffc-ab45-ddc1949ebf6c"
+            },
+            "f4db0896-7e14-48e5-a0c8-59d13709e6c4": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                0.7071067811865476,
+                                0.7071067811865475
+                            ],
+                            "point": [
+                                3060.0,
+                                -957.573593128807,
+                                2042.426406871193
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "ab03c547-eed8-4044-ae77-5fd41044b701"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                0.0,
+                                1.0
+                            ],
+                            "point": [
+                                3060.0,
+                                3.67394039744206e-15,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "5b450d7d-ce54-4115-9080-c12f8e619125"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "2dcaa239-4558-414d-a0e7-2c75568d590c",
+                        "68aa3b3a-9ac4-4e38-a91b-a665dc0cd250"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "f4db0896-7e14-48e5-a0c8-59d13709e6c4"
+            },
+            "f5f139aa-88e4-470a-9ea5-68812f99c724": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                1.2297855042001735e-16,
+                                1.0,
+                                -0.0
+                            ],
+                            "point": [
+                                3060.0,
+                                59.99999999999981,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "fcd05694-2f77-4490-9965-2b8531f71fe3"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                1.0,
+                                0.0,
+                                -0.0
+                            ],
+                            "point": [
+                                2940.0,
+                                60.00000000000001,
+                                1940.0
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "717abdcb-e647-47bc-bdf0-ea74b357bffd"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "cef865a8-469f-45ea-96fe-43d6f896ac29",
+                        "68aa3b3a-9ac4-4e38-a91b-a665dc0cd250"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": true,
+                    "name": "LButtJoint",
+                    "reject_i": false,
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/LButtJoint",
+                "guid": "f5f139aa-88e4-470a-9ea5-68812f99c724"
+            },
+            "fa96313f-8abb-4372-a3e0-d36526780352": {
+                "data": {
+                    "back_plane": {
+                        "data": {
+                            "normal": [
+                                0.0,
+                                0.0,
+                                1.0
+                            ],
+                            "point": [
+                                2004.984213989657,
+                                59.99999999999991,
+                                1659.5716131249415
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "01ff3659-4cd5-4448-9517-065d6d5735aa"
+                    },
+                    "butt_plane": {
+                        "data": {
+                            "normal": [
+                                -1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "point": [
+                                527.9030250550998,
+                                60.0,
+                                -1.8369701987210304e-15
+                            ]
+                        },
+                        "dtype": "compas.geometry/Plane",
+                        "guid": "c15ee78b-7735-4ebf-9b78-c39414c41fe7"
+                    },
+                    "conical_tool": false,
+                    "element_guids": [
+                        "d5f30507-f7fb-4a0b-9c91-492f725364ca",
+                        "ec1d8453-49fc-4d85-b51e-233fdd02df57"
+                    ],
+                    "force_pocket": false,
+                    "location": null,
+                    "mill_depth": null,
+                    "modify_cross": false,
+                    "name": "TButtJoint",
+                    "topology": 0
+                },
+                "dtype": "compas_timber.connections/TButtJoint",
+                "guid": "fa96313f-8abb-4372-a3e0-d36526780352"
             }
         },
         "materials": {},
@@ -5828,127 +5829,127 @@
             "root": {
                 "children": [
                     {
-                        "element": "6a981e44-1623-49dc-b475-bf029f0c47bd",
+                        "element": "d5f30507-f7fb-4a0b-9c91-492f725364ca",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "c760f2d8-37d6-41bd-8ccd-a03f4fd1e968",
+                        "element": "0a04cf8c-a620-4200-a218-006461b51686",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "060875a1-a057-4dc8-9684-e7f233f521d2",
+                        "element": "d4c95d21-c986-4ec8-9c7f-1dc3cc35844b",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "9d51b9d4-721d-4579-b6ad-41228650cb5c",
+                        "element": "2b5dd74c-1ce8-4234-9416-ed44da6a0c15",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "c1c7146e-c7b9-4912-a0cd-09d68222b617",
+                        "element": "28828f51-d0f8-4d8f-840c-9565ff4e684d",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "de24c9aa-92d2-422e-bdf6-09e47d7649c0",
+                        "element": "2dcaa239-4558-414d-a0e7-2c75568d590c",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "e62615e3-3d55-4988-9b4c-3706f41ad351",
+                        "element": "4fc6b138-6bee-4808-8d9c-824de512490d",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "50940319-a44b-4eb5-be67-14933c16f538",
+                        "element": "03285a2b-8eae-408e-8358-67c487c1c107",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "efde03ed-a40a-4212-85d2-9a5477e828b3",
+                        "element": "1e88ad95-f487-4600-a5ef-8320662a903c",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "1a711710-6c26-49dc-8ae0-43ae1692624c",
+                        "element": "74381909-2c04-4510-b880-17df88cd93e1",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "cf11abdc-899c-42ca-bed1-d6f9e6a450ca",
+                        "element": "c32d947d-70b8-4e4c-8a8f-6667e567f511",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "251f3ab6-5580-4d40-9219-ff11788f2d30",
+                        "element": "ec1d8453-49fc-4d85-b51e-233fdd02df57",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "83d65f37-b71c-4774-8704-53520465b4b6",
+                        "element": "7aedfe70-6276-4029-aaa8-9892bf0e736f",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "895beb30-28c4-4794-98e0-06d24a086217",
+                        "element": "642120b1-28c3-4762-8607-e889f56645f9",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "45078bb4-7729-4624-9966-b8609ddf1afd",
+                        "element": "9ce9f96e-1547-4e44-b74d-4605672b54e2",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "928eb8b5-bea9-4504-832f-318c3231854a",
+                        "element": "af5b648d-a596-4317-a730-218c28434b39",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "960cda32-1a88-46a1-b360-1cd586c88067",
+                        "element": "68aa3b3a-9ac4-4e38-a91b-a665dc0cd250",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "b30d063f-6537-477a-aa64-f5ff59f4a947",
+                        "element": "52c72e39-f5ad-4de6-a423-77b11aa36e20",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "2748d58b-7ad2-40fd-ac6a-0855a497a000",
+                        "element": "cfb8bfdf-03bf-4ba6-922f-7ef6926c64d0",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "6b029936-f988-407f-8b8e-8b4473795e0a",
+                        "element": "a58f3f5a-c3eb-40e2-a967-e4d7cc7795c8",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "934feddd-8db9-4d08-9ad0-083bba29a35f",
+                        "element": "cef865a8-469f-45ea-96fe-43d6f896ac29",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "2181217f-7468-4cdd-ba5d-a2203d39f36b",
+                        "element": "7ac92736-9a70-4979-8441-430e924ab9d9",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "0e918642-9d6b-4437-845a-03a8b85f59cd",
+                        "element": "6f516961-c0c9-4264-8749-716cd22a985f",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "203d7dd5-1e80-4f15-9b36-fc4b925d79a1",
+                        "element": "9b4340ab-e094-48a2-823a-2b464c54c41c",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "28984213-5f27-4ef5-8d12-a4dab0091968",
+                        "element": "6f955f15-b316-4918-8764-9e4106dda755",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "a1a31d0f-d10f-4f4a-9c70-77ce34f62795",
+                        "element": "bdb24d25-87c7-431f-ad70-8fc2ce5e770d",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "faee9be6-610d-4c46-86d0-01c4d4609bb1",
+                        "element": "4974254b-9a12-4d3e-b83e-6251ab157f8f",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "ffde3ca4-8413-4b8a-8a78-d36e230b7adf",
+                        "element": "658a71ec-3e5e-4f60-a468-39ec51dd47cd",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "503cf99d-5860-4e4e-a792-fab1d00a91ee",
+                        "element": "e4db5300-d801-4945-a8f3-896a2666016f",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "c8c6c5b4-a35c-4175-92e7-65c6fed4a00b",
+                        "element": "950b5119-3208-4291-be1d-c77e1e9d6fa6",
                         "name": "ElementNode"
                     },
                     {
-                        "element": "f4c08ca9-60ea-48a3-a981-a4e587da6809",
+                        "element": "dd34a65b-c4c1-41ea-a7cc-c68bf32f0889",
                         "name": "ElementNode"
                     }
                 ],
@@ -5957,7 +5958,7 @@
         }
     },
     "dtype": "compas_timber.model/TimberModel",
-    "guid": "a30203b3-336b-4797-8fd8-bdf44299ecd9",
+    "guid": "2d631cc8-f6a2-4009-b550-935d9afa509b",
     "inheritance": [
         "compas_model.models/Model"
     ]

--- a/src/compas_timber/connections/butt_joint.py
+++ b/src/compas_timber/connections/butt_joint.py
@@ -35,12 +35,8 @@ class ButtJoint(Joint):
         The cross beam to be joined.
     mill_depth : float
         The depth of the pocket to be milled in the cross beam. This will be ignored if `butt_plane` is provided.
-    modify_cross : bool, default False
-        If True, the cross beam will be extended to the opposite face of the main beam and cut with the same plane.
     butt_plane : :class:`~compas.geometry.Plane`, optional
         The plane used to cut the main beam. If not provided, the closest side of the cross beam will be used.
-    back_plane : :class:`~compas.geometry.Plane`, optional
-        The plane used to cut the cross beam if `modify_cross` is True.
     force_pocket : bool
         If `True` applies a `:~compas_timber.fabrication.Pocket` feature instead of a `:~compas_timber.fabrication.Lap` on the cross beam. Default is `False`.
     conical_tool : bool
@@ -56,12 +52,8 @@ class ButtJoint(Joint):
         A list containing the main beam and the cross beam.
     mill_depth : float
         The depth of the pocket to be milled in the cross beam.
-    modify_cross : bool, default False
-        If True, the cross beam will be extended to the opposite face of the main beam and cut with the same plane.
     butt_plane : :class:`~compas.geometry.Plane`, optional
         The plane used to cut the main beam. If not provided, the closest side of the cross beam will be used.
-    back_plane : :class:`~compas.geometry.Plane`, optional
-        The plane used to cut the cross beam if `modify_cross` is True.
     force_pocket : bool
         If `True` applies a `:~compas_timber.fabrication.Pocket` feature instead of a `:~compas_timber.fabrication.Lap` on the cross beam. Default is `False`.
     conical_tool : bool
@@ -81,9 +73,7 @@ class ButtJoint(Joint):
     def __data__(self):
         data = super(ButtJoint, self).__data__
         data["mill_depth"] = self.mill_depth
-        data["modify_cross"] = self.modify_cross
         data["butt_plane"] = self.butt_plane
-        data["back_plane"] = self.back_plane
         data["force_pocket"] = self.force_pocket
         data["conical_tool"] = self.conical_tool
         return data
@@ -93,21 +83,17 @@ class ButtJoint(Joint):
         main_beam: Beam = None,
         cross_beam: Beam = None,
         mill_depth: Optional[float] = None,
-        modify_cross: bool = True,
         butt_plane: Optional[Plane] = None,
-        back_plane: Optional[Plane] = None,
         force_pocket: bool = False,
         conical_tool: bool = False,
         **kwargs,
     ):
         super(ButtJoint, self).__init__(elements=(main_beam, cross_beam), **kwargs)
         self.mill_depth = mill_depth
-        self.modify_cross = modify_cross
         self.force_pocket = force_pocket
         self.conical_tool = conical_tool
         self.features = []
         self._butt_plane = butt_plane
-        self._back_plane = back_plane
 
     @property
     def main_beam(self):
@@ -143,12 +129,6 @@ class ButtJoint(Joint):
             self._butt_plane = Plane.from_frame(cutting_plane)
         return self._butt_plane
 
-    @property
-    def back_plane(self) -> Plane:
-        if self._back_plane is None:
-            return Plane.from_frame(self.main_beam.opp_side(self.main_beam_ref_side_index))
-        return self._back_plane
-
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
@@ -169,17 +149,6 @@ class ButtJoint(Joint):
             raise BeamJoiningError(beams=self.elements, joint=self, debug_info=str(ae), debug_geometries=[self.butt_plane])
         except Exception as ex:
             raise BeamJoiningError(beams=self.elements, joint=self, debug_info=str(ex))
-
-        # extend the cross beam
-        if self.modify_cross:
-            try:
-                start, end = self.cross_beam.extension_to_plane(self.back_plane)
-                extension_tolerance = 0
-                # extension_tolerance = 0.01 if TOL.unit == "M" else 10
-                joint_id = self.guid
-                self.cross_beam.add_blank_extension(start + extension_tolerance, end + extension_tolerance, joint_id)
-            except AttributeError as ae:
-                raise BeamJoiningError(beams=self.elements, joint=self, debug_info=str(ae), debug_geometries=[self.back_plane])
 
     def add_features(self) -> None:
         """Removes this joint's previously generated features and adds new features to each beam."""
@@ -216,12 +185,6 @@ class ButtJoint(Joint):
                 )
             self.cross_beam.add_features(cross_feature)
             self.features.append(cross_feature)
-
-        # apply a refinement cut on the cross beam
-        if self.modify_cross:
-            cross_refinement_feature = JackRafterCutProxy.from_plane_and_beam(self.back_plane, self.cross_beam, self.cross_beam_ref_side_index)
-            self.cross_beam.add_features(cross_refinement_feature)
-            self.features.append(cross_refinement_feature)
 
     def _get_milling_volume_for_pocket(self) -> Polyhedron:
         top_plane = Plane.from_frame(self.cross_beam.ref_sides[self.cross_beam_ref_side_index])

--- a/src/compas_timber/connections/l_butt.py
+++ b/src/compas_timber/connections/l_butt.py
@@ -1,4 +1,7 @@
+from compas.geometry import Plane
+
 from compas_timber.errors import BeamJoiningError
+from compas_timber.fabrication import JackRafterCutProxy
 
 from .butt_joint import ButtJoint
 from .solver import JointTopology
@@ -55,6 +58,8 @@ class LButtJoint(ButtJoint):
     @property
     def __data__(self):
         data = super(LButtJoint, self).__data__
+        data["modify_cross"] = self.modify_cross
+        data["back_plane"] = self.back_plane
         data["reject_i"] = self.reject_i
         return data
 
@@ -75,14 +80,20 @@ class LButtJoint(ButtJoint):
             main_beam=main_beam,
             cross_beam=cross_beam,
             mill_depth=mill_depth,
-            modify_cross=modify_cross,
             butt_plane=butt_plane,
-            back_plane=back_plane,
             force_pocket=force_pocket,
             conical_tool=conical_tool,
             **kwargs,
         )
+        self.modify_cross = modify_cross
+        self._back_plane = back_plane
         self.reject_i = reject_i
+
+    @property
+    def back_plane(self):
+        if self._back_plane is None:
+            return Plane.from_frame(self.main_beam.opp_side(self.main_beam_ref_side_index))
+        return self._back_plane
 
     @property
     def main_beam_ref_side_index(self):
@@ -94,6 +105,35 @@ class LButtJoint(ButtJoint):
             raise BeamJoiningError(beams=self.elements, joint=self, debug_info="Beams are in I topology and reject_i flag is True")
 
         return ref_side_index
+
+    def add_extensions(self):
+        """Calculates and adds the necessary extensions to the beams.
+
+        Raises
+        ------
+        BeamJoiningError
+            If the extension could not be calculated.
+        """
+        super(LButtJoint, self).add_extensions()
+
+        if self.modify_cross:
+            assert self.main_beam and self.cross_beam
+            try:
+                start, end = self.cross_beam.extension_to_plane(self.back_plane)
+                extension_tolerance = 0
+                joint_id = self.guid
+                self.cross_beam.add_blank_extension(start + extension_tolerance, end + extension_tolerance, joint_id)
+            except AttributeError as ae:
+                raise BeamJoiningError(beams=self.elements, joint=self, debug_info=str(ae), debug_geometries=[self.back_plane])
+
+    def add_features(self):
+        """Removes this joint's previously generated features and adds new features to each beam."""
+        super(LButtJoint, self).add_features()
+
+        if self.modify_cross:
+            cross_refinement_feature = JackRafterCutProxy.from_plane_and_beam(self.back_plane, self.cross_beam, self.cross_beam_ref_side_index)
+            self.cross_beam.add_features(cross_refinement_feature)
+            self.features.append(cross_refinement_feature)
 
     @classmethod
     def create(

--- a/src/compas_timber/connections/t_butt.py
+++ b/src/compas_timber/connections/t_butt.py
@@ -56,6 +56,7 @@ class TButtJoint(ButtJoint):
             conical_tool=conical_tool,
             **kwargs,
         )
+        self.modify_cross = False
 
         self.fasteners = []
         if fastener:

--- a/src/compas_timber/connections/t_butt.py
+++ b/src/compas_timber/connections/t_butt.py
@@ -56,7 +56,6 @@ class TButtJoint(ButtJoint):
             conical_tool=conical_tool,
             **kwargs,
         )
-        self.modify_cross = False
 
         self.fasteners = []
         if fastener:

--- a/tests/compas_timber/test_t_butt_joint.py
+++ b/tests/compas_timber/test_t_butt_joint.py
@@ -56,13 +56,9 @@ def test_create_t_butt_with_depth():
 
 
 def test_t_butt_does_not_modify_cross_beam():
-    # regression test: TButtJoint must force modify_cross=False, otherwise it trims/extends
-    # the cross beam to the main beam's back plane, i.e. it behaves like an LButtJoint.
     beam_a = Beam.from_endpoints(Point(0, 0.5, 0), Point(1, 0.5, 0), z_vector=Vector(0, 0, 1), width=0.100, height=0.200)
     beam_b = Beam.from_endpoints(Point(0, 0.0, 0), Point(0, 1.0, 0), z_vector=Vector(0, 0, 1), width=0.100, height=0.200)
     joint = TButtJoint(beam_a, beam_b)
-
-    assert joint.modify_cross is False
 
     joint.add_features()
 
@@ -104,7 +100,7 @@ def non_planar_beam():
 
 
 def test_L_butt_joint_features_planar_lap(cross_beam, planar_beam):
-    joint = TButtJoint(planar_beam, cross_beam, mill_depth=10, modify_cross=False, force_pocket=False, conical_tool=False)
+    joint = TButtJoint(planar_beam, cross_beam, mill_depth=10, force_pocket=False, conical_tool=False)
     joint.add_features()
     assert len(cross_beam.features) == 1
     assert len(planar_beam.features) == 1
@@ -112,7 +108,7 @@ def test_L_butt_joint_features_planar_lap(cross_beam, planar_beam):
 
 
 def test_L_butt_joint_features_non_planar_lap(cross_beam, non_planar_beam):
-    joint = TButtJoint(non_planar_beam, cross_beam, mill_depth=10, modify_cross=False, force_pocket=False, conical_tool=False)
+    joint = TButtJoint(non_planar_beam, cross_beam, mill_depth=10, force_pocket=False, conical_tool=False)
     joint.add_features()
     assert len(cross_beam.features) == 1
     assert len(non_planar_beam.features) == 1
@@ -120,7 +116,7 @@ def test_L_butt_joint_features_non_planar_lap(cross_beam, non_planar_beam):
 
 
 def test_L_butt_joint_features_planar_pocket(cross_beam, planar_beam):
-    joint = TButtJoint(planar_beam, cross_beam, mill_depth=10, modify_cross=False, force_pocket=True, conical_tool=False)
+    joint = TButtJoint(planar_beam, cross_beam, mill_depth=10, force_pocket=True, conical_tool=False)
     joint.add_features()
     assert len(cross_beam.features) == 1
     assert len(planar_beam.features) == 1
@@ -128,7 +124,7 @@ def test_L_butt_joint_features_planar_pocket(cross_beam, planar_beam):
 
 
 def test_L_butt_joint_features_planar_pocket_conical_tool(cross_beam, planar_beam):
-    joint = TButtJoint(planar_beam, cross_beam, mill_depth=10, modify_cross=False, force_pocket=True, conical_tool=True)
+    joint = TButtJoint(planar_beam, cross_beam, mill_depth=10, force_pocket=True, conical_tool=True)
     joint.add_features()
     assert len(cross_beam.features) == 1
     assert len(planar_beam.features) == 1
@@ -136,7 +132,7 @@ def test_L_butt_joint_features_planar_pocket_conical_tool(cross_beam, planar_bea
 
 
 def test_L_butt_joint_features_non_planar_pocket(cross_beam, non_planar_beam):
-    joint = TButtJoint(non_planar_beam, cross_beam, mill_depth=10, modify_cross=False, force_pocket=True, conical_tool=False)
+    joint = TButtJoint(non_planar_beam, cross_beam, mill_depth=10, force_pocket=True, conical_tool=False)
     joint.add_features()
     assert len(cross_beam.features) == 1
     assert len(non_planar_beam.features) == 1
@@ -144,7 +140,7 @@ def test_L_butt_joint_features_non_planar_pocket(cross_beam, non_planar_beam):
 
 
 def test_L_butt_joint_features_non_planar_pocket_conical_tool(cross_beam, non_planar_beam):
-    joint = TButtJoint(non_planar_beam, cross_beam, mill_depth=10, modify_cross=False, force_pocket=True, conical_tool=True)
+    joint = TButtJoint(non_planar_beam, cross_beam, mill_depth=10, force_pocket=True, conical_tool=True)
     joint.add_features()
     assert len(cross_beam.features) == 1
     assert len(non_planar_beam.features) == 1

--- a/tests/compas_timber/test_t_butt_joint.py
+++ b/tests/compas_timber/test_t_butt_joint.py
@@ -11,6 +11,7 @@ from compas_timber.elements import PlateFastener
 from compas_timber.elements import FastenerTimberInterface
 from compas_timber.fabrication.pocket import Pocket
 from compas_timber.fabrication.lap import Lap
+from compas_timber.fabrication.jack_cut import JackRafterCut
 
 
 def test_create():
@@ -52,6 +53,22 @@ def test_create_t_butt_with_depth():
     beam_b = Beam.from_endpoints(Point(0, 0.0, 0), Point(0, 1.0, 0), z_vector=Vector(0, 0, 1), width=0.100, height=0.200)
     butt = TButtJoint(beam_a, beam_b, mill_depth=0.1)
     butt.add_features()
+
+
+def test_t_butt_does_not_modify_cross_beam():
+    # regression test: TButtJoint must force modify_cross=False, otherwise it trims/extends
+    # the cross beam to the main beam's back plane, i.e. it behaves like an LButtJoint.
+    beam_a = Beam.from_endpoints(Point(0, 0.5, 0), Point(1, 0.5, 0), z_vector=Vector(0, 0, 1), width=0.100, height=0.200)
+    beam_b = Beam.from_endpoints(Point(0, 0.0, 0), Point(0, 1.0, 0), z_vector=Vector(0, 0, 1), width=0.100, height=0.200)
+    joint = TButtJoint(beam_a, beam_b)
+
+    assert joint.modify_cross is False
+
+    joint.add_features()
+
+    assert len(beam_a.features) == 1
+    assert isinstance(beam_a.features[0], JackRafterCut)
+    assert len(beam_b.features) == 0
 
 
 @pytest.fixture

--- a/tests/compas_timber/test_t_butt_joint.py
+++ b/tests/compas_timber/test_t_butt_joint.py
@@ -11,7 +11,6 @@ from compas_timber.elements import PlateFastener
 from compas_timber.elements import FastenerTimberInterface
 from compas_timber.fabrication.pocket import Pocket
 from compas_timber.fabrication.lap import Lap
-from compas_timber.fabrication.jack_cut import JackRafterCut
 
 
 def test_create():

--- a/tests/compas_timber/test_t_butt_joint.py
+++ b/tests/compas_timber/test_t_butt_joint.py
@@ -67,7 +67,6 @@ def test_t_butt_does_not_modify_cross_beam():
     joint.add_features()
 
     assert len(beam_a.features) == 1
-    assert isinstance(beam_a.features[0], JackRafterCut)
     assert len(beam_b.features) == 0
 
 


### PR DESCRIPTION
* Fixed `TButtJoint` errorneously cutting cross beam even though `modify_cross` is set to `False`.
* Fix TButtJoint cutting/extending the cross beam under certain conditions, by moving modify_cross/back_plane out of the shared ButtJoint base into LButtJoint, where they're actually used.
- TButtJoint no longer has any trace of modify_cross (no attribute, constructor param, or serialized field) — it's structurally impossible for a T-Butt to modify the cross beam now, rather than relying on a hardcoded override.
 
### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).
