### PR TITLE
Model panel updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `TimberModel.unpromoted_joint_candidates` property — returns the subset of joint candidates that do not yet have a joint assigned on their edge.
+* Added `TimberModel.process_panel_joinery()` — processes only `PanelJoint` instances (extensions → `apply_edge_extensions` on panels → features), mirroring the existing `process_joinery` flow for beam joints.
+
 ### Changed
+
+* `TimberModel.process_joinery()` now skips `PanelJoint` instances. Use `process_panel_joinery()` to process panel-specific joints.
 
 ### Removed
 

--- a/src/compas_timber/model.py
+++ b/src/compas_timber/model.py
@@ -18,7 +18,6 @@ from compas_timber.connections import PanelJoint
 from compas_timber.connections import PlateConnectionSolver
 from compas_timber.connections import PlateJoint
 from compas_timber.connections import PlateJointCandidate
-from compas_timber.base import TimberElement
 from compas_timber.elements import Beam
 from compas_timber.elements import Fastener
 from compas_timber.elements import Panel
@@ -779,6 +778,7 @@ class TimberModel(Model):
                 if stop_on_first_error:
                     raise bje
         return errors
+
     # =============================================================================
     # Model sub-tree surgery
     # =============================================================================

--- a/src/compas_timber/model.py
+++ b/src/compas_timber/model.py
@@ -589,7 +589,7 @@ class TimberModel(Model):
 
         """
         errors = []
-        joints = self.joints
+        joints = [j for j in self.joints if not isinstance(j, PanleJoint)]
 
         for joint in joints:
             try:

--- a/src/compas_timber/model.py
+++ b/src/compas_timber/model.py
@@ -18,6 +18,7 @@ from compas_timber.connections import PanelJoint
 from compas_timber.connections import PlateConnectionSolver
 from compas_timber.connections import PlateJoint
 from compas_timber.connections import PlateJointCandidate
+from compas_timber.base import TimberElement
 from compas_timber.elements import Beam
 from compas_timber.elements import Fastener
 from compas_timber.elements import Panel
@@ -129,6 +130,16 @@ class TimberModel(Model):
         for edge in self._graph.edges():
             edge_candidate = self._graph.edge_attribute(edge, "candidates")
             if edge_candidate is not None:
+                candidates.add(edge_candidate)
+        return candidates
+
+    @property
+    def unpromoted_joint_candidates(self) -> set[JointCandidate]:
+        candidates = set()
+        for edge in self._graph.edges():
+            edge_candidate = self._graph.edge_attribute(edge, "candidates")
+            joint = self._graph.edge_attribute(edge, "joints")
+            if edge_candidate and not joint:
                 candidates.add(edge_candidate)
         return candidates
 
@@ -589,7 +600,7 @@ class TimberModel(Model):
 
         """
         errors = []
-        joints = [j for j in self.joints if not isinstance(j, PanleJoint)]
+        joints = [j for j in self.joints if not isinstance(j, PanelJoint)]
 
         for joint in joints:
             try:
@@ -722,6 +733,52 @@ class TimberModel(Model):
             candidate = PlateJointCandidate(result.plate_a, result.plate_b, **kwargs)
             self.add_joint_candidate(candidate)
 
+    def process_panel_joinery(self, stop_on_first_error=False):
+        """Process the joinery of the model. This methods checks the feasibility of the joints and instructs all joints to add their extensions and features.
+
+        The sequence is important here since the feature parameters must be calculated based on the extended blanks.
+        For this reason, the first iteration will only extend the beams, and the second iteration will add the features.
+
+        Parameters
+        ----------
+        stop_on_first_error : bool, optional
+            If True, the method will raise an exception on the first error it encounters. Default is False.
+
+        Returns
+        -------
+        list[:class:`~compas_timber.errors.BeamJoiningError`]
+            A list of errors that occurred during the joinery process.
+
+        """
+        errors = []
+        joints = [j for j in self.joints if isinstance(j, PanelJoint)]
+
+        for joint in joints:
+            try:
+                joint.check_elements_compatibility(joint.elements)  # TODO: is this necessary here? This should be done at joint creation.
+                joint.add_extensions()
+            except BeamJoiningError as bje:
+                errors.append(bje)
+                if stop_on_first_error:
+                    raise bje
+
+        for panel in self.panels:
+            panel.apply_edge_extensions()
+
+        for joint in joints:
+            try:
+                joint.add_features()
+            except BeamJoiningError as bje:
+                errors.append(bje)
+                if stop_on_first_error:
+                    raise bje
+
+            except ValueError as ve:
+                bje = BeamJoiningError(joint.elements, joint, debug_info=str(ve))
+                errors.append(bje)
+                if stop_on_first_error:
+                    raise bje
+        return errors
     # =============================================================================
     # Model sub-tree surgery
     # =============================================================================

--- a/tests/compas_timber/test_model.py
+++ b/tests/compas_timber/test_model.py
@@ -15,8 +15,11 @@ from compas_timber.connections import LButtJoint
 from compas_timber.connections import TButtJoint
 from compas_timber.connections import JointCandidate
 from compas_timber.connections import JointTopology
+from compas_timber.connections import PanelMiterJoint
+from compas_timber.connections import PlateConnectionSolver
 from compas.geometry import Line
 from compas_timber.elements import Beam
+from compas_timber.elements import Panel
 from compas_timber.elements import Plate
 from compas_timber.model import TimberModel
 
@@ -518,3 +521,100 @@ def test_element_by_guid_deprecated_warning(mocker):
     _ = model.element_by_guid(str(beam.guid))
 
     warn_spy.assert_called_once()
+
+
+# =============================================================================
+# unpromoted_joint_candidates
+# =============================================================================
+
+
+def _two_panel_model_with_miter_joint():
+    polyline_a = Polyline([Point(0, 0, 0), Point(0, 10, 0), Point(10, 10, 0), Point(10, 0, 0), Point(0, 0, 0)])
+    polyline_b = Polyline([Point(0, 10, 0), Point(10, 10, 0), Point(20, 20, 10), Point(0, 20, 10), Point(0, 10, 0)])
+    panel_a = Panel.from_outline_thickness(Polyline(list(polyline_a.points)), 1)
+    panel_b = Panel.from_outline_thickness(Polyline(list(polyline_b.points)), 1)
+    model = TimberModel()
+    model.add_elements([panel_a, panel_b])
+    cs = PlateConnectionSolver()
+    tr = cs.find_topology(panel_a, panel_b)
+    joint = PanelMiterJoint.create(model, tr.plate_a, tr.plate_b, topology=tr.topology, a_segment_index=tr.a_segment_index, b_segment_index=tr.b_segment_index)
+    return model, panel_a, panel_b, joint
+
+
+def test_unpromoted_joint_candidates_empty():
+    model = TimberModel()
+    b1 = Beam(Frame.worldXY(), length=1.0, width=0.1, height=0.1)
+    b2 = Beam(Frame.worldYZ(), length=1.0, width=0.1, height=0.1)
+    model.add_element(b1)
+    model.add_element(b2)
+    assert len(model.unpromoted_joint_candidates) == 0
+
+
+def test_unpromoted_joint_candidates_returns_candidate_without_joint():
+    model = TimberModel()
+    b1 = Beam(Frame.worldXY(), length=1.0, width=0.1, height=0.1)
+    b2 = Beam(Frame.worldYZ(), length=1.0, width=0.1, height=0.1)
+    model.add_element(b1)
+    model.add_element(b2)
+    model.connect_adjacent_beams()
+    unpromoted = model.unpromoted_joint_candidates
+    assert len(unpromoted) == 1
+
+
+def test_unpromoted_joint_candidates_excludes_promoted():
+    model = TimberModel()
+    b1 = Beam(Frame.worldXY(), length=1.0, width=0.1, height=0.1)
+    b2 = Beam(Frame.worldYZ(), length=1.0, width=0.1, height=0.1)
+    b3 = Beam(Frame.worldZX(), length=1.0, width=0.1, height=0.1)
+    model.add_element(b1)
+    model.add_element(b2)
+    model.add_element(b3)
+
+    model.connect_adjacent_beams()
+    assert len(model.unpromoted_joint_candidates) == 3
+
+    LButtJoint.create(model, b1, b2)
+
+    assert len(model.unpromoted_joint_candidates) == 2
+
+
+# =============================================================================
+# process_joinery / process_panel_joinery separation
+# =============================================================================
+
+
+def test_process_joinery_skips_panel_joints(mocker):
+    model, _, _, _ = _two_panel_model_with_miter_joint()
+    mock_add_extensions = mocker.patch.object(PanelMiterJoint, "add_extensions")
+    mock_add_features = mocker.patch.object(PanelMiterJoint, "add_features")
+    model.process_joinery()
+    mock_add_extensions.assert_not_called()
+    mock_add_features.assert_not_called()
+
+
+def test_process_panel_joinery_returns_list():
+    model = TimberModel()
+    errors = model.process_panel_joinery()
+    assert isinstance(errors, list)
+    assert len(errors) == 0
+
+
+def test_process_panel_joinery_calls_extensions_and_features(mocker):
+    model, _, _, _ = _two_panel_model_with_miter_joint()
+    mock_add_extensions = mocker.patch.object(PanelMiterJoint, "add_extensions")
+    mock_add_features = mocker.patch.object(PanelMiterJoint, "add_features")
+    model.process_panel_joinery()
+    mock_add_extensions.assert_called_once()
+    mock_add_features.assert_called_once()
+
+
+def test_process_panel_joinery_skips_beam_joints(mocker):
+    model = TimberModel()
+    b1 = Beam(Frame.worldXY(), length=1.0, width=0.1, height=0.1)
+    b2 = Beam(Frame.worldYZ(), length=1.0, width=0.1, height=0.1)
+    model.add_element(b1)
+    model.add_element(b2)
+    LButtJoint.create(model, b1, b2)
+    mock_add_features = mocker.patch.object(LButtJoint, "add_features")
+    model.process_panel_joinery()
+    mock_add_features.assert_not_called()


### PR DESCRIPTION
  **Summary**

  - Added `TimberModel.unpromoted_joint_candidates` property — returns the subset of joint candidates on graph edges that do not yet have a joint assigned. Useful for workflow steps that need to identify which candidates still need to be resolved.
  - Added `TimberModel.process_panel_joinery()` — a dedicated processing pipeline for `PanelJoint` instances. Follows the same extension → `apply_edge_extensions` → features sequence already used for beam joints.
  - `TimberModel.process_joinery()` now explicitly excludes `PanelJoint` instances, so beam and panel joinery can be processed independently.

  **Motivation**

  - Panel Population relies on `PaneJoint`s and their `PanelConnectionInterface` being present at time of population. The general workflow should now be: 

1. add elements to model.
2. join panels and add extensions and features to panels
3. populate panels and add timber elements back to model.
4. join timber elements.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).
