### PR TITLE
Reset `joint._location` when joint removed from model.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+* `model.remove_joint()` now calls `joint.reset_location()`, which clears the joint's cached location and allows it to be recomputed if needed.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `Joint.reset_location()`, which clears the joint's cached location and allows it to be recomputed if needed.
 
 ### Changed
-* `TimbberModel.remove_joint()` now calls `Joint.reset_location()`.
+* `TimberModel.remove_joint()` now calls `Joint.reset_location()`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+* Added `Joint.reset_location()`, which clears the joint's cached location and allows it to be recomputed if needed.
 
 ### Changed
-* `model.remove_joint()` now calls `joint.reset_location()`, which clears the joint's cached location and allows it to be recomputed if needed.
+* `TimbberModel.remove_joint()` now calls `Joint.reset_location()`.
 
 ### Removed
 

--- a/src/compas_timber/connections/joint.py
+++ b/src/compas_timber/connections/joint.py
@@ -151,6 +151,10 @@ class Joint(Data):
             raise TypeError("Location must be a Point.")
         self._location = value
 
+    def reset_location(self):
+        """Reset cached joint.location value to None so that it will be recalculated from the beam centerlines on next access."""
+        self._location = None
+
     @property
     def generated_elements(self):
         return []

--- a/src/compas_timber/model.py
+++ b/src/compas_timber/model.py
@@ -523,6 +523,7 @@ class TimberModel(Model):
             self.remove_interaction(element_a, element_b)
         for element in joint.generated_elements:
             self.remove_element(element)
+        joint.reset_location()
 
     def remove_interaction(self, a, b, _=None):
         """Remove the interaction between two elements.

--- a/tests/compas_timber/test_model_subtree.py
+++ b/tests/compas_timber/test_model_subtree.py
@@ -95,12 +95,13 @@ def test_remove_element_subtree_clears_cache_on_removed_elements():
 def test_remove_element_subtree_removes_joints_spanning_only_descendants(mocker):
     mocker.patch("compas_timber.connections.LButtJoint.add_features")
     model, panel, beam_a, beam_b = _hierarchy_model()
-    LButtJoint.create(model, beam_a, beam_b)
+    joint = LButtJoint.create(model, beam_a, beam_b)
     assert len(list(model.joints)) == 1
-
+    assert joint.location is not None
     model.remove_element_subtree(panel)
 
     assert len(list(model.joints)) == 0
+    assert joint._location is None
 
 
 def test_remove_element_subtree_leaf_element():


### PR DESCRIPTION
This is a small change that clears cached `Joint._location` value so that it can be recomputed when called next. 

added `Joint.reset_location()`.
called this in `model.remove_joint()`.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).
