### PR TITLE
fix frame creation in `PlateGeometry.from_global_outlines`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+* Fixed a bug in `PlateGeometry.from_global_outlines` where the frame-flip was applied incorrectly when the initial local frame's normal pointed in the −Z direction.
 
 ### Removed
 

--- a/src/compas_timber/elements/plate_geometry.py
+++ b/src/compas_timber/elements/plate_geometry.py
@@ -237,11 +237,12 @@ class PlateGeometry(Data):
         frame = Frame.from_points(outline_a[0], outline_a[1], pt_c)
 
         if orientation:
-            orientation = cross_vectors(cross_vectors(orientation, frame.normal), frame.normal)  # project to `frame`
-            frame = Frame(outline_a[0], cross_vectors(orientation, frame.normal), orientation)  # create new frame based on orientation
+            frame_x = cross_vectors(orientation, frame.normal)
+            frame_y = cross_vectors(frame.normal, frame_x)
+            frame = Frame(outline_a[0], frame_x, frame_y)  # create new frame based on orientation
 
         if dot_vectors(Vector.from_start_end(outline_a[0], outline_b[0]), frame.normal) < 0:
-            frame = Frame(frame.point, frame.yaxis, frame.xaxis)  # flip frame if outline_b in -z space
+            frame = Frame(frame.point, -frame.xaxis, frame.yaxis)  # flip frame if outline_b in -z space
         transform_to_world_xy = Transformation.from_frame_to_frame(frame, Frame.worldXY())
 
         # move polylines to XY

--- a/tests/compas_timber/test_free_contour.py
+++ b/tests/compas_timber/test_free_contour.py
@@ -26,8 +26,10 @@ def test_plate_blank():
 
     assert len(plate.features) == 1
     assert isinstance(plate.features[0], FreeContour)
-    assert TOL.is_zero(plate.blank.xsize - 100.0)  # x-axis is the vector from `plate.outline[0]` to `plate.outline[1]`
-    assert TOL.is_zero(plate.blank.ysize - 200.0)
+    # x-axis is the vector from `plate.outline[0]` to `plate.outline[1]`, which here is (0, 200, 0):
+    # local x follows that direction (not necessarily world x), so xsize tracks the 200-long edge.
+    assert TOL.is_zero(plate.blank.xsize - 200.0)
+    assert TOL.is_zero(plate.blank.ysize - 100.0)
     assert TOL.is_zero(plate.blank.zsize - 10.0)
 
 
@@ -37,8 +39,9 @@ def test_plate_blank_reversed():
 
     assert len(plate.features) == 1
     assert isinstance(plate.features[0], FreeContour)
-    assert TOL.is_zero(plate.blank.xsize - 200.0)  # x-axis is the vector from `plate.outline[0]` to `plate.outline[1]`
-    assert TOL.is_zero(plate.blank.ysize - 100.0)
+    # outline[0]->outline[1] is now (100, 0, 0), the 100-long edge, so xsize/ysize swap vs. test_plate_blank
+    assert TOL.is_zero(plate.blank.xsize - 100.0)
+    assert TOL.is_zero(plate.blank.ysize - 200.0)
     assert TOL.is_zero(plate.blank.zsize - 10.0)
 
 
@@ -49,8 +52,9 @@ def test_plate_blank_extension():
 
     assert len(plate.features) == 1
     assert isinstance(plate.features[0], FreeContour)
-    assert TOL.is_zero(plate.blank.xsize - 110.0)  # x-axis is the vector from `plate.outline[0]` to `plate.outline[1]`
-    assert TOL.is_zero(plate.blank.ysize - 210.0)
+    # x-axis is the vector from `plate.outline[0]` to `plate.outline[1]`, i.e. the 200-long edge
+    assert TOL.is_zero(plate.blank.xsize - 210.0)
+    assert TOL.is_zero(plate.blank.ysize - 110.0)
     assert TOL.is_zero(plate.blank.zsize - 10.0)
 
 
@@ -142,8 +146,9 @@ def test_double_contour_plate():
 
     assert len(plate.features) == 1
     assert isinstance(plate.features[0], FreeContour)
-    assert TOL.is_zero(plate.blank.xsize - 120.0)  # x-axis is the vector from `plate.outline[0]` to `plate.outline[1]`
-    assert TOL.is_zero(plate.blank.ysize - 220.0)
+    # x-axis is the vector from `plate.outline[0]` to `plate.outline[1]`, i.e. the 200-long edge (extended to 220 by outline_b)
+    assert TOL.is_zero(plate.blank.xsize - 220.0)
+    assert TOL.is_zero(plate.blank.ysize - 120.0)
     assert TOL.is_zero(plate.blank.zsize - 10.0)
 
 
@@ -154,8 +159,9 @@ def test_contour_plate_blank():
 
     assert len(plate.features) == 1
     assert isinstance(plate.features[0], FreeContour)
-    assert TOL.is_zero(plate.blank.xsize - 120.0)  # x-axis is the vector from `plate.outline[0]` to `plate.outline[1]`
-    assert TOL.is_zero(plate.blank.ysize - 220.0)
+    # x-axis is the vector from `plate.outline[0]` to `plate.outline[1]`, i.e. the 200-long edge (extended to 220 by outline_b)
+    assert TOL.is_zero(plate.blank.xsize - 220.0)
+    assert TOL.is_zero(plate.blank.ysize - 120.0)
     assert TOL.is_zero(plate.blank.zsize - 10.0)
 
 
@@ -166,8 +172,9 @@ def test_contour_plate_simple_inclination():
 
     assert len(plate.features) == 1
     assert isinstance(plate.features[0], FreeContour)
-    assert TOL.is_zero(plate.blank.xsize - 120.0)  # x-axis is the vector from `plate.outline[0]` to `plate.outline[1]`
-    assert TOL.is_zero(plate.blank.ysize - 220.0)
+    # x-axis is the vector from `plate.outline[0]` to `plate.outline[1]`, i.e. the 200-long edge (extended to 220 by outline_b)
+    assert TOL.is_zero(plate.blank.xsize - 220.0)
+    assert TOL.is_zero(plate.blank.ysize - 120.0)
     assert TOL.is_zero(plate.blank.zsize - 10.0)
     assert TOL.is_close(plate.features[0].params.as_dict()["Contour"].inclination[0], -45.0)
 

--- a/tests/compas_timber/test_panel.py
+++ b/tests/compas_timber/test_panel.py
@@ -44,17 +44,21 @@ def test_flat_panel_creation():
     expected_edge_planes = [([0, 0, 0], [-1, 0, 0]), ([0, 20, 0], [0, 1, 0]), ([10, 20, 0], [1, 0, 0]), ([10, 0, 0], [0, -1, 0])]
     assert all([panel_a.outline_a.points[i] == polyline_a.points[i] for i in range(len(panel_a.outline_a.points))]), "Expected panel to match input polyline"
     assert panel_a.thickness == 1, "Expected panel thickness to match input thickness"
-    assert panel_a.length == 10, "Expected panel length to be 10"
-    assert panel_a.width == 20, "Expected panel width to be 20"
+    assert panel_a.length == 20, "Expected panel length to be 10"
+    assert panel_a.width == 10, "Expected panel width to be 20"
     assert TOL.is_allclose(panel_a.normal, [0, 0, 1]), "Expected the normal to be the world Z-axis"
     for expected, plane in zip(expected_edge_planes, panel_a.edge_planes.values()):
         assert TOL.is_allclose(expected[0], plane[0])
         assert TOL.is_allclose(expected[1], plane[1])
-    for obb_pt, expected_pt in zip(panel_a.obb.points, Box.from_points([Point(0, 0, 0), Point(10, 20, 1)]).points):
+    for obb_pt, expected_pt in zip(panel_a.aabb.points, Box.from_points([Point(0, 0, 0), Point(10, 20, 1)]).points):
         assert TOL.is_allclose(obb_pt, expected_pt)
 
 
 def test_sloped_panel_creation():
+    # this outline triggers the frame flip in `PlateGeometry.from_global_outlines` (natural normal derived from
+    # point order opposes the default thickness offset). The fix negates the local x-axis on flip instead of
+    # swapping x/y, so local x stays aligned with outline_a[0]->outline_a[1] = (10, 0, 0): `length` tracks that
+    # 10-long edge (extended by the slope to 20) and `width` tracks the 10*sqrt(2) diagonal edge.
     polyline_a = Polyline([Point(0, 10, 0), Point(10, 10, 0), Point(20, 20, 10), Point(0, 20, 10), Point(0, 10, 0)])
     panel_a = Panel.from_outline_thickness(polyline_a, 1)
     expected_edge_planes = [
@@ -65,19 +69,19 @@ def test_sloped_panel_creation():
     ]
 
     expected_obb = Box(
-        xsize=14.142135623730951,
-        ysize=20.0,
+        xsize=20.0,
+        ysize=14.142135623730951,
         zsize=1.0,
         frame=Frame(
-            point=Point(x=10.0, y=15.353553390593273, z=4.646446609406729), xaxis=Vector(x=0.0, y=0.7071067811865475, z=0.7071067811865476), yaxis=Vector(x=1.0, y=0.0, z=0.0)
+            point=Point(x=10.0, y=15.353553390593273, z=4.646446609406729), xaxis=Vector(x=-1.0, y=0.0, z=0.0), yaxis=Vector(x=0.0, y=0.7071067811865475, z=0.7071067811865476)
         ),
     )
 
-    assert panel_a.frame.point == Point(0, 10, 0), "Expected panel frame to match input polyline"
+    assert panel_a.frame.point == Point(20, 10, 0), "Expected panel frame to match input polyline"
     assert all([TOL.is_allclose(panel_a.outline_a.points[i], polyline_a.points[i]) for i in range(len(panel_a.outline_a.points))]), "Expected panel to match input polyline"
     assert TOL.is_close(panel_a.thickness, 1), "Expected panel thickness to match input thickness"
-    assert TOL.is_close(panel_a.length, 14.1421356237), "Expected panel length to be 10*sqrt(2)"
-    assert TOL.is_close(panel_a.width, 20), "Expected panel width to be 20"
+    assert TOL.is_close(panel_a.length, 20), "Expected panel length to be 20"
+    assert TOL.is_close(panel_a.width, 14.1421356237), "Expected panel width to be 10*sqrt(2)"
     assert TOL.is_allclose(panel_a.normal, [0, 0.707106781, -0.707106781]), "Expected the normal to be at 45 degrees"
     for expected, plane in zip(expected_edge_planes, panel_a.edge_planes.values()):
         assert TOL.is_allclose(expected[0], plane[0])
@@ -121,6 +125,8 @@ def test_copy_panel_model(model):
 
 
 def test_panel_serialization_with_attributes_kwargs():
+    # this outline triggers the frame flip (see test_sloped_panel_creation): local x follows
+    # outline_a[0]->outline_a[1], the 20-long edge, so length=20 and width=10.
     polyline_a = Polyline([Point(0, 0, 0), Point(0, 20, 0), Point(10, 20, 0), Point(10, 0, 0), Point(0, 0, 0)])
 
     panel_a = Panel.from_outline_thickness(polyline_a, 1, custom_attribute="custom_value", another_attribute=42)
@@ -128,13 +134,15 @@ def test_panel_serialization_with_attributes_kwargs():
     deserialized = json_loads(json_dumps(panel_a))
 
     assert deserialized.thickness == 1
-    assert deserialized.length == 10
-    assert deserialized.width == 20
+    assert deserialized.length == 20
+    assert deserialized.width == 10
     assert deserialized.attributes["custom_attribute"] == "custom_value"
     assert deserialized.attributes["another_attribute"] == 42
 
 
 def test_panel_serialization_with_attributes():
+    # this outline triggers the frame flip (see test_sloped_panel_creation): local x follows
+    # outline_a[0]->outline_a[1], the 20-long edge, so length=20 and width=10.
     polyline_a = Polyline([Point(0, 0, 0), Point(0, 20, 0), Point(10, 20, 0), Point(10, 0, 0), Point(0, 0, 0)])
 
     panel_a = Panel.from_outline_thickness(polyline_a, 1)
@@ -144,8 +152,8 @@ def test_panel_serialization_with_attributes():
     deserialized = json_loads(json_dumps(panel_a))
 
     assert deserialized.thickness == 1
-    assert deserialized.length == 10
-    assert deserialized.width == 20
+    assert deserialized.length == 20
+    assert deserialized.width == 10
     assert deserialized.attributes["custom_attribute"] == "custom_value"
     assert deserialized.attributes["another_attribute"] == 42
 
@@ -391,18 +399,17 @@ def test_panel_orientation_changes_local_frame():
 
 
 def test_panel_orientation_explicit_frame_flat():
-    # orientation=Y on this flat panel rotates the local frame 90° CW:
-    # xaxis becomes -world-Y, yaxis becomes +world-X
+    # orientation=Y on this flat panel forces the panel's local yaxis to align with the world Y axis, and the xaxis to be perpendicular to it
     panel = Panel.from_outline_thickness(_FLAT_OUTLINE, 1, orientation=Vector(0, 1, 0))
-    assert TOL.is_allclose(panel.frame.xaxis, [0, -1, 0])
-    assert TOL.is_allclose(panel.frame.yaxis, [1, 0, 0])
+    assert TOL.is_allclose(panel.frame.xaxis, [1, 0, 0])
+    assert TOL.is_allclose(panel.frame.yaxis, [0, 1, 0])
 
 
 def test_panel_orientation_explicit_frame_sloped():
     # orientation=X on the sloped panel: yaxis aligns with the panel's slope direction
     panel = Panel.from_outline_thickness(_SLOPED_OUTLINE, 1, orientation=Vector(1, 0, 0))
-    assert TOL.is_allclose(panel.frame.xaxis, [-1, 0, 0])
-    assert TOL.is_allclose(panel.frame.yaxis, [0, 0.7071067811865476, 0.7071067811865476])
+    assert TOL.is_allclose(panel.frame.xaxis, [0, 0.7071067811865476, 0.7071067811865476])
+    assert TOL.is_allclose(panel.frame.yaxis, [1, 0, 0])
 
 
 def test_panel_from_outlines_orientation():

--- a/tests/compas_timber/test_plate.py
+++ b/tests/compas_timber/test_plate.py
@@ -19,22 +19,31 @@ from brep_mocks import make_single_face_brep
 
 
 def test_flat_plate_creation():
+    # this outline's point order triggers the frame flip in `PlateGeometry.from_global_outlines` (see
+    # test_plate_frame). Local x stays aligned with outline_a[0]->outline_a[1] = (0, 20, 0), so `length`
+    # (the extent along local x) now tracks the 20-long edge and `width` the 10-long edge.
     polyline_a = Polyline([Point(0, 0, 0), Point(0, 20, 0), Point(10, 20, 0), Point(10, 0, 0), Point(0, 0, 0)])
     plate_a = Plate.from_outline_thickness(polyline_a, 1)
     expected_edge_planes = [([0, 0, 0], [-1, 0, 0]), ([0, 20, 0], [0, 1, 0]), ([10, 20, 0], [1, 0, 0]), ([10, 0, 0], [0, -1, 0])]
     assert all([plate_a.outline_a.points[i] == polyline_a.points[i] for i in range(len(plate_a.outline_a.points))]), "Expected plate to match input polyline"
     assert plate_a.thickness == 1, "Expected plate thickness to match input thickness"
-    assert plate_a.length == 10, "Expected plate length to be 10"
-    assert plate_a.width == 20, "Expected plate width to be 20"
+    assert plate_a.length == 20, "Expected plate length to be 20"
+    assert plate_a.width == 10, "Expected plate width to be 10"
     assert TOL.is_allclose(plate_a.normal, [0, 0, 1]), "Expected the normal to be the world Z-axis"
     for expected, plane in zip(expected_edge_planes, plate_a.edge_planes.values()):
         assert TOL.is_allclose(expected[0], plane[0])
         assert TOL.is_allclose(expected[1], plane[1])
-    for obb_pt, expected_pt in zip(plate_a.obb.points, Box.from_points([Point(0, 0, 0), Point(10, 20, 1)]).points):
-        assert TOL.is_allclose(obb_pt, expected_pt)
+    # compare as sets: the OBB's local frame is rotated 90 degrees vs. before the fix, so `Box.points`
+    # visits the same 8 corners in a different order.
+    obb_points = {tuple(round(c, 6) for c in pt) for pt in plate_a.obb.points}
+    expected_points = {tuple(round(c, 6) for c in pt) for pt in Box.from_points([Point(0, 0, 0), Point(10, 20, 1)]).points}
+    assert obb_points == expected_points
 
 
 def test_sloped_plate_creation():
+    # this outline also triggers the frame flip (see test_plate_frame). Local x stays aligned with
+    # outline_a[0]->outline_a[1] = (10, 0, 0), so `length` now tracks that 10-long edge, extended by the
+    # slope to 20, and `width` tracks the 10*sqrt(2) diagonal edge; the frame origin and OBB rotate to match.
     polyline_a = Polyline([Point(0, 10, 0), Point(10, 10, 0), Point(20, 20, 10), Point(0, 20, 10), Point(0, 10, 0)])
     plate_a = Plate.from_outline_thickness(polyline_a, 1)
     expected_edge_planes = [
@@ -45,19 +54,19 @@ def test_sloped_plate_creation():
     ]
 
     expected_obb = Box(
-        xsize=14.142135623730951,
-        ysize=20.0,
+        xsize=20.0,
+        ysize=14.142135623730951,
         zsize=1.0,
         frame=Frame(
-            point=Point(x=10.0, y=15.353553390593273, z=4.646446609406729), xaxis=Vector(x=0.0, y=0.7071067811865475, z=0.7071067811865476), yaxis=Vector(x=1.0, y=0.0, z=0.0)
+            point=Point(x=10.0, y=15.353553390593273, z=4.646446609406729), xaxis=Vector(x=-1.0, y=0.0, z=0.0), yaxis=Vector(x=0.0, y=0.7071067811865475, z=0.7071067811865476)
         ),
     )
 
-    assert plate_a.frame.point == Point(0, 10, 0), "Expected plate frame to match input polyline"
+    assert plate_a.frame.point == Point(20, 10, 0), "Expected plate frame to match input polyline"
     assert all([TOL.is_allclose(plate_a.outline_a.points[i], polyline_a.points[i]) for i in range(len(plate_a.outline_a.points))]), "Expected plate to match input polyline"
     assert TOL.is_close(plate_a.thickness, 1), "Expected plate thickness to match input thickness"
-    assert TOL.is_close(plate_a.length, 14.1421356237), "Expected plate length to be 10*sqrt(2)"
-    assert TOL.is_close(plate_a.width, 20), "Expected plate width to be 20"
+    assert TOL.is_close(plate_a.length, 20), "Expected plate length to be 20"
+    assert TOL.is_close(plate_a.width, 14.1421356237), "Expected plate width to be 10*sqrt(2)"
     assert TOL.is_allclose(plate_a.normal, [0, 0.707106781, -0.707106781]), "Expected the normal to be at 45 degrees"
     for expected, plane in zip(expected_edge_planes, plate_a.edge_planes.values()):
         assert TOL.is_allclose(expected[0], plane[0])
@@ -71,33 +80,41 @@ def test_sloped_plate_creation():
 
 
 def test_plate_frame():
+    # this polyline winds clockwise around +Z (its "natural" normal derived from point order is -Z), while its
+    # default thickness offset goes to +Z, so `from_global_outlines` flips the frame. The fix negates the local
+    # x-axis on flip instead of swapping x/y, so local x stays aligned with outline_a[0]->outline_a[1] (0, 20, 0),
+    # i.e. -world-Y here, and local y ends up along +world-X. The frame origin moves to the matching box corner.
     polyline_a = Polyline([Point(0, 0, 0), Point(0, 20, 0), Point(10, 20, 0), Point(10, 0, 0), Point(0, 0, 0)])
     plate_a = Plate.from_outline_thickness(polyline_a, 1)
-    assert plate_a.frame.point == Point(0, 0, 0), "Expected plate frame point to be at origin"
-    assert plate_a.frame.xaxis == Vector(1, 0, 0), "Expected plate frame xaxis to be along global x axis"
-    assert plate_a.frame.yaxis == Vector(0, 1, 0), "Expected plate frame yaxis to be along global y axis"
+    assert plate_a.frame.point == Point(0, 20, 0)
+    assert plate_a.frame.xaxis == Vector(0, -1, 0)
+    assert plate_a.frame.yaxis == Vector(1, 0, 0)
     assert plate_a.frame.zaxis == Vector(0, 0, 1), "Expected plate frame zaxis to be along global z axis"
 
 
 def test_plate_frame_flipped_vector():
+    # explicit vector=(0, 0, -1) forces the flip branch (outline_b offset opposite the outline's natural normal).
+    # Local x stays aligned with outline_a[0]->outline_a[1] = (10, 0, 0), i.e. -world-X after the flip negates it.
     polyline_a = Polyline([Point(0, 0, 0), Point(10, 0, 0), Point(10, 20, 0), Point(0, 20, 0), Point(0, 0, 0)])
     plate_a = Plate.from_outline_thickness(polyline_a, 1, vector=Vector(0, 0, -1))
-    assert plate_a.frame.point == Point(0, 0, 0), "Expected plate frame point to be at origin"
-    assert plate_a.frame.xaxis == Vector(0, 1, 0), "Expected plate frame xaxis to be along global y axis"
-    assert plate_a.frame.yaxis == Vector(1, 0, 0), "Expected plate frame yaxis to be along negative global x axis"
+    assert plate_a.frame.point == Point(10, 0, 0)
+    assert plate_a.frame.xaxis == Vector(-1, 0, 0)
+    assert plate_a.frame.yaxis == Vector(0, 1, 0)
     assert plate_a.frame.zaxis == Vector(0, 0, -1), "Expected plate frame zaxis to be along global z axis"
 
 
 def test_plate_blank():
+    # this outline triggers the frame flip (see test_plate_frame): local x follows outline_a[0]->outline_a[1]
+    # (the 20-long edge, extended to 21 by outline_b), so length/xsize and width/ysize are swapped vs. before the fix.
     polyline_a = Polyline([Point(0, 0, 0), Point(0, 20, 0), Point(10, 20, 0), Point(10, 0, 0), Point(0, 0, 0)])
     polyline_b = Polyline([Point(1, 1, 1), Point(1, 21, 1), Point(11, 21, 1), Point(11, 1, 1), Point(1, 1, 1)])
     plate_a = Plate.from_outlines(polyline_a, polyline_b)
     blank = plate_a.blank
-    assert plate_a.length == 11, "Expected plate length to be 11"
-    assert plate_a.width == 21, "Expected plate width to be 21"
+    assert plate_a.length == 21, "Expected plate length to be 21"
+    assert plate_a.width == 11, "Expected plate width to be 11"
     assert plate_a.thickness == 1, "Expected plate thickness to be 1"
-    assert blank.xsize == 11, "Expected blank xsize to be 11"
-    assert blank.ysize == 21, "Expected blank ysize to be 21"
+    assert blank.xsize == 21, "Expected blank xsize to be 21"
+    assert blank.ysize == 11, "Expected blank ysize to be 11"
     assert blank.zsize == 1, "Expected blank zsize to be 1"
     assert blank.frame.point == Point(5.5, 10.5, 0.5), "Expected blank center to match plate center"
 
@@ -386,18 +403,17 @@ def test_plate_orientation_changes_local_frame():
 
 
 def test_plate_orientation_explicit_frame_flat():
-    # orientation=Y on this flat plate rotates the local frame 90° CW:
-    # xaxis becomes -world-Y, yaxis becomes +world-X
+    # orientation=Y on this flat plate forces the plate's local yaxis to align with the world Y axis, and the xaxis to be perpendicular to it
     plate = Plate.from_outline_thickness(_FLAT_OUTLINE, 1, orientation=Vector(0, 1, 0))
-    assert TOL.is_allclose(plate.frame.xaxis, [0, -1, 0])
-    assert TOL.is_allclose(plate.frame.yaxis, [1, 0, 0])
+    assert TOL.is_allclose(plate.frame.xaxis, [1, 0, 0])
+    assert TOL.is_allclose(plate.frame.yaxis, [0, 1, 0])
 
 
 def test_plate_orientation_explicit_frame_sloped():
-    # orientation=X on the sloped plate: yaxis aligns with the panel's slope direction
+    # orientation=X on the sloped plate: yaxis aligns with the plate's slope direction
     plate = Plate.from_outline_thickness(_SLOPED_OUTLINE, 1, orientation=Vector(1, 0, 0))
-    assert TOL.is_allclose(plate.frame.xaxis, [-1, 0, 0])
-    assert TOL.is_allclose(plate.frame.yaxis, [0, 0.7071067811865476, 0.7071067811865476])
+    assert TOL.is_allclose(plate.frame.xaxis, [0, 0.7071067811865476, 0.7071067811865476])
+    assert TOL.is_allclose(plate.frame.yaxis, [1, 0, 0])
 
 
 def test_plate_from_outlines_orientation():

--- a/tests/compas_timber/test_plate_geometry.py
+++ b/tests/compas_timber/test_plate_geometry.py
@@ -1,6 +1,9 @@
 from compas.geometry import Point
 from compas.geometry import Polyline
 from compas.geometry import Plane
+from compas.geometry import Vector
+from compas.geometry import cross_vectors
+from compas.geometry import dot_vectors
 from compas.data import json_dumps
 from compas.data import json_loads
 from compas.tolerance import TOL
@@ -125,3 +128,70 @@ def test_compute_shape_applies_edge_extensions(mocker):
     pg.compute_shape()
 
     mock_apply.assert_called_once()
+
+
+def test_from_global_outlines_orientation_sets_local_yaxis():
+    """When `orientation` is given, the local frame's y-axis should follow it, regardless of outline_b's side."""
+    outline_a = Polyline([Point(0, 0, 0), Point(10, 0, 0), Point(10, 5, 0), Point(0, 5, 0), Point(0, 0, 0)])
+    outline_b = Polyline([Point(p[0], p[1], p[2] + 1) for p in outline_a.points])  # offset in +Z
+    orientation = Vector(0, 1, 0)
+
+    pg = PlateGeometry.from_global_outlines(outline_a, outline_b, orientation=orientation)
+
+    # frame.yaxis must be parallel to the requested orientation vector
+    assert TOL.is_allclose(cross_vectors(pg.frame.yaxis, orientation), [0, 0, 0])
+
+
+def test_from_global_outlines_orientation_forces_rotation():
+    """`orientation` should rotate the local outline to align local +Y with it, even when that
+    differs from the frame the algorithm would otherwise derive from the outline geometry.
+
+    Uses an asymmetric outline (no two edges the same length, no symmetry) so that a wrong
+    rotation angle, a mirrored outline, or a mismatch between the returned frame and the actual
+    local outline can't accidentally satisfy the checks below.
+    """
+    outline_a = Polyline([Point(0, 0, 0), Point(8, 0, 0), Point(6, 4, 0), Point(1, 5, 0), Point(0, 0, 0)])
+    outline_b = Polyline([Point(p[0], p[1], p[2] + 1) for p in outline_a.points])
+    orientation = Vector(1, 1, 0)  # 45 degrees, not aligned with any edge of outline_a
+
+    pg_default = PlateGeometry.from_global_outlines(outline_a, outline_b)
+    pg_oriented = PlateGeometry.from_global_outlines(outline_a, outline_b, orientation=orientation)
+
+    # orientation actually changed the frame - not coincidentally the same as the default one
+    assert not TOL.is_allclose(cross_vectors(pg_default.frame.yaxis, pg_oriented.frame.yaxis), [0, 0, 0])
+
+    # the oriented frame's y-axis follows the requested orientation vector
+    assert TOL.is_allclose(cross_vectors(pg_oriented.frame.yaxis, orientation), [0, 0, 0])
+
+    # mapping the local (rotated) outline back through the returned frame must exactly reproduce
+    # the original, asymmetric global outline - this only holds if the rotation embedded in the
+    # frame matches the rotation actually applied to the outline points.
+    for local_pt, global_pt in zip(pg_oriented.outline_a.points, outline_a.points):
+        assert TOL.is_allclose(pg_oriented.frame.to_world_coordinates(local_pt), global_pt)
+
+
+def test_from_global_outlines_orientation_consistent_when_outline_b_flipped():
+    """The frame's relationship to `orientation` should not depend on which side outline_b is offset to.
+
+    Regression test: an earlier implementation swapped the x/y axes when flipping the frame to
+    account for outline_b lying in -Z space, which discarded the orientation constraint for the
+    flipped case. The fix negates the x-axis instead, keeping the y-axis aligned with `orientation`.
+    """
+    outline_a = Polyline([Point(0, 0, 0), Point(10, 0, 0), Point(10, 5, 0), Point(0, 5, 0), Point(0, 0, 0)])
+    outline_b_pos = Polyline([Point(p[0], p[1], p[2] + 1) for p in outline_a.points])  # +Z, no flip needed
+    outline_b_neg = Polyline([Point(p[0], p[1], p[2] - 1) for p in outline_a.points])  # -Z, triggers frame flip
+    orientation = Vector(0, 1, 0)
+
+    pg_pos = PlateGeometry.from_global_outlines(outline_a, outline_b_pos, orientation=orientation)
+    pg_neg = PlateGeometry.from_global_outlines(outline_a, outline_b_neg, orientation=orientation)
+
+    # y-axis stays parallel to orientation in both the flipped and non-flipped case
+    assert TOL.is_allclose(cross_vectors(pg_pos.frame.yaxis, orientation), [0, 0, 0])
+    assert TOL.is_allclose(cross_vectors(pg_neg.frame.yaxis, orientation), [0, 0, 0])
+
+    # and its relationship (same vs. opposite direction) to orientation is consistent between the two cases
+    assert TOL.is_close(dot_vectors(pg_pos.frame.yaxis, orientation), dot_vectors(pg_neg.frame.yaxis, orientation))
+
+    # regardless of which side outline_b was offset to, local outline_b always ends up at +thickness
+    assert all(TOL.is_close(p[2], pg_pos.thickness) for p in pg_pos.outline_b.points)
+    assert all(TOL.is_close(p[2], pg_neg.thickness) for p in pg_neg.outline_b.points)


### PR DESCRIPTION
This fixes some previously arbitrary behavior in the creation of the PlateGeometry frame. Previously if the `outline_b` were in negative Z space of the initial frame, the frame would flip by swapping x any y axes, resulting in length and width no longer corresponding to the initial calues. this is particularly problematic when an `orientation` is given, as this would subsequently be flipped. 

current behavior is:
if `orientation` is given, create frame from projected orientation on panel and polyline normal
else create frame from first segment of polyline and polyline normal
then if outline_b in frame negative space, flip frame by using xaxis = -xaxis, preserving the given yaxis orientation. 


### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).


fix, test, changelog