### PR TITLE
added **kwargs passthrough to Beam constructors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-
+* Added `**kwargs` passthrough to all `Beam` constructors.
 * Fixed `TButtJoint` erroneously cutting cross beam even though `modify_cross` is set to `False`.
 
 ### Removed

--- a/src/compas_timber/elements/beam.py
+++ b/src/compas_timber/elements/beam.py
@@ -234,7 +234,7 @@ class Beam(TimberElement):
     # ==========================================================================
 
     @classmethod
-    def from_centerline(cls, centerline, width, height, z_vector=None):
+    def from_centerline(cls, centerline, width, height, z_vector=None, **kwargs):
         """Define the beam from its centerline.
 
         Parameters
@@ -264,10 +264,10 @@ class Beam(TimberElement):
         frame = Frame(centerline.start, x_vector, y_vector)
         length = centerline.length
 
-        return cls(frame, length, width, height)
+        return cls(frame, length, width, height, **kwargs)
 
     @classmethod
-    def from_endpoints(cls, point_start, point_end, width, height, z_vector=None):
+    def from_endpoints(cls, point_start, point_end, width, height, z_vector=None, **kwargs):
         """Creates a Beam from the given endpoints.
 
         Parameters
@@ -290,10 +290,10 @@ class Beam(TimberElement):
 
         """
         line = Line(point_start, point_end)
-        return cls.from_centerline(line, width, height, z_vector)
+        return cls.from_centerline(line, width, height, z_vector, **kwargs)
 
     @classmethod
-    def from_box(cls, box):
+    def from_box(cls, box, **kwargs):
         """Define the beam from a box.
 
         Parameters
@@ -316,7 +316,7 @@ class Beam(TimberElement):
             raise ValueError("The given box has zero height along its z-axis. Check the box dimensions.")
         origin = box.frame.point + box.frame.xaxis * (-box.xsize / 2.0)
         frame = Frame(origin, box.frame.xaxis, box.frame.yaxis)
-        return cls(frame, box.xsize, box.ysize, box.zsize)
+        return cls(frame, box.xsize, box.ysize, box.zsize, **kwargs)
 
     # ==========================================================================
     # Extensions and Modifications


### PR DESCRIPTION
This adds `**kwargs` passthrough to `Beam` constructors.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).
