### PR TITLE
bugs in lap and xnotch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * Fixed a bug that prevented `FrenchRidgeLapJoint` from adding extensions to beams.
+* Fixed `Lap.from_shapes_and_element` calling a non-existent method; it now correctly defers to `LapProxy.from_volume_and_beam`.
+* Fixed `XNotchJoint.add_features` referencing non-existent `main_beam` / `cross_beam` attributes instead of `notch_beam` / `solid_beam`.
+* Fixed `Lap._sort_planes` and `Pocket._sort_planes` reusing the same plane for two roles (e.g. `start_plane` and `front_plane`) when a plane had the minimum dot product on two axes, causing `intersection_plane_plane_plane` to fail for non-axis-aligned volumes.
 
 * `PlateGeometry.from_global_outlines` now uses a robust backwards search to find a non-colinear third point when building the initial local frame, fixing a failure on outlines where the second-to-last point is colinear with the first edge.
 * Fixed a bug in `PlateGeometry.from_global_outlines` where the frame-flip check was applied after computing `transform_to_world_xy`, producing an incorrect transform for outlines whose natural frame normal pointed in the −Z direction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed a bug that prevented `FrenchRidgeLapJoint` from adding extensions to beams.
 * Fixed `Lap.from_shapes_and_element` calling a non-existent method; it now correctly defers to `LapProxy.from_volume_and_beam`.
 * Fixed `XNotchJoint.add_features` referencing non-existent `main_beam` / `cross_beam` attributes instead of `notch_beam` / `solid_beam`.
-* Fixed `Lap._sort_planes` and `Pocket._sort_planes` reusing the same plane for two roles (e.g. `start_plane` and `front_plane`) when a plane had the minimum dot product on two axes, causing `intersection_plane_plane_plane` to fail for non-axis-aligned volumes.
+* Fixed `Lap.from_volume_and_beam` reusing the same plane for two roles (e.g. `start_plane` and `front_plane`) when a plane had the minimum dot product on two axes, causing it to fail for non-axis-aligned volumes.
 
 * `PlateGeometry.from_global_outlines` now uses a robust backwards search to find a non-colinear third point when building the initial local frame, fixing a failure on outlines where the second-to-last point is colinear with the first edge.
 * Fixed a bug in `PlateGeometry.from_global_outlines` where the frame-flip check was applied after computing `transform_to_world_xy`, producing an incorrect transform for outlines whose natural frame normal pointed in the −Z direction.

--- a/src/compas_timber/connections/x_notch.py
+++ b/src/compas_timber/connections/x_notch.py
@@ -105,18 +105,18 @@ class XNotchJoint(Joint):
         This method is automatically called when joint is created by the call to `Joint.create()`.
 
         """
-        assert self.main_beam and self.cross_beam
+        assert self.notch_beam and self.solid_beam
 
         if self.features:
-            self.main_beam.remove_features(self.features)
-            self.cross_beam.remove_features(self.features)
+            self.notch_beam.remove_features(self.features)
+            self.solid_beam.remove_features(self.features)
 
         # create pocket features
         negative_volume = self._create_negative_volume()
-        pocket_feature = PocketProxy.from_volume_and_element(negative_volume, self.main_beam, ref_side_index=self.main_ref_side_index)
+        pocket_feature = PocketProxy.from_volume_and_element(negative_volume, self.notch_beam, ref_side_index=self.main_ref_side_index)
 
         # add features to the beams
-        self.main_beam.add_features(pocket_feature)
+        self.notch_beam.add_features(pocket_feature)
 
         # register processings to the joint
         self.features.append(pocket_feature)

--- a/src/compas_timber/fabrication/lap.py
+++ b/src/compas_timber/fabrication/lap.py
@@ -521,7 +521,7 @@ class Lap(BTLxProcessing):
             The Lap feature.
 
         """
-        return cls.from_volume_and_element(volume, element, **kwargs)
+        return LapProxy.from_volume_and_beam(volume, element, **kwargs)
 
     @staticmethod
     def _calculate_orientation(ref_side, plane):
@@ -592,16 +592,18 @@ class Lap(BTLxProcessing):
     @staticmethod
     def _sort_planes(planes, ref_side):
         # Sort planes based on the dot product of face normals with the x-axis
-        planes.sort(key=lambda plane: plane.normal.dot(ref_side.xaxis))
-        start_plane, end_plane = planes[0], planes[-1]
+        by_x = sorted(planes, key=lambda plane: plane.normal.dot(ref_side.xaxis))
+        start_plane, end_plane = by_x[0], by_x[-1]
+        remaining = by_x[1:-1]
 
         # Sort planes based on the dot product of face normals with the y-axis
-        planes.sort(key=lambda plane: plane.normal.dot(ref_side.yaxis))
-        front_plane, back_plane = planes[0], planes[-1]
+        by_y = sorted(remaining, key=lambda plane: plane.normal.dot(ref_side.yaxis))
+        front_plane, back_plane = by_y[0], by_y[-1]
+        remaining = by_y[1:-1]
 
         # Sort planes based on the dot product of face normals with the z-axis
-        planes.sort(key=lambda plane: plane.normal.dot(ref_side.zaxis))
-        bottom_plane, top_plane = planes[0], planes[-1]
+        by_z = sorted(remaining, key=lambda plane: plane.normal.dot(ref_side.zaxis))
+        bottom_plane, top_plane = by_z[0], by_z[-1]
 
         return start_plane, end_plane, front_plane, back_plane, bottom_plane, top_plane
 

--- a/src/compas_timber/fabrication/lap.py
+++ b/src/compas_timber/fabrication/lap.py
@@ -521,7 +521,7 @@ class Lap(BTLxProcessing):
             The Lap feature.
 
         """
-        return LapProxy.from_volume_and_beam(volume, element, **kwargs)
+        return cls.from_volume_and_beam(volume, element, **kwargs)
 
     @staticmethod
     def _calculate_orientation(ref_side, plane):

--- a/src/compas_timber/fabrication/pocket.py
+++ b/src/compas_timber/fabrication/pocket.py
@@ -472,16 +472,18 @@ class Pocket(BTLxProcessing):
     @staticmethod
     def _sort_planes(planes, ref_side) -> list[Plane]:
         # Sort planes based on the dot product of face normals with the x-axis
-        planes.sort(key=lambda plane: plane.normal.dot(ref_side.xaxis))
-        start_plane, end_plane = planes[0], planes[-1]
+        by_x = sorted(planes, key=lambda plane: plane.normal.dot(ref_side.xaxis))
+        start_plane, end_plane = by_x[0], by_x[-1]
+        remaining = by_x[1:-1]
 
         # Sort planes based on the dot product of face normals with the y-axis
-        planes.sort(key=lambda plane: plane.normal.dot(ref_side.yaxis))
-        front_plane, back_plane = planes[0], planes[-1]
+        by_y = sorted(remaining, key=lambda plane: plane.normal.dot(ref_side.yaxis))
+        front_plane, back_plane = by_y[0], by_y[-1]
+        remaining = by_y[1:-1]
 
         # Sort planes based on the dot product of face normals with the z-axis
-        planes.sort(key=lambda plane: plane.normal.dot(ref_side.zaxis))
-        bottom_plane, top_plane = planes[0], planes[-1]
+        by_z = sorted(remaining, key=lambda plane: plane.normal.dot(ref_side.zaxis))
+        bottom_plane, top_plane = by_z[0], by_z[-1]
 
         return start_plane, end_plane, front_plane, back_plane, bottom_plane, top_plane
 


### PR DESCRIPTION
Fixes three `AttributeError`/`TypeError` bugs found while updating the Grasshopper components for the `timber_design` plugin. All three surfaced during `Model.process_joinery()` or `BTLxFromGeometryDefinition.feature_from_element()`:

1. `Lap.from_shapes_and_element` called a non-existent `from_volume_and_element` method on `Lap`. It now defers to `LapProxy.from_volume_and_beam`, consistent with how all other lap-based joints construct their features (deferred proxy, geometry applied by direct volume subtraction, BTLx params computed on demand).
2. `XNotchJoint.add_features` referenced `self.main_beam` / `self.cross_beam`, which don't exist — the joint stores its elements as `self.notch_beam` / `self.solid_beam`.
3. `Lap._sort_planes` and `Pocket._sort_planes` sorted the same plane list in place across three axes, so for non-axis-aligned volumes a single plane could be assigned to two roles (e.g. both `start_plane` and `front_plane`). Passing the same plane twice into `intersection_plane_plane_plane` returns `None`, which raised a `TypeError` caught upstream as `ValueError("Failed to orient the volume...")`. Fixed by shrinking the candidate pool after each axis is assigned so no plane can be reused.

(A fourth bug — `LFrenchRidgeLapJoint.add_extensions` referencing nonexistent `beam_a_guid`/`beam_b_guid` — was already fixed on `main` via #759.)

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).
