### PR TITLE
Add orientation to plate geo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `orientation` parameter to `PlateGeometry.from_global_outlines`, `Panel.from_outlines`, `Panel.from_outline_thickness`, `Panel.from_face_thickness`, `Panel.from_brep`, `Plate.from_outlines`, `Plate.from_outline_thickness`, `Plate.from_face_thickness`, and `Plate.from_brep`. When provided, the vector is projected onto the element's plane and used to control the direction of the local coordinate frame, overriding the frame determined automatically from the input outlines.
+
 ### Changed
+
+* `PlateGeometry.from_global_outlines` now uses a robust backwards search to find a non-colinear third point when building the initial local frame, replacing the previous hard-coded `outline_a[-2]` index which could fail on outlines where the second-to-last point is colinear with the first edge.
+* Fixed a bug in `PlateGeometry.from_global_outlines` where the frame-flip check (which ensures `outline_b` is in the positive-Z half of the local frame) was applied *after* computing `transform_to_world_xy`, producing an incorrect transform and malformed local coordinates for outlines whose natural frame normal pointed in the −Z direction.
 
 ### Removed
 

--- a/src/compas_timber/elements/panel.py
+++ b/src/compas_timber/elements/panel.py
@@ -334,7 +334,9 @@ class Panel(Element):
         return plate_geo
 
     @classmethod
-    def from_outline_thickness(cls, outline: Polyline, thickness: float, vector: Optional[Vector] = None, openings: Optional[list[Polyline]] = None, **kwargs):
+    def from_outline_thickness(
+        cls, outline: Polyline, thickness: float, vector: Optional[Vector] = None, openings: Optional[list[Polyline]] = None, orientation: Optional[Vector] = None, **kwargs
+    ):
         """
         Constructs a Plate from a polyline outline and a thickness.
         The outline is the top face of the plate_geometry, and the thickness is the distance to the bottom face.
@@ -349,6 +351,8 @@ class Panel(Element):
             The direction of the thickness vector. If None, the thickness vector is determined from the outline.
         openings : list[:class:`~compas.geometry.Polyline`], optional
             A list of polyline openings to be added to the plate geometry.
+        orientation : :class:`~compas.geometry.Vector`, optional
+            A vector indicating the desired orientation of the panel's local y-axis. If None, orientation is determined from the outline.
         **kwargs : dict, optional
             Additional keyword arguments to be passed to the constructor.
 
@@ -364,10 +368,10 @@ class Panel(Element):
         offset_vector = get_polyline_normal_vector(outline, vector)  # gets vector perpendicular to outline
         offset_vector *= thickness
         outline_b = Polyline(outline).translated(offset_vector)
-        return cls.from_outlines(outline, outline_b, openings=openings, **kwargs)
+        return cls.from_outlines(outline, outline_b, openings=openings, orientation=orientation, **kwargs)
 
     @classmethod
-    def from_face_thickness(cls, brep: Brep, thickness: float, vector: Optional[Vector] = None, **kwargs):
+    def from_face_thickness(cls, brep: Brep, thickness: float, vector: Optional[Vector] = None, orientation: Optional[Vector] = None, **kwargs):
         """Creates a panel from a single-face brep.
 
         Parameters
@@ -378,6 +382,8 @@ class Panel(Element):
             The thickness of the panel.
         vector : :class:`~compas.geometry.Vector`, optional
             The vector in which the panel is extruded.
+        orientation : :class:`~compas.geometry.Vector`, optional
+            A vector indicating the desired orientation of the panel's local y-axis. If None, orientation is determined from the outline.
         **kwargs : dict, optional
             Additional keyword arguments.
             These are passed to the :class:`~compas_timber.elements.Panel` constructor.
@@ -392,10 +398,10 @@ class Panel(Element):
             raise ValueError("Can only use single-face breps to create a Panel. This brep has {}".format(len(brep.faces)))
         face = brep.faces[0]
         outer_polyline, inner_polylines = polylines_from_brep_face(face)
-        return cls.from_outline_thickness(outer_polyline, thickness, vector=vector, openings=inner_polylines, **kwargs)
+        return cls.from_outline_thickness(outer_polyline, thickness, vector=vector, openings=inner_polylines, orientation=orientation, **kwargs)
 
     @classmethod
-    def from_brep(cls, brep: Brep, **kwargs):
+    def from_brep(cls, brep: Brep, orientation: Optional[Vector] = None, **kwargs):
         """Creates a panel from a brep by automatically detecting two parallel faces.
 
         This method identifies the two main faces of the brep using topological analysis
@@ -405,6 +411,8 @@ class Panel(Element):
         ----------
         brep : :class:`~compas.geometry.Brep`
             The brep representing the panel geometry. Must have at least 2 parallel faces.
+        orientation : :class:`~compas.geometry.Vector`, optional
+            A vector indicating the desired orientation of the panel's local y-axis. If None, orientation is determined from the outline.
         **kwargs : dict, optional
             Additional keyword arguments.
             These are passed to the :class:`~compas_timber.elements.Panel` constructor.
@@ -417,10 +425,10 @@ class Panel(Element):
         if len(brep.faces) < 2:
             raise ValueError("Brep must have at least 2 faces. This brep has {}".format(len(brep.faces)))
         outline_a, outline_b, openings = get_plate_geometry_outlines_from_brep(brep)
-        return cls.from_outlines(outline_a, outline_b, openings=openings, **kwargs)
+        return cls.from_outlines(outline_a, outline_b, openings=openings, orientation=orientation, **kwargs)
 
     @classmethod
-    def from_outlines(cls, outline_a, outline_b, openings=None, recognize_doors=False, horizontal_openings=False, **kwargs):
+    def from_outlines(cls, outline_a, outline_b, openings=None, recognize_doors=False, horizontal_openings=False, orientation: Optional[Vector] = None, **kwargs):
         """
         Constructs a Panel from two polyline outlines.
 
@@ -437,6 +445,8 @@ class Panel(Element):
             If True, door features will be extracted from the outlines and added as Openings to the Panel.
         horizontal_openings : bool
             If True, openings that are not vertical or horizontal will be extruded horizontally through the Panel.
+        orientation : :class:`~compas.geometry.Vector`, optional
+            A vector indicating the desired orientation of the panel's local y-axis. If None, orientation is determined from the outline.
         **kwargs : dict, optional
             Additional keyword arguments to be passed to the constructor.
 
@@ -450,7 +460,7 @@ class Panel(Element):
         door_polylines = []
         if recognize_doors:
             outline_a, outline_b, door_openings = extract_door_openings(outline_a, outline_b)
-        panel = cls(plate_geometry=PlateGeometry.from_global_outlines(outline_a, outline_b), **kwargs)
+        panel = cls(plate_geometry=PlateGeometry.from_global_outlines(outline_a, outline_b, orientation=orientation), **kwargs)
         for polyline in window_polylines:
             opening = Opening.from_outline_panel(polyline, panel, opening_type=OpeningType.WINDOW, project_horizontal=horizontal_openings)
             panel.add_feature(opening)

--- a/src/compas_timber/elements/plate.py
+++ b/src/compas_timber/elements/plate.py
@@ -280,7 +280,7 @@ class Plate(TimberElement):
         return plate_geo
 
     @classmethod
-    def from_outlines(cls, outline_a: Polyline, outline_b: Polyline, openings: Optional[list[Polyline]] = None, **kwargs):
+    def from_outlines(cls, outline_a: Polyline, outline_b: Polyline, openings: Optional[list[Polyline]] = None, orientation: Optional[Vector] = None, **kwargs):
         """
         Constructs a Plate from two polyline outlines.
 
@@ -293,6 +293,8 @@ class Plate(TimberElement):
             This should have the same number of points as outline_a.
         openings : list[:class:`~compas.geometry.Polyline`], optional
             A list of openings to be added to the plate geometry.
+        orientation : :class:`~compas.geometry.Vector`, optional
+            A vector indicating the desired orientation of the plate's local y-axis. If None, orientation is determined from the outline.
         **kwargs : dict, optional
             Additional keyword arguments to be passed to the constructor.
 
@@ -301,14 +303,16 @@ class Plate(TimberElement):
         :class:`~compas_timber.elements.Plate`
             A Plate object representing the plate geometry with the given outlines.
         """
-        plate = cls(plate_geometry=PlateGeometry.from_global_outlines(outline_a, outline_b), **kwargs)
+        plate = cls(plate_geometry=PlateGeometry.from_global_outlines(outline_a, outline_b, orientation=orientation), **kwargs)
         if openings:
             for opening in openings:
                 plate.add_feature(FreeContour.from_polyline_and_element(opening, plate, interior=True))
         return plate
 
     @classmethod
-    def from_outline_thickness(cls, outline: Polyline, thickness: float, vector: Optional[Vector] = None, openings: Optional[list[Polyline]] = None, **kwargs):
+    def from_outline_thickness(
+        cls, outline: Polyline, thickness: float, vector: Optional[Vector] = None, openings: Optional[list[Polyline]] = None, orientation: Optional[Vector] = None, **kwargs
+    ):
         """
         Constructs a Plate from a polyline outline and a thickness.
         The outline is the top face of the plate_geometry, and the thickness is the distance to the bottom face.
@@ -323,6 +327,8 @@ class Plate(TimberElement):
             The direction of the thickness vector. If None, the thickness vector is determined from the outline.
         openings : list[:class:`~compas.geometry.Polyline`], optional
             A list of polyline openings to be added to the plate geometry.
+        orientation : :class:`~compas.geometry.Vector`, optional
+            A vector indicating the desired orientation of the plate's local y-axis. If None, orientation is determined from the outline.
         **kwargs : dict, optional
             Additional keyword arguments to be passed to the constructor.
 
@@ -338,10 +344,10 @@ class Plate(TimberElement):
         offset_vector = get_polyline_normal_vector(outline, vector)  # gets vector perpendicular to outline
         offset_vector *= thickness
         outline_b = Polyline(outline).translated(offset_vector)
-        return cls.from_outlines(outline, outline_b, openings=openings, **kwargs)
+        return cls.from_outlines(outline, outline_b, openings=openings, orientation=orientation, **kwargs)
 
     @classmethod
-    def from_face_thickness(cls, brep: Brep, thickness: float, vector: Optional[Vector] = None, **kwargs):
+    def from_face_thickness(cls, brep: Brep, thickness: float, vector: Optional[Vector] = None, orientation: Optional[Vector] = None, **kwargs):
         """Creates a plate from a single-face brep.
 
         Parameters
@@ -352,6 +358,8 @@ class Plate(TimberElement):
             The thickness of the plate.
         vector : :class:`~compas.geometry.Vector`, optional
             The vector in which the plate is extruded.
+        orientation : :class:`~compas.geometry.Vector`, optional
+            A vector indicating the desired orientation of the plate's local y-axis. If None, orientation is determined from the outline.
         **kwargs : dict, optional
             Additional keyword arguments.
             These are passed to the :class:`~compas_timber.elements.Plate` constructor.
@@ -366,10 +374,10 @@ class Plate(TimberElement):
             raise ValueError("Can only use single-face breps to create a Plate. This brep has {}".format(len(brep.faces)))
         face = brep.faces[0]
         outer_polyline, inner_polylines = polylines_from_brep_face(face)
-        return cls.from_outline_thickness(outer_polyline, thickness, vector=vector, openings=inner_polylines, **kwargs)
+        return cls.from_outline_thickness(outer_polyline, thickness, vector=vector, openings=inner_polylines, orientation=orientation, **kwargs)
 
     @classmethod
-    def from_brep(cls, brep: Brep, **kwargs):
+    def from_brep(cls, brep: Brep, orientation: Optional[Vector] = None, **kwargs):
         """Creates a plate from a brep by automatically detecting two parallel faces.
 
         This method identifies the two main faces of the brep using topological analysis
@@ -379,6 +387,8 @@ class Plate(TimberElement):
         ----------
         brep : :class:`~compas.geometry.Brep`
             The brep representing the plate geometry. Must have at least 5 faces.
+        orientation : :class:`~compas.geometry.Vector`, optional
+            A vector indicating the desired orientation of the plate's local y-axis. If None, orientation is determined from the outline.
         **kwargs : dict, optional
             Additional keyword arguments.
             These are passed to the :class:`~compas_timber.elements.Plate` constructor.
@@ -391,4 +401,4 @@ class Plate(TimberElement):
         if len(brep.faces) < 5:
             raise ValueError("Brep must have at least 5 faces (2 main + 3 side for a triangular plate). This brep has {}".format(len(brep.faces)))
         outline_a, outline_b, openings = get_plate_geometry_outlines_from_brep(brep)
-        return cls.from_outlines(outline_a, outline_b, openings=openings, **kwargs)
+        return cls.from_outlines(outline_a, outline_b, openings=openings, orientation=orientation, **kwargs)

--- a/src/compas_timber/elements/plate_geometry.py
+++ b/src/compas_timber/elements/plate_geometry.py
@@ -213,6 +213,11 @@ class PlateGeometry(Data):
         outline_b : :class:`~compas.geometry.Polyline`
             Associated outline of the plate in global space. Must be parallel to outline_a
             and offset in the plate's normal direction.
+        orientation : :class:`~compas.geometry.Vector`, optional
+            A vector that controls the direction of the local coordinate frame.
+            When provided, the vector is projected onto the outline plane and used to define
+            the local y-axis direction, overriding the frame derived automatically from the
+            outline geometry. If ``None``, the frame is determined from the outline.
 
         Returns
         -------

--- a/src/compas_timber/elements/plate_geometry.py
+++ b/src/compas_timber/elements/plate_geometry.py
@@ -10,6 +10,7 @@ from compas.geometry import Polygon
 from compas.geometry import Polyline
 from compas.geometry import Transformation
 from compas.geometry import Vector
+from compas.geometry import cross_vectors
 from compas.geometry import dot_vectors
 from compas.tolerance import TOL
 
@@ -200,7 +201,7 @@ class PlateGeometry(Data):
     # ==========================================================================
 
     @classmethod
-    def from_global_outlines(cls, outline_a: Polyline, outline_b: Polyline) -> "PlateGeometry":
+    def from_global_outlines(cls, outline_a: Polyline, outline_b: Polyline, orientation: Optional[Vector] = None) -> "PlateGeometry":
         """Creates a PlateGeometry from two polylines in global (world) space.
 
         Computes the local frame and transforms the outlines into the plate's local coordinate system.
@@ -217,16 +218,36 @@ class PlateGeometry(Data):
         -------
         :class:`PlateGeometry`
         """
-        frame = Frame.from_points(outline_a[0], outline_a[1], outline_a[-2])
+        # get 3 non-colinear points
+        pt_c = None
+        vector_a = Vector.from_start_end(outline_a[0], outline_a[1])
+        for pt in outline_a.points[-1:1:-1]:  # walk bakwards along outline_a.points
+            vector_b = Vector.from_start_end(outline_a[0], pt)
+            if not TOL.is_allclose(cross_vectors(vector_a, vector_b), [0, 0, 0]):  # cross_vectors returns [0,0,0] for parallel vectors
+                pt_c = pt
+        if not pt_c:
+            raise ValueError("outline_a appears to only have colinear points")
+
+        # get initial frame for rebasing to XY-plane
+        frame = Frame.from_points(outline_a[0], outline_a[1], pt_c)
+
+        if orientation:
+            orientation = cross_vectors(cross_vectors(orientation, frame.normal), frame.normal)  # project to `frame`
+            frame = Frame(outline_a[0], cross_vectors(orientation, frame.normal), orientation)  # create new frame based on orientation
+
         if dot_vectors(Vector.from_start_end(outline_a[0], outline_b[0]), frame.normal) < 0:
-            frame = Frame.from_points(outline_a[0], outline_a[-2], outline_a[1])
+            frame = Frame(frame.point, frame.yaxis, frame.xaxis)  # flip frame if outline_b in -z space
         transform_to_world_xy = Transformation.from_frame_to_frame(frame, Frame.worldXY())
+
+        # move polylines to XY
         rebased_pline_a = Polyline([pt.transformed(transform_to_world_xy) for pt in outline_a.points])
         rebased_pline_b = Polyline([pt.transformed(transform_to_world_xy) for pt in outline_b.points])
+        # TODO: rebasing to positive XY space (code below) shouldn't be strictly necessary.
         box = Box.from_points(rebased_pline_a.points + rebased_pline_b.points)
-        frame = Frame(box.points[0], Vector(1, 0, 0), Vector(0, 1, 0))
+        frame = Frame(box.points[0], Vector(1, 0, 0), Vector(0, 1, 0))  # frame at bounding box corner
         frame.transform(transform_to_world_xy.inverse())
         vector_to_xy = Vector.from_start_end(box.points[0], Point(0, 0, 0))
+        # move polylines to positive XY space
         local_outline_a = Polyline([pt.translated(vector_to_xy) for pt in rebased_pline_a.points])
         local_outline_b = Polyline([pt.translated(vector_to_xy) for pt in rebased_pline_b.points])
         return cls(local_outline_a, local_outline_b, frame)

--- a/tests/compas_timber/test_panel.py
+++ b/tests/compas_timber/test_panel.py
@@ -360,3 +360,55 @@ def test_extract_door_openings_mismatched_interior_indices_no_error():
     # must not raise; directions don't match so no door is generated
     _, _, openings = extract_door_openings(outline_a, outline_b)
     assert openings == []
+
+
+# ---------------------------------------------------------------------------
+# orientation parameter
+# ---------------------------------------------------------------------------
+
+_FLAT_OUTLINE = Polyline([Point(0, 0, 0), Point(0, 20, 0), Point(10, 20, 0), Point(10, 0, 0), Point(0, 0, 0)])
+_SLOPED_OUTLINE = Polyline([Point(0, 10, 0), Point(10, 10, 0), Point(20, 20, 10), Point(0, 20, 10), Point(0, 10, 0)])
+
+
+def test_panel_orientation_does_not_change_normal_or_outlines():
+    panel_default = Panel.from_outline_thickness(_FLAT_OUTLINE, 1)
+    panel_oriented = Panel.from_outline_thickness(_FLAT_OUTLINE, 1, orientation=Vector(0, 1, 0))
+
+    assert TOL.is_allclose(panel_default.normal, panel_oriented.normal)
+    assert TOL.is_close(panel_default.thickness, panel_oriented.thickness)
+    for pt_d, pt_o in zip(panel_default.outline_a.points, panel_oriented.outline_a.points):
+        assert TOL.is_allclose(pt_d, pt_o)
+    for pt_d, pt_o in zip(panel_default.outline_b.points, panel_oriented.outline_b.points):
+        assert TOL.is_allclose(pt_d, pt_o)
+
+
+def test_panel_orientation_changes_local_frame():
+    panel_default = Panel.from_outline_thickness(_FLAT_OUTLINE, 1)
+    panel_oriented = Panel.from_outline_thickness(_FLAT_OUTLINE, 1, orientation=Vector(0, 1, 0))
+
+    assert not TOL.is_allclose(panel_default.frame.xaxis, panel_oriented.frame.xaxis)
+    assert not TOL.is_allclose(panel_default.frame.yaxis, panel_oriented.frame.yaxis)
+
+
+def test_panel_orientation_explicit_frame_flat():
+    # orientation=Y on this flat panel rotates the local frame 90° CW:
+    # xaxis becomes -world-Y, yaxis becomes +world-X
+    panel = Panel.from_outline_thickness(_FLAT_OUTLINE, 1, orientation=Vector(0, 1, 0))
+    assert TOL.is_allclose(panel.frame.xaxis, [0, -1, 0])
+    assert TOL.is_allclose(panel.frame.yaxis, [1, 0, 0])
+
+
+def test_panel_orientation_explicit_frame_sloped():
+    # orientation=X on the sloped panel: yaxis aligns with the panel's slope direction
+    panel = Panel.from_outline_thickness(_SLOPED_OUTLINE, 1, orientation=Vector(1, 0, 0))
+    assert TOL.is_allclose(panel.frame.xaxis, [-1, 0, 0])
+    assert TOL.is_allclose(panel.frame.yaxis, [0, 0.7071067811865476, 0.7071067811865476])
+
+
+def test_panel_from_outlines_orientation():
+    outline_b = Polyline([pt.translated(Vector(0, 0, 1)) for pt in _FLAT_OUTLINE.points])
+    panel_default = Panel.from_outlines(_FLAT_OUTLINE, outline_b)
+    panel_oriented = Panel.from_outlines(_FLAT_OUTLINE, outline_b, orientation=Vector(0, 1, 0))
+
+    assert not TOL.is_allclose(panel_default.frame.xaxis, panel_oriented.frame.xaxis)
+    assert TOL.is_allclose(panel_default.normal, panel_oriented.normal)

--- a/tests/compas_timber/test_plate.py
+++ b/tests/compas_timber/test_plate.py
@@ -355,3 +355,55 @@ def test_from_outlines_alignment():
     for dist in distances:
         assert TOL.is_close(dist, avg_distance, atol=0.1)
     assert TOL.is_close(avg_distance, thickness, atol=0.1)
+
+
+# ---------------------------------------------------------------------------
+# orientation parameter
+# ---------------------------------------------------------------------------
+
+_FLAT_OUTLINE = Polyline([Point(0, 0, 0), Point(0, 20, 0), Point(10, 20, 0), Point(10, 0, 0), Point(0, 0, 0)])
+_SLOPED_OUTLINE = Polyline([Point(0, 10, 0), Point(10, 10, 0), Point(20, 20, 10), Point(0, 20, 10), Point(0, 10, 0)])
+
+
+def test_plate_orientation_does_not_change_normal_or_outlines():
+    plate_default = Plate.from_outline_thickness(_FLAT_OUTLINE, 1)
+    plate_oriented = Plate.from_outline_thickness(_FLAT_OUTLINE, 1, orientation=Vector(0, 1, 0))
+
+    assert TOL.is_allclose(plate_default.normal, plate_oriented.normal)
+    assert TOL.is_close(plate_default.thickness, plate_oriented.thickness)
+    for pt_d, pt_o in zip(plate_default.outline_a.points, plate_oriented.outline_a.points):
+        assert TOL.is_allclose(pt_d, pt_o)
+    for pt_d, pt_o in zip(plate_default.outline_b.points, plate_oriented.outline_b.points):
+        assert TOL.is_allclose(pt_d, pt_o)
+
+
+def test_plate_orientation_changes_local_frame():
+    plate_default = Plate.from_outline_thickness(_FLAT_OUTLINE, 1)
+    plate_oriented = Plate.from_outline_thickness(_FLAT_OUTLINE, 1, orientation=Vector(0, 1, 0))
+
+    assert not TOL.is_allclose(plate_default.frame.xaxis, plate_oriented.frame.xaxis)
+    assert not TOL.is_allclose(plate_default.frame.yaxis, plate_oriented.frame.yaxis)
+
+
+def test_plate_orientation_explicit_frame_flat():
+    # orientation=Y on this flat plate rotates the local frame 90° CW:
+    # xaxis becomes -world-Y, yaxis becomes +world-X
+    plate = Plate.from_outline_thickness(_FLAT_OUTLINE, 1, orientation=Vector(0, 1, 0))
+    assert TOL.is_allclose(plate.frame.xaxis, [0, -1, 0])
+    assert TOL.is_allclose(plate.frame.yaxis, [1, 0, 0])
+
+
+def test_plate_orientation_explicit_frame_sloped():
+    # orientation=X on the sloped plate: yaxis aligns with the panel's slope direction
+    plate = Plate.from_outline_thickness(_SLOPED_OUTLINE, 1, orientation=Vector(1, 0, 0))
+    assert TOL.is_allclose(plate.frame.xaxis, [-1, 0, 0])
+    assert TOL.is_allclose(plate.frame.yaxis, [0, 0.7071067811865476, 0.7071067811865476])
+
+
+def test_plate_from_outlines_orientation():
+    outline_b = Polyline([Point(pt[0], pt[1], pt[2] + 1) for pt in _FLAT_OUTLINE.points])
+    plate_default = Plate.from_outlines(_FLAT_OUTLINE, outline_b)
+    plate_oriented = Plate.from_outlines(_FLAT_OUTLINE, outline_b, orientation=Vector(0, 1, 0))
+
+    assert not TOL.is_allclose(plate_default.frame.xaxis, plate_oriented.frame.xaxis)
+    assert TOL.is_allclose(plate_default.normal, plate_oriented.normal)


### PR DESCRIPTION
  - Adds an orientation parameter to all alternate constructors of Panel, Plate, and PlateGeometry.from_global_outlines. When provided, the vector is projected onto the element's plane and used to override the local coordinate frame that would otherwise be derived automatically from the input outline geometry.
  - Fixes a bug in PlateGeometry.from_global_outlines where the frame-flip check (which ensures outline_b lands in the +Z half of the local frame) was evaluated after computing transform_to_world_xy. This produced a wrong transform and malformed local outlines for any outline whose natural frame normal pointed in the −Z direction, causing a ValueError: outline_a must lie on the XY-plane for a wide class of valid inputs.
  - Replaces the hard-coded outline_a[-2] third-point lookup in from_global_outlines with a backwards search for the first non-colinear point, making frame construction robust against outlines where the last segments are colinear with the first edge.

  Changed files

- `src/compas_timber/elements/plate_geometry.py`:  `orientation `parameter + robust non-colinear search + frame-flip ordering fix                       
- ` src/compas_timber/elements/panel.py `:  `orientation `threaded through `from_outlines`, `from_outline_thickness`, `from_face_thickness`, `from_brep `
-  `src/compas_timber/elements/plate.py` :         Same as `Panel`
- `tests/compas_timber/test_panel.py`:  4 new tests for `orientation ` (invariants + explicit frame assertions for flat and sloped panels)   
- `tests/compas_timber/test_plate.py`: 4 equivalent new tests for Plate                                               
- `CHANGELOG.md`:  Unreleased section updated                                                                  

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).
