### PR TITLE
Update DOI badge link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![pip downloads](https://img.shields.io/pypi/dm/compas_timber)](https://pypi.python.org/project/compas_timber)
 [![PyPI Package latest release](https://img.shields.io/pypi/v/compas_timber.svg)](https://pypi.python.org/pypi/compas_timber)
 [![Supported implementations](https://img.shields.io/pypi/implementation/compas_timber.svg)](https://pypi.python.org/pypi/compas_timber)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7934267.svg)](https://doi.org/10.5281/zenodo.7934267)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7934266.svg)](https://doi.org/10.5281/zenodo.7934266)
 [![Twitter Follow](https://img.shields.io/twitter/follow/compas_dev?style=social)](https://twitter.com/compas_dev)
 [![Made with COMPAS](https://compas.dev/badge.svg)](https://compas.dev/#/)
 ![COMPAS Timber](https://raw.githubusercontent.com/gramaziokohler/compas_timber/main/docs/_images/compas_timber.jpg)


### PR DESCRIPTION
closes https://github.com/gramaziokohler/compas_timber/issues/773

So that it points to the general zenodo url which redirects to the latest version.

<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).
