### PR TITLE
bumped compas_brep dependency for bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * `TimberModel.remove_joint()` now calls `Joint.reset_location()`.
+* Bumped minimum required `compas_brep` due to bugfix in Grasshopper Brep scene object.
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "compas >=2.15.1, <3.0",
     "compas_model == 0.9.2", # pin until first release
     "scipy >= 1.1",
-    "compas_brep"
+    "compas_brep >= 0.1.3"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Issue identified by @obucklin 

* Bumping minimum dependency of `compas_brep` to patch fixing issue with Grasshopper scene object not found for Brep.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).
