### PR TITLE
add `TimberModel.unpromoted_joint_candidates`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Added `Joint.reset_location()`, which clears the joint's cached location and allows it to be recomputed if needed.
 * Added `brep_from_outlines` to `compas_timber.geometry`.
+* Added `TimberModel.unpromoted_joint_candidates`, returning only the `JointCandidate` instances that have not yet been promoted to a joint on the same edge.
 
 ### Changed
 * `FeatureApplicationError` raised from `BTLxProcessing.apply()` now carries geometry in the model's global coordinate system (previously local/element space), matching errors raised elsewhere. 

--- a/src/compas_timber/model.py
+++ b/src/compas_timber/model.py
@@ -129,9 +129,7 @@ class TimberModel(Model):
         return candidates
 
     @property
-    def unpromoted_joint_candidates(self):
-        """returns JointCandidates that lie on edges that don't also have a Joint instance on them."""
-        # type: () -> set[JointCandidate]
+    def unpromoted_joint_candidates(self) -> set[JointCandidate]:
         unpromoted = set()
         for edge in self._graph.edges():
             edge_candidate = self._graph.edge_attribute(edge, "candidates")

--- a/src/compas_timber/model.py
+++ b/src/compas_timber/model.py
@@ -129,6 +129,18 @@ class TimberModel(Model):
         return candidates
 
     @property
+    def unpromoted_joint_candidates(self):
+        """returns JointCandidates that lie on edges that don't also have a Joint instance on them."""
+        # type: () -> set[JointCandidate]
+        unpromoted = set()
+        for edge in self._graph.edges():
+            edge_candidate = self._graph.edge_attribute(edge, "candidates")
+            edge_joint = self._graph.edge_attribute(edge, "joints")
+            if edge_candidate is not None and edge_joint is None:
+                unpromoted.add(edge_candidate)
+        return unpromoted
+
+    @property
     def topologies(self):
         return self._topologies
 

--- a/tests/compas_timber/test_model.py
+++ b/tests/compas_timber/test_model.py
@@ -278,6 +278,7 @@ def test_error_deepcopy_joint():
     assert error.debug_info == "dog"
     assert error.debug_geometries == ["cucumber"]
 
+
 @pytest.mark.requires_occ
 def test_feature_application_error_geometry_is_in_model_space():
     """A FeatureApplicationError caught by compute_elementgeometry() must carry geometry in

--- a/tests/compas_timber/test_model.py
+++ b/tests/compas_timber/test_model.py
@@ -416,6 +416,32 @@ def test_joint_candidates_and_joints_separate():
     assert beam3 in joint.elements
 
 
+def test_unpromoted_joint_candidates_excludes_promoted():
+    """Test that a candidate promoted to a joint on the same edge drops out of unpromoted_joint_candidates but stays in joint_candidates."""
+    model = TimberModel()
+
+    line1 = Line(Point(0, 0, 0), Point(1, 0, 0))
+    line2 = Line(Point(0.5, -0.5, 0), Point(0.5, 0.5, 0))
+
+    beam1 = Beam.from_centerline(line1, 0.1, 0.1)
+    beam2 = Beam.from_centerline(line2, 0.1, 0.1)
+
+    model.add_element(beam1)
+    model.add_element(beam2)
+
+    model.connect_adjacent_beams()
+
+    assert len(model.joint_candidates) == 1
+    assert len(model.unpromoted_joint_candidates) == 1
+
+    candidate = list(model.joint_candidates)[0]
+    LButtJoint.promote_joint_candidate(model, candidate)
+
+    # promoting doesn't remove the candidate: it now coexists with the joint on the same edge
+    assert len(model.joint_candidates) == 1
+    assert len(model.unpromoted_joint_candidates) == 0
+
+
 def test_remove_joint_candidates():
     """Test removal of joint candidates."""
     # Create a model with multiple beams


### PR DESCRIPTION
Add `TimberModel.unpromoted_joint_candidates`, which returns only the `JointCandidate` instances that have **not** yet been promoted to a real `Joint` on the same graph edge.

The existing `TimberModel.joint_candidates` returns *every* candidate on the graph, even ones whose edge has since been promoted to a joint — `add_joint_candidate` intentionally allows a `candidates` and a `joints` attribute to coexist on the same edge, and `promote_joint_candidate` does not clear the candidate after creating the joint. This made it impossible to ask "which candidates still need a decision?" without manually cross-referencing `joint_candidates` against `joints`. This property answers that directly.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`). *(ran `tests/compas_timber/test_model.py`: 36 passed)*
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`). *(ran `ruff check` on the two changed files — clean)*
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`. *(N/A — this is a property on the existing `TimberModel` class, not a new top-level export)*
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate). 