### PR TITLE
Normalize FeatureApplicationError/BeamJoiningError geometry to model space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `brep_from_outlines` to `compas_timber.geometry`.
 
 ### Changed
+* `FeatureApplicationError` raised from `BTLxProcessing.apply()` now carries geometry in the model's global coordinate system (previously local/element space), matching errors raised elsewhere. 
+* Fixed a live crash (`TypeError`) and two other constructor-argument bugs on `BeamJoiningError` call sites.
 * Fixed wrong `RefPosition` assigned to one beam in `LFrenchRidgeLapJoint` for 90° configurations where floating-point drift caused `_calculate_ref_position` to miss the orthogonal-connection branch (`angle == 90.0` replaced with `TOL.is_close(angle, 90.0)`). Also removed a stray `print(90)` debug statement.
 * `TimberModel.remove_joint()` now calls `Joint.reset_location()`.
 * `TimberModel.connect_adjacent_beams()`, `connect_adjacent_plates()`, and `connect_adjacent_panels()` now share a single `TimberModel.compute_topologies()` implementation. Joint-candidate clearing is now unconditional (all candidates, not just the connected element type) and no longer removes existing concrete joints.

--- a/src/compas_timber/connections/joint.py
+++ b/src/compas_timber/connections/joint.py
@@ -333,7 +333,12 @@ class Joint(Data):
         """
         if reordered_elements:
             if set(reordered_elements) != cluster.elements:
-                raise BeamJoiningError(cls, "Elements of the joint candidate must match the provided elements.", [e.blank for e in reordered_elements])
+                raise BeamJoiningError(
+                    beams=reordered_elements,
+                    joint=cls,
+                    debug_info="Elements of the joint candidate must match the provided elements.",
+                    debug_geometries=[e.blank for e in reordered_elements],
+                )
         if len(cluster.joints) == 1:
             elements = reordered_elements or cluster.joints[0].elements
             return cls.promote_joint_candidate(model, cluster.joints[0], reordered_elements=elements, **kwargs)

--- a/src/compas_timber/connections/plate_joint.py
+++ b/src/compas_timber/connections/plate_joint.py
@@ -121,7 +121,11 @@ class PlateJoint(Joint, ABC):
             if allow_reordering:
                 self.plate_a, self.plate_b = topo_results.plate_a, topo_results.plate_b
             else:
-                raise BeamJoiningError("The order of plates is incompatible with the joint topology. Try reversing the order of the plates.")
+                raise BeamJoiningError(
+                    beams=[self.plate_a, self.plate_b],
+                    joint=self,
+                    debug_info="The order of plates is incompatible with the joint topology. Try reversing the order of the plates.",
+                )
         self.topology = topo_results.topology
         self.a_segment_index = topo_results.a_segment_index
         self.b_segment_index = topo_results.b_segment_index

--- a/src/compas_timber/connections/t_step_joint.py
+++ b/src/compas_timber/connections/t_step_joint.py
@@ -171,14 +171,15 @@ class TStepJoint(Joint):
         """
         assert self.cross_beam and self.main_beam
         start_a = None
+        plane_a = None
         try:
             plane_a = self.main_extension_plane
             start_a, end_a = self.main_beam.extension_to_plane(plane_a)
         except AttributeError as ae:
             # I want here just the plane that caused the error
-            raise BeamJoiningError(self.main_beam, self, debug_info=str(ae), debug_geometries=plane_a)
+            raise BeamJoiningError(self.elements, self, debug_info=str(ae), debug_geometries=[plane_a] if plane_a else [])
         except Exception as ex:
-            raise BeamJoiningError(self.main_beam, self, debug_info=str(ex))
+            raise BeamJoiningError(self.elements, self, debug_info=str(ex), debug_geometries=[plane_a] if plane_a else [])
         self.main_beam.add_blank_extension(start_a, end_a, self.guid)
 
     def add_features(self):

--- a/src/compas_timber/errors.py
+++ b/src/compas_timber/errors.py
@@ -3,12 +3,18 @@ class FeatureApplicationError(Exception):
 
     TODO: perhaps should be renamed to ProcessingVisualizationError or something similar.
 
+    `feature_geometry` and `element_geometry` are always expected to be in the model's global
+    coordinate system, regardless of the coordinate system the failure was detected in. Callers
+    raising this error from a context where the geometry is in local/element space (e.g. inside
+    `BTLxProcessing.apply()`) are responsible for transforming the geometry to model space
+    themselves (e.g. via `geometry.transformed(beam.modeltransformation)`) before passing it in.
+
     Attributes
     ----------
     feature_geometry : :class:`~compas.geometry.Geometry`
-        The geometry of the feature that could not be applied.
+        The geometry of the feature that could not be applied, in model space.
     element_geometry : :class:`~compas.geometry.Geometry`
-        The geometry of the element that could not be modified.
+        The geometry of the element that could not be modified, in model space.
     message : str
         The error message.
 
@@ -31,12 +37,16 @@ class BeamJoiningError(Exception):
     This error should indicate that an error has occurred while calculating the features which
     should be applied by this joint.
 
+    `debug_geometries` is always expected to be in the model's global coordinate system, e.g. the
+    planes/boxes involved are typically taken directly from beam properties such as `ref_sides` or
+    `blank`, which are already expressed in model space.
+
     Attributes
     ----------
     beams : list(:class:`~compas_timber.parts.Beam`)
         The beams that were supposed to be joined.
     debug_geometries : list(:class:`~compas.geometry.Geometry`)
-        A list of geometries that can be used to visualize the error.
+        A list of geometries, in model space, that can be used to visualize the error.
     debug_info : str
         A string containing debug information about the error.
     joint : :class:`~compas_timber.connections.Joint`
@@ -49,6 +59,8 @@ class BeamJoiningError(Exception):
         self.beams = beams
         self.joint = joint
         self.debug_info = debug_info
+        if debug_geometries and not isinstance(debug_geometries, list):
+            debug_geometries = [debug_geometries]
         self.debug_geometries = debug_geometries or []
 
     def __reduce__(self):

--- a/src/compas_timber/fabrication/double_cut.py
+++ b/src/compas_timber/fabrication/double_cut.py
@@ -339,7 +339,7 @@ class DoubleCut(BTLxProcessing):
             cutting_planes = self.planes_from_params_and_beam(beam)
         except ValueError as e:
             raise FeatureApplicationError(
-                None, geometry, "Failed to generate cutting planes from parameters and beam: {}".format(str(e))
+                None, geometry.transformed(beam.modeltransformation), "Failed to generate cutting planes from parameters and beam: {}".format(str(e))
             )
         # convert to the local coordinates of the beam
         cutting_planes = [plane.transformed(beam.transformation_to_local()) for plane in cutting_planes]
@@ -540,7 +540,7 @@ class DoubleCutProxy(object):
         # determine if concave or convex based on the stored planes
         # get the intersection line of cutting planes
         if not intersection_plane_plane(self.planes[0], self.planes[1]):
-            raise FeatureApplicationError(None, geometry, "The two cutting planes are parallel.")
+            raise FeatureApplicationError(None, geometry.transformed(beam.modeltransformation), "The two cutting planes are parallel.")
 
         # check angle between planes to determine concavity
         angle_between = angle_vectors(self.planes[0].normal, self.planes[1].normal, deg=True)

--- a/src/compas_timber/fabrication/dovetail_mortise.py
+++ b/src/compas_timber/fabrication/dovetail_mortise.py
@@ -536,7 +536,7 @@ class DovetailMortise(BTLxProcessing):
             dovetail_volume = self.dovetail_volume_from_params_and_beam(beam)
         except ValueError as e:
             raise FeatureApplicationError(
-                None, geometry, "Failed to generate dovetail mortise volume from parameters and beam: {}".format(str(e))
+                None, geometry.transformed(beam.modeltransformation), "Failed to generate dovetail mortise volume from parameters and beam: {}".format(str(e))
             )
 
         # fillet the edges of the dovetail volume based on the shape
@@ -549,21 +549,24 @@ class DovetailMortise(BTLxProcessing):
                     self.shape_radius, [dovetail_volume.edges[edge_indices[0]], dovetail_volume.edges[edge_indices[1]]]
                 )  # TODO: NotImplementedError
             except Exception as e:
+                # dovetail_volume is still in model space here (not yet localized below), geometry is local
                 raise FeatureApplicationError(
                     dovetail_volume,
-                    geometry,
+                    geometry.transformed(beam.modeltransformation),
                     "Failed to fillet the edges of the dovetail volume based on the shape: {}".format(str(e)),
                 )
 
         # transform dovetail volume to local coordinates of the beam
         dovetail_volume.transform(beam.transformation_to_local())
 
-        # remove tenon volume to geometry
+        # remove tenon volume from geometry
         try:
             geometry -= dovetail_volume
         except Exception as e:
             raise FeatureApplicationError(
-                dovetail_volume, geometry, "Failed to add tenon volume to geometry: {}".format(str(e))
+                dovetail_volume.transformed(beam.modeltransformation),
+                geometry.transformed(beam.modeltransformation),
+                "Failed to subtract tenon volume from geometry: {}".format(str(e))
             )
 
         return geometry

--- a/src/compas_timber/fabrication/dovetail_tenon.py
+++ b/src/compas_timber/fabrication/dovetail_tenon.py
@@ -638,7 +638,7 @@ class DovetailTenon(BTLxProcessing):
             cutting_plane = Plane.from_frame(self.frame_from_params_and_beam(beam))
         except ValueError as e:
             raise FeatureApplicationError(
-                None, geometry, "Failed to generate cutting frame from parameters and beam: {}".format(str(e))
+                None, geometry.transformed(beam.modeltransformation), "Failed to generate cutting frame from parameters and beam: {}".format(str(e))
             )
 
         # get dovetail volume from params and beam
@@ -646,7 +646,7 @@ class DovetailTenon(BTLxProcessing):
             dovetail_volume = self.dovetail_volume_from_params_and_beam(beam)
         except ValueError as e:
             raise FeatureApplicationError(
-                None, geometry, "Failed to generate dovetail tenon volume from parameters and beam: {}".format(str(e))
+                None, geometry.transformed(beam.modeltransformation), "Failed to generate dovetail tenon volume from parameters and beam: {}".format(str(e))
             )
 
         # fillet the edges of the dovetail volume based on the shape
@@ -659,9 +659,10 @@ class DovetailTenon(BTLxProcessing):
                     self.shape_radius, [dovetail_volume.edges[edge_indices[0]], dovetail_volume.edges[edge_indices[1]]]
                 )  # TODO: NotImplementedError
             except Exception as e:
+                # dovetail_volume is still in model space here (not yet localized below), geometry is local
                 raise FeatureApplicationError(
                     dovetail_volume,
-                    geometry,
+                    geometry.transformed(beam.modeltransformation),
                     "Failed to fillet the edges of the dovetail volume based on the shape: {}".format(str(e)),
                 )
 
@@ -680,7 +681,9 @@ class DovetailTenon(BTLxProcessing):
             geometry.trim(cutting_plane)
         except Exception as e:
             raise FeatureApplicationError(
-                cutting_plane, geometry, "Failed to trim geometry with cutting plane: {}".format(str(e))
+                cutting_plane.transformed(beam.modeltransformation),
+                geometry.transformed(beam.modeltransformation),
+                "Failed to trim geometry with cutting plane: {}".format(str(e)),
             )
 
         # add tenon volume to geometry
@@ -688,7 +691,9 @@ class DovetailTenon(BTLxProcessing):
             geometry += dovetail_volume
         except Exception as e:
             raise FeatureApplicationError(
-                dovetail_volume, geometry, "Failed to add tenon volume to geometry: {}".format(str(e))
+                dovetail_volume.transformed(beam.modeltransformation),
+                geometry.transformed(beam.modeltransformation),
+                "Failed to add tenon volume to geometry: {}".format(str(e)),
             )
 
         return geometry

--- a/src/compas_timber/fabrication/drilling.py
+++ b/src/compas_timber/fabrication/drilling.py
@@ -334,8 +334,8 @@ class Drilling(BTLxProcessing):
             return geometry - drill_geometry
         except IndexError:
             raise FeatureApplicationError(
-                drill_geometry,
-                geometry,
+                drill_geometry.transformed(element.modeltransformation),
+                geometry.transformed(element.modeltransformation),
                 "The drill geometry does not intersect with element geometry.",
             )
 
@@ -528,8 +528,8 @@ class DrillingProxy(object):
             return geometry - drill_geometry
         except IndexError:
             raise FeatureApplicationError(
-                drill_geometry,
-                geometry,
+                drill_geometry.transformed(element.modeltransformation),
+                geometry.transformed(element.modeltransformation),
                 "The drill geometry does not intersect with element geometry.",
             )
 

--- a/src/compas_timber/fabrication/french_ridge_lap.py
+++ b/src/compas_timber/fabrication/french_ridge_lap.py
@@ -299,8 +299,8 @@ class FrenchRidgeLap(BTLxProcessing):
                 geometry.trim(trimming_frame)
             except BrepTrimmingError:
                 raise FeatureApplicationError(
-                    trimming_frame,
-                    geometry,
+                    trimming_frame.transformed(beam.modeltransformation),
+                    geometry.transformed(beam.modeltransformation),
                     "Could not trim the beam geometry with the cutting frame.",
                 )
         # subtract the lap volume from the beam geometry
@@ -310,8 +310,8 @@ class FrenchRidgeLap(BTLxProcessing):
             return geometry - subtracting_volume
         except IndexError:
             raise FeatureApplicationError(
-                subtracting_volume,
-                geometry,
+                subtracting_volume.transformed(beam.modeltransformation),
+                geometry.transformed(beam.modeltransformation),
                 "Could not subtract the cutting volume from the beam geometry.",
             )
 

--- a/src/compas_timber/fabrication/jack_cut.py
+++ b/src/compas_timber/fabrication/jack_cut.py
@@ -257,8 +257,8 @@ class JackRafterCut(BTLxProcessing):
             return geometry.trimmed(cutting_plane)
         except BrepTrimmingError:
             raise FeatureApplicationError(
-                cutting_plane,
-                geometry,
+                cutting_plane.transformed(beam.modeltransformation),
+                geometry.transformed(beam.modeltransformation),
                 "The cutting plane does not intersect with beam geometry.",
             )
 
@@ -412,8 +412,8 @@ class JackRafterCutProxy(object):
             return geometry.trimmed(self.plane)
         except BrepTrimmingError:
             raise FeatureApplicationError(
-                self.plane,
-                geometry,
+                self.plane.transformed(beam.modeltransformation),
+                geometry.transformed(beam.modeltransformation),
                 "The cutting plane does not intersect with beam geometry.",
             )
 

--- a/src/compas_timber/fabrication/lap.py
+++ b/src/compas_timber/fabrication/lap.py
@@ -679,8 +679,8 @@ class Lap(BTLxProcessing):
             lap_volume = Brep.from_mesh(lap_volume.to_mesh())
         except Exception:
             raise FeatureApplicationError(
-                lap_volume,
-                geometry,
+                lap_volume.transformed(beam.modeltransformation),
+                geometry.transformed(beam.modeltransformation),
                 "Could not convert the lap volume to a Brep.",
             )
 
@@ -689,8 +689,8 @@ class Lap(BTLxProcessing):
             return geometry - lap_volume
         except IndexError:
             raise FeatureApplicationError(
-                lap_volume,
-                geometry,
+                lap_volume.transformed(beam.modeltransformation),
+                geometry.transformed(beam.modeltransformation),
                 "The lap volume does not intersect with the beam geometry.",
             )
 
@@ -953,8 +953,8 @@ class LapProxy(object):
             return geometry - inflated_brep
         except IndexError:
             raise FeatureApplicationError(
-                self.volume,
-                geometry,
+                self.volume.transformed(self.beam.modeltransformation),
+                geometry.transformed(self.beam.modeltransformation),
                 "The volume to subtract does not intersect with beam geometry.",
             )
 

--- a/src/compas_timber/fabrication/longitudinal_cut.py
+++ b/src/compas_timber/fabrication/longitudinal_cut.py
@@ -421,7 +421,11 @@ class LongitudinalCut(BTLxProcessing):
             try:
                 return geometry.trimmed(cutting_plane)
             except BrepTrimmingError:
-                raise FeatureApplicationError(cutting_plane, geometry, "The trimming operation failed. The cutting plane does not intersect with beam geometry.")
+                raise FeatureApplicationError(
+                    cutting_plane.transformed(beam.modeltransformation),
+                    geometry.transformed(beam.modeltransformation),
+                    "The trimming operation failed. The cutting plane does not intersect with beam geometry.",
+                )
         else:
             # if the cut is limited, calculate the negative volume representing the cut and subtract it from the geometry
             neg_vol = self.volume_from_params_and_beam(beam)
@@ -429,7 +433,11 @@ class LongitudinalCut(BTLxProcessing):
             try:
                 return geometry - neg_vol
             except IndexError:
-                raise FeatureApplicationError(neg_vol, geometry, "The boolean difference between the cutting volume and the beam geometry failed.")
+                raise FeatureApplicationError(
+                    neg_vol.transformed(beam.modeltransformation),
+                    geometry.transformed(beam.modeltransformation),
+                    "The boolean difference between the cutting volume and the beam geometry failed.",
+                )
 
     def plane_from_params_and_beam(self, beam):
         """Calculates the cutting plane from the machining parameters in this instance and the given beam
@@ -664,7 +672,11 @@ class LongitudinalCutProxy(object):
             # TODO: add geometry implementation for cuts that don't go full length of beam
             return geometry.trimmed(self.plane)
         except BrepTrimmingError:
-            raise FeatureApplicationError(self.plane, geometry, "The trimming operation failed. The cutting plane does not intersect with beam geometry.")
+            raise FeatureApplicationError(
+                self.plane.transformed(self.beam.modeltransformation),
+                geometry.transformed(self.beam.modeltransformation),
+                "The trimming operation failed. The cutting plane does not intersect with beam geometry.",
+            )
 
     def __getattr__(self, attr):
         # any unknown calls are passed through to the processing instance

--- a/src/compas_timber/fabrication/mortise.py
+++ b/src/compas_timber/fabrication/mortise.py
@@ -436,7 +436,7 @@ class Mortise(BTLxProcessing):
             mortise_volume = self.volume_from_params_and_beam(beam)
         except ValueError as e:
             raise FeatureApplicationError(
-                None, geometry, "Failed to generate mortise mortise volume from parameters and beam: {}".format(str(e))
+                None, geometry.transformed(beam.modeltransformation), "Failed to generate mortise volume from parameters and beam: {}".format(str(e))
             )
 
         # fillet the edges of the mortise volume based on the shape
@@ -445,9 +445,10 @@ class Mortise(BTLxProcessing):
                 edges = mortise_volume.edges[:8]
                 mortise_volume.fillet(self.shape_radius, edges)
             except Exception as e:
+                # mortise_volume is still in model space here (not yet localized below), geometry is local
                 raise FeatureApplicationError(
                     mortise_volume,
-                    geometry,
+                    geometry.transformed(beam.modeltransformation),
                     "Failed to fillet the edges of the tenon volume based on the shape: {}".format(str(e)),
                 )
         # transform mortise volume to local coordinates of the beam
@@ -458,7 +459,9 @@ class Mortise(BTLxProcessing):
             return geometry - mortise_volume
         except Exception as e:
             raise FeatureApplicationError(
-                mortise_volume, geometry, "Failed to remove mortise volume from geometry: {}".format(str(e))
+                mortise_volume.transformed(beam.modeltransformation),
+                geometry.transformed(beam.modeltransformation),
+                "Failed to remove mortise volume from geometry: {}".format(str(e)),
             )
 
     def frame_from_params_and_beam(self, beam):

--- a/src/compas_timber/fabrication/pocket.py
+++ b/src/compas_timber/fabrication/pocket.py
@@ -555,16 +555,16 @@ class Pocket(BTLxProcessing):
             pocket_volume = Brep.from_mesh(polyhedron_volume.to_mesh())
         except Exception as e:
             raise FeatureApplicationError(
-                polyhedron_volume,
-                geometry,
+                polyhedron_volume.transformed(element.modeltransformation),
+                geometry.transformed(element.modeltransformation),
                 "The pocket volume could not be converted to a Brep." + str(e),
             )
         try:
             return geometry - pocket_volume
         except Exception as e:
             raise FeatureApplicationError(
-                pocket_volume,
-                geometry,
+                pocket_volume.transformed(element.modeltransformation),
+                geometry.transformed(element.modeltransformation),
                 "The pocket volume does not intersect with the element geometry." + str(e),
             )
 
@@ -847,8 +847,8 @@ class PocketProxy(object):
             return geometry - self.volume
         except IndexError:
             raise FeatureApplicationError(
-                self.volume,
-                geometry,
+                self.volume.transformed(self.element.modeltransformation),
+                geometry.transformed(self.element.modeltransformation),
                 "The volume to subtract does not intersect with element geometry.",
             )
 

--- a/src/compas_timber/fabrication/simple_scarf.py
+++ b/src/compas_timber/fabrication/simple_scarf.py
@@ -258,8 +258,8 @@ class SimpleScarf(BTLxProcessing):
             drill_volumes = [Brep.from_cylinder(dv) for dv in drill_volumes]
         except Exception:
             raise FeatureApplicationError(
-                scarf_volume,
-                geometry,
+                scarf_volume.transformed(beam.modeltransformation),
+                geometry.transformed(beam.modeltransformation),
                 "Could not convert the scarf volume mesh to a Brep."
             )
 
@@ -273,13 +273,13 @@ class SimpleScarf(BTLxProcessing):
                     return b
         except IndexError:
             raise FeatureApplicationError(
-                scarf_volume,
-                geometry,
+                scarf_volume.transformed(beam.modeltransformation),
+                geometry.transformed(beam.modeltransformation),
                 "The scarf volume does not intersect with the beam geometry."
             )
         raise FeatureApplicationError(
-            scarf_volume,
-            geometry,
+            scarf_volume.transformed(beam.modeltransformation),
+            geometry.transformed(beam.modeltransformation),
             "No valid result solid found after boolean difference: the beam midpoint is not contained in any result Brep.",
         )
 

--- a/src/compas_timber/fabrication/slot.py
+++ b/src/compas_timber/fabrication/slot.py
@@ -392,8 +392,8 @@ class Slot(BTLxProcessing):
 
         except Exception:
             raise FeatureApplicationError(
-                subtraction_volume,
-                geometry,
+                subtraction_volume.transformed(beam.modeltransformation),
+                geometry.transformed(beam.modeltransformation),
                 "The slot subtracting volume does not intersect with the beam geometry."
                 )
 

--- a/src/compas_timber/fabrication/step_joint.py
+++ b/src/compas_timber/fabrication/step_joint.py
@@ -362,7 +362,7 @@ class StepJoint(BTLxProcessing):
             cutting_planes = self.planes_from_params_and_beam(beam)
         except ValueError as e:
             raise FeatureApplicationError(
-                None, geometry, "Failed to generate cutting planes from parameters and beam: {}".format(str(e))
+                None, geometry.transformed(beam.modeltransformation), "Failed to generate cutting planes from parameters and beam: {}".format(str(e))
             )
         cutting_planes = [plane.transformed(beam.transformation_to_local()) for plane in cutting_planes]
 
@@ -373,7 +373,9 @@ class StepJoint(BTLxProcessing):
                     geometry.trim(cutting_plane)
                 except Exception as e:
                     raise FeatureApplicationError(
-                        cutting_plane, geometry, "Failed to trim geometry with cutting planes: {}".format(str(e))
+                        cutting_plane.transformed(beam.modeltransformation),
+                        geometry.transformed(beam.modeltransformation),
+                        "Failed to trim geometry with cutting planes: {}".format(str(e)),
                     )
 
         elif self.step_shape == StepShapeType.HEEL:
@@ -384,7 +386,9 @@ class StepJoint(BTLxProcessing):
                     trimmed_geometies.append(geometry.trimmed(cutting_plane))
                 except Exception as e:
                     raise FeatureApplicationError(
-                        cutting_plane, geometry, "Failed to trim geometry with cutting plane: {}".format(str(e))
+                        cutting_plane.transformed(beam.modeltransformation),
+                        geometry.transformed(beam.modeltransformation),
+                        "Failed to trim geometry with cutting plane: {}".format(str(e)),
                     )
             try:
                 geometry = (
@@ -392,7 +396,9 @@ class StepJoint(BTLxProcessing):
                 )  # TODO: should be swed (.sew()) for a cleaner Brep
             except Exception as e:
                 raise FeatureApplicationError(
-                    trimmed_geometies, geometry, "Failed to union trimmed geometries: {}".format(str(e))
+                    [g.transformed(beam.modeltransformation) for g in trimmed_geometies],
+                    geometry.transformed(beam.modeltransformation),
+                    "Failed to union trimmed geometries: {}".format(str(e)),
                 )
 
         elif self.step_shape == StepShapeType.TAPERED_HEEL:
@@ -402,7 +408,9 @@ class StepJoint(BTLxProcessing):
                 geometry.trim(cutting_plane)
             except Exception as e:
                 raise FeatureApplicationError(
-                    cutting_planes, geometry, "Failed to trim geometry with cutting plane: {}".format(str(e))
+                    [p.transformed(beam.modeltransformation) for p in cutting_planes],
+                    geometry.transformed(beam.modeltransformation),
+                    "Failed to trim geometry with cutting plane: {}".format(str(e)),
                 )
 
         elif self.step_shape == StepShapeType.DOUBLE:
@@ -412,7 +420,9 @@ class StepJoint(BTLxProcessing):
                 geometry.trim(cutting_planes[-1])
             except Exception as e:
                 raise FeatureApplicationError(
-                    cutting_planes[-1], geometry, "Failed to trim geometry with cutting plane: {}".format(str(e))
+                    cutting_planes[-1].transformed(beam.modeltransformation),
+                    geometry.transformed(beam.modeltransformation),
+                    "Failed to trim geometry with cutting plane: {}".format(str(e)),
                 )
             # trim geometry with first two cutting planes
             trimmed_geometies = []
@@ -422,7 +432,9 @@ class StepJoint(BTLxProcessing):
                     trimmed_geometies.append(geometry.trimmed(cutting_plane))
                 except Exception as e:
                     raise FeatureApplicationError(
-                        cutting_plane, geometry, "Failed to trim geometry with cutting plane: {}".format(str(e))
+                        cutting_plane.transformed(beam.modeltransformation),
+                        geometry.transformed(beam.modeltransformation),
+                        "Failed to trim geometry with cutting plane: {}".format(str(e)),
                     )
             try:
                 geometry = (
@@ -430,7 +442,9 @@ class StepJoint(BTLxProcessing):
                 )  # TODO: should be swed (.sew()) for a cleaner Brep
             except Exception as e:
                 raise FeatureApplicationError(
-                    trimmed_geometies, geometry, "Failed to union trimmed geometries: {}".format(str(e))
+                    [g.transformed(beam.modeltransformation) for g in trimmed_geometies],
+                    geometry.transformed(beam.modeltransformation),
+                    "Failed to union trimmed geometries: {}".format(str(e)),
                 )
 
         if self.tenon and self.step_shape != StepShapeType.DOUBLE:  # TODO: check if tenon applies only to step in BTLx
@@ -444,8 +458,8 @@ class StepJoint(BTLxProcessing):
                     tenon_volume.trim(cutting_planes[0])
                 except Exception as e:
                     raise FeatureApplicationError(
-                        cutting_planes[0],
-                        tenon_volume,
+                        cutting_planes[0].transformed(beam.modeltransformation),
+                        tenon_volume.transformed(beam.modeltransformation),
                         "Failed to trim tenon volume with cutting plane: {}".format(str(e)),
                     )
                 # trim tenon volume with second cutting plane if tenon height is greater than step depth
@@ -454,8 +468,8 @@ class StepJoint(BTLxProcessing):
                         tenon_volume.trim(cutting_planes[1])
                     except Exception as e:
                         raise FeatureApplicationError(
-                            cutting_planes[1],
-                            tenon_volume,
+                            cutting_planes[1].transformed(beam.modeltransformation),
+                            tenon_volume.transformed(beam.modeltransformation),
                             "Failed to trim tenon volume with second cutting plane: {}".format(str(e)),
                         )
             # add tenon volume to geometry
@@ -463,7 +477,9 @@ class StepJoint(BTLxProcessing):
                 geometry += tenon_volume
             except Exception as e:
                 raise FeatureApplicationError(
-                    tenon_volume, geometry, "Failed to add tenon volume to geometry: {}".format(str(e))
+                    tenon_volume.transformed(beam.modeltransformation),
+                    geometry.transformed(beam.modeltransformation),
+                    "Failed to add tenon volume to geometry: {}".format(str(e)),
                 )
 
         return geometry

--- a/src/compas_timber/fabrication/step_joint_notch.py
+++ b/src/compas_timber/fabrication/step_joint_notch.py
@@ -464,7 +464,7 @@ class StepJointNotch(BTLxProcessing):
             cutting_planes = self.planes_from_params_and_beam(beam)
         except ValueError as e:
             raise FeatureApplicationError(
-                None, geometry, "Failed to generate cutting planes from parameters and beam: {}".format(str(e))
+                None, geometry.transformed(beam.modeltransformation), "Failed to generate cutting planes from parameters and beam: {}".format(str(e))
             )
 
         [plane.transform(beam.transformation_to_local()) for plane in cutting_planes]
@@ -479,8 +479,8 @@ class StepJointNotch(BTLxProcessing):
                     subtraction_volume.trim(cutting_plane)
             except Exception as e:
                 raise FeatureApplicationError(
-                    cutting_planes[-1],
-                    subtraction_volume,
+                    cutting_planes[-1].transformed(beam.modeltransformation),
+                    subtraction_volume.transformed(beam.modeltransformation),
                     "Failed to trim geometry with cutting plane: {}".format(str(e)),
                 )
             # trim geometry with two middle cutting planes
@@ -491,8 +491,8 @@ class StepJointNotch(BTLxProcessing):
                     trimmed_geometies.append(subtraction_volume.trimmed(cutting_plane))
                 except Exception as e:
                     raise FeatureApplicationError(
-                        cutting_plane,
-                        subtraction_volume,
+                        cutting_plane.transformed(beam.modeltransformation),
+                        subtraction_volume.transformed(beam.modeltransformation),
                         "Failed to trim geometry with cutting plane: {}".format(str(e)),
                     )
             subtraction_volume = trimmed_geometies
@@ -504,8 +504,8 @@ class StepJointNotch(BTLxProcessing):
                     subtraction_volume.trim(cutting_plane)
                 except Exception as e:
                     raise FeatureApplicationError(
-                        cutting_plane,
-                        subtraction_volume,
+                        cutting_plane.transformed(beam.modeltransformation),
+                        subtraction_volume.transformed(beam.modeltransformation),
                         "Failed to trim geometry with cutting planes: {}".format(str(e)),
                     )
         ## subtract volume from geometry
@@ -515,7 +515,9 @@ class StepJointNotch(BTLxProcessing):
                     geometry -= sub_vol
                 except Exception as e:
                     raise FeatureApplicationError(
-                        sub_vol, geometry, "Failed to subtract volume from geometry: {}".format(str(e))
+                        sub_vol.transformed(beam.modeltransformation),
+                        geometry.transformed(beam.modeltransformation),
+                        "Failed to subtract volume from geometry: {}".format(str(e)),
                     )
         else:
             geometry -= subtraction_volume
@@ -537,16 +539,16 @@ class StepJointNotch(BTLxProcessing):
                 mortise_volume.trim(cutting_plane_step)
             except Exception as e:
                 raise FeatureApplicationError(
-                    cutting_plane_step,
-                    mortise_volume,
+                    cutting_plane_step.transformed(beam.modeltransformation),
+                    mortise_volume.transformed(beam.modeltransformation),
                     "Failed to trim mortise volume with step cutting plane: {}".format(str(e)),
                 )
             try:
                 geometry -= mortise_volume
             except Exception as e:
                 raise FeatureApplicationError(
-                    mortise_volume,
-                    subtraction_volume,
+                    mortise_volume.transformed(beam.modeltransformation),
+                    subtraction_volume.transformed(beam.modeltransformation),
                     "Failed to subtract mortise volume from geometry: {}".format(str(e)),
                 )
         return geometry

--- a/src/compas_timber/fabrication/tenon.py
+++ b/src/compas_timber/fabrication/tenon.py
@@ -539,7 +539,7 @@ class Tenon(BTLxProcessing):
             cutting_plane = Plane.from_frame(self.frame_from_params_and_beam(beam))
         except ValueError as e:
             raise FeatureApplicationError(
-                None, geometry, "Failed to generate cutting frame from parameters and beam: {}".format(str(e))
+                None, geometry.transformed(beam.modeltransformation), "Failed to generate cutting frame from parameters and beam: {}".format(str(e))
             )
 
         cutting_plane.transform(beam.transformation_to_local())
@@ -549,14 +549,16 @@ class Tenon(BTLxProcessing):
             geometry.trim(cutting_plane)
         except Exception as e:
             raise FeatureApplicationError(
-                cutting_plane, geometry, "Failed to trim geometry with cutting plane: {}".format(str(e))
+                cutting_plane.transformed(beam.modeltransformation),
+                geometry.transformed(beam.modeltransformation),
+                "Failed to trim geometry with cutting plane: {}".format(str(e)),
             )
         # get tenon volume from params and beam
         try:
             tenon_volume = self.volume_from_params_and_beam(beam)
         except ValueError as e:
             raise FeatureApplicationError(
-                None, geometry, "Failed to generate tenon volume from parameters and beam: {}".format(str(e))
+                None, geometry.transformed(beam.modeltransformation), "Failed to generate tenon volume from parameters and beam: {}".format(str(e))
             )
         # fillet the edges of the volume based on the shape
         if self.shape is not TenonShapeType.SQUARE:
@@ -564,9 +566,10 @@ class Tenon(BTLxProcessing):
                 edges = tenon_volume.edges[:8]
                 tenon_volume.fillet(self.shape_radius, edges)
             except Exception as e:
+                # tenon_volume is still in model space here (not yet localized below), geometry is local
                 raise FeatureApplicationError(
                     tenon_volume,
-                    geometry,
+                    geometry.transformed(beam.modeltransformation),
                     "Failed to fillet the edges of the tenon volume based on the shape: {}".format(str(e)),
                 )
 
@@ -583,7 +586,9 @@ class Tenon(BTLxProcessing):
             geometry += tenon_volume
         except Exception as e:
             raise FeatureApplicationError(
-                tenon_volume, geometry, "Failed to add tenon volume to geometry: {}".format(str(e))
+                tenon_volume.transformed(beam.modeltransformation),
+                geometry.transformed(beam.modeltransformation),
+                "Failed to add tenon volume to geometry: {}".format(str(e)),
             )
         return geometry
 

--- a/tests/compas_timber/test_model.py
+++ b/tests/compas_timber/test_model.py
@@ -275,7 +275,42 @@ def test_error_deepcopy_joint():
     assert error.beams == "mama"
     assert error.joint == "papa"
     assert error.debug_info == "dog"
-    assert error.debug_geometries == "cucumber"
+    assert error.debug_geometries == ["cucumber"]
+
+
+def test_feature_application_error_geometry_is_in_model_space():
+    """A FeatureApplicationError caught by compute_elementgeometry() must carry geometry in
+    model space, not the local/element space `apply()` operates in."""
+    from compas.geometry import bounding_box
+
+    from compas_timber.errors import FeatureApplicationError
+
+    class _FailingFeature(object):
+        """Mimics a real BTLxProcessing.apply(): receives local-space geometry and raises a
+        FeatureApplicationError with geometry already transformed to model space, exactly as
+        production code does."""
+
+        def apply(self, geometry, beam):
+            raise FeatureApplicationError(None, geometry.transformed(beam.modeltransformation), "boom")
+
+    frame = Frame(Point(1000, 2000, 300), Vector(1, 0, 0), Vector(0, 1, 0))
+    beam = Beam(frame=frame, width=100, height=200, length=1000)
+    beam.add_features(_FailingFeature())
+
+    beam.geometry  # triggers compute_elementgeometry(), which catches the error into debug_info
+
+    assert len(beam.debug_info) == 1
+    error = beam.debug_info[0]
+    assert isinstance(error, FeatureApplicationError)
+
+    error_bbox = bounding_box([v.point for v in error.element_geometry.vertices])
+    blank_bbox = bounding_box(beam.blank.points)
+    for error_point, blank_point in zip(error_bbox, blank_bbox):
+        assert Point(*error_point).distance_to_point(Point(*blank_point)) < 1e-6
+
+    # sanity check: local-space geometry would sit near the origin, far from the beam's actual position
+    origin_distance = min(v.point.distance_to_point(Point(0, 0, 0)) for v in error.element_geometry.vertices)
+    assert origin_distance > 900
 
 
 def test_beam_graph_node_available_after_serialization():

--- a/tests/compas_timber/test_model.py
+++ b/tests/compas_timber/test_model.py
@@ -1,3 +1,4 @@
+import pytest
 from pytest import raises
 
 from copy import deepcopy
@@ -277,7 +278,7 @@ def test_error_deepcopy_joint():
     assert error.debug_info == "dog"
     assert error.debug_geometries == ["cucumber"]
 
-
+@pytest.mark.requires_occ
 def test_feature_application_error_geometry_is_in_model_space():
     """A FeatureApplicationError caught by compute_elementgeometry() must carry geometry in
     model space, not the local/element space `apply()` operates in."""


### PR DESCRIPTION
FeatureApplicationError and BeamJoiningError carry geometry meant for downstream error visualization (the GH DebugInfomation component draws it directly in the Rhino document — i.e. world/model space). The geometry space was inconsistent depending on where the error was raised:

- FeatureApplicationError: errors raised inside `BTLxProcessing.apply()` (~55 sites across 16 fabrication/*.py files) stored local/element-space geometry, since that's the space apply() itself operates in. Errors raised outside apply() (`Drilling.from_line_and_element`, `BTLxFromGeometryDefinition.feature_from_element`) already used global/model-space geometry. Same exception type, two conventions depending on call path.
- BeamJoiningError: mostly already consistent, but 3 call sites misused the constructor's (beams, joint, debug_info=None, debug_geometries=None) signature — one (plate_joint.py) would actually crash with TypeError rather than raise BeamJoiningError, since it omitted the required joint argument.

This PR:
1. Makes every FeatureApplicationError raised inside apply() transform its geometry to model space inline before construction (`geometry.transformed(beam.modeltransformation)`), matching the already-global sites.
2. Fixes the 3 BeamJoiningError constructor bugs found while auditing every call site for the same consistency issue.
3. Documents the "always model space" invariant on both exception classes' docstrings, and makes `BeamJoiningError.debug_geometries` tolerant of a single geometry being passed instead of a list.


### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).
