### PR TITLE
CompositeJoint -> ClusterJoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-* Added `CompositeJoint`, which is a Joint composed of a list of pairwise joints, intended to make 3+ element joint definition simpler. Typical use via `CompositeJointRule` in timber_design repo.
+* Added `ClusterJoint`, which is a Joint composed of a list of pairwise joints, intended to make 3+ element joint definition simpler. Typical use via `CompositeJointRule` in timber_design repo.
 * Added `Joint.reset_location()`, which clears the joint's cached location and allows it to be recomputed if needed.
 * Added `brep_from_outlines` to `compas_timber.geometry`.
 * Added `TimberModel.unpromoted_joint_candidates`, returning only the `JointCandidate` instances that have not yet been promoted to a joint on the same edge.

--- a/docs/contribution/class_diagrams.md
+++ b/docs/contribution/class_diagrams.md
@@ -407,7 +407,7 @@ classDiagram
          +beams : list
       }
 
-      class CompositeJoint {
+      class ClusterJoint {
          +joints : list[Joint]
          +elements : tuple[Element]
          +location : Point
@@ -476,8 +476,8 @@ classDiagram
       Joint <|-- TDovetailJoint
       Joint <|-- TStepJoint
       Joint <|-- YButtJoint
-      Joint <|-- CompositeJoint
-      CompositeJoint "1" *-- "1..*" Joint : sub-joints
+      Joint <|-- ClusterJoint
+      ClusterJoint "1" *-- "1..*" Joint : sub-joints
 
       Joint <|-- PlateJoint
 

--- a/src/compas_timber/connections/__init__.py
+++ b/src/compas_timber/connections/__init__.py
@@ -44,7 +44,7 @@ from .panel_miter_joint import PanelMiterJoint
 from .panel_layer_butt_joint import PanelLLayerButtJoint
 from .cluster import Cluster
 from .cluster import get_clusters_from_joint_candidates
-from .composite_joint import CompositeJoint
+from .cluster_joint import ClusterJoint
 
 
 __all__ = [
@@ -96,5 +96,5 @@ __all__ = [
     "PanelLLayerButtJoint",
     "Cluster",
     "get_clusters_from_joint_candidates",
-    "CompositeJoint",
+    "ClusterJoint",
 ]

--- a/src/compas_timber/connections/cluster.py
+++ b/src/compas_timber/connections/cluster.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 
+from compas.data import Data
 from compas.geometry import Point
 from compas.tolerance import TOL
 from compas_model.elements import Element
@@ -8,7 +9,7 @@ from compas_timber.connections import JointTopology
 from compas_timber.geometry import KDTree
 
 
-class Cluster:
+class Cluster(Data):
     """Groups together the clustered joints and offers access to the beams
 
     Parameters
@@ -25,8 +26,12 @@ class Cluster:
     location : :class:`~compas.geometry.Point`
         The approximated location of the cluster, effectively the location of the first joint.
     """
+    @property
+    def __data__(self):
+        return {"joints": self.joints}
 
     def __init__(self, joints):
+        super(Cluster, self).__init__()
         self.joints = joints
         self._elements = None
 

--- a/src/compas_timber/connections/cluster.py
+++ b/src/compas_timber/connections/cluster.py
@@ -26,6 +26,7 @@ class Cluster(Data):
     location : :class:`~compas.geometry.Point`
         The approximated location of the cluster, effectively the location of the first joint.
     """
+
     @property
     def __data__(self):
         return {"joints": self.joints}

--- a/src/compas_timber/connections/cluster_joint.py
+++ b/src/compas_timber/connections/cluster_joint.py
@@ -8,15 +8,16 @@ from .solver import JointTopology
 
 if TYPE_CHECKING:
     from compas_timber.model import TimberModel
+from compas_timber.errors import BeamJoiningError
 
 
-class CompositeJoint(Joint):
+class ClusterJoint(Joint):
     """A joint composed of multiple pairwise sub-joints acting on a cluster of 3 or more elements.
 
     Instead of defining a single fabrication strategy for the whole cluster, this joint
     delegates all feature and extension calculations to a list of pairwise sub-joints.
     The sub-joints are instantiated without being registered in the model; only the
-    CompositeJoint itself is added.
+    ClusterJoint itself is added.
 
     Parameters
     ----------
@@ -45,16 +46,15 @@ class CompositeJoint(Joint):
     MIN_ELEMENT_COUNT = 3
     MAX_ELEMENT_COUNT = None
 
-    def __init__(self, joints, name=None, cluster=None, **kwargs):
-        self.joints = joints
-        self._cluster = cluster
-        elements = list(set([e for j in joints for e in j.elements]))
-        super(CompositeJoint, self).__init__(elements=elements, name=name, **kwargs)
+    def __init__(self, cluster, name=None, **kwargs):
+        self.cluster = cluster
+        elements = cluster.elements
+        super(ClusterJoint, self).__init__(elements=elements, name=name, **kwargs)
 
     @property
     def __data__(self):
         data = super().__data__
-        data["joints"] = self.joints
+        data["cluster"] = self.cluster
         return data
 
     def __repr__(self):
@@ -71,11 +71,9 @@ class CompositeJoint(Joint):
         return self.cluster.topology
 
     @property
-    def cluster(self):
+    def joints(self):
         """The cluster of elements connected by this joint."""
-        if self._cluster is None:
-            self._cluster = Cluster(self.joints)
-        return self._cluster
+        return self.cluster.joints
 
     @property
     def features(self):
@@ -91,8 +89,8 @@ class CompositeJoint(Joint):
         pass
 
     @classmethod
-    def create(cls, model, joints=None, **kwargs):
-        """Creates a CompositeJoint and registers it in the model.
+    def create(cls, model, cluster=None, **kwargs):
+        """Creates a ClusterJoint and registers it in the model.
 
         Parameters
         ----------
@@ -103,11 +101,43 @@ class CompositeJoint(Joint):
 
         Returns
         -------
-        :class:`~compas_timber.connections.CompositeJoint`
+        :class:`~compas_timber.connections.ClusterJoint`
         """
-        joint = cls(joints=joints, **kwargs)
+        joint = cls(cluster=cluster, **kwargs)
         model.add_joint(joint)
         return joint
+
+    @classmethod
+    def promote_cluster(cls, model, cluster, reordered_elements=None, **kwargs):
+        """Creates an instance of this joint from a cluster of elements.
+
+        Parameters
+        ----------
+        model : :class:`~compas_timber.model.TimberModel`
+            The model to which the elements and this joint belong.
+        cluster : :class:`~compas_model.clusters.Cluster`
+            The cluster containing the elements to be connected by this joint.
+        reordered_elements : list(:class:`~compas_model.elements.Element`), optional
+            The elements to be connected by this joint. If not provided, the elements of the cluster will be used.
+            This is used to explicitly define the element order.
+        **kwargs : dict
+            Additional keyword arguments that are passed to the joint's constructor.
+
+        Returns
+        -------
+        :class:`compas_timber.connections.Joint`
+            The instance of the created joint.
+
+        """
+        if reordered_elements:
+            if set(reordered_elements) != cluster.elements:
+                raise BeamJoiningError(
+                    beams=reordered_elements,
+                    joint=cls,
+                    debug_info="Elements of the joint candidate must match the provided elements.",
+                    debug_geometries=[e.blank for e in reordered_elements],
+                )
+        return cls.create(model, cluster, **kwargs)
 
     def add_features(self):
         """Delegates feature calculation to each sub-joint."""

--- a/src/compas_timber/connections/cluster_joint.py
+++ b/src/compas_timber/connections/cluster_joint.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from .joint import Joint
 from .solver import JointTopology
+from .cluster import Cluster
 
 if TYPE_CHECKING:
     from compas_timber.model import TimberModel
@@ -158,3 +159,8 @@ class ClusterJoint(Joint):
             joint.restore_elements_from_keys(model)
             joint._set_unset_attributes()
         self._elements = tuple(set([e for j in self.joints for e in j.elements]))
+
+    @classmethod
+    def from_joints(cls, joints: list[Joint])->ClusterJoint:
+        cluster = Cluster(joints)
+        return cls(cluster=cluster)

--- a/src/compas_timber/connections/cluster_joint.py
+++ b/src/compas_timber/connections/cluster_joint.py
@@ -108,7 +108,7 @@ class ClusterJoint(Joint):
         return joint
 
     @classmethod
-    def promote_cluster(cls, model, cluster, reordered_elements=None, **kwargs):
+    def promote_cluster(cls, model, cluster, **kwargs):
         """Creates an instance of this joint from a cluster of elements.
 
         Parameters
@@ -117,9 +117,6 @@ class ClusterJoint(Joint):
             The model to which the elements and this joint belong.
         cluster : :class:`~compas_model.clusters.Cluster`
             The cluster containing the elements to be connected by this joint.
-        reordered_elements : list(:class:`~compas_model.elements.Element`), optional
-            The elements to be connected by this joint. If not provided, the elements of the cluster will be used.
-            This is used to explicitly define the element order.
         **kwargs : dict
             Additional keyword arguments that are passed to the joint's constructor.
 
@@ -129,14 +126,6 @@ class ClusterJoint(Joint):
             The instance of the created joint.
 
         """
-        if reordered_elements:
-            if set(reordered_elements) != cluster.elements:
-                raise BeamJoiningError(
-                    beams=reordered_elements,
-                    joint=cls,
-                    debug_info="Elements of the joint candidate must match the provided elements.",
-                    debug_geometries=[e.blank for e in reordered_elements],
-                )
         return cls.create(model, cluster, **kwargs)
 
     def add_features(self):

--- a/src/compas_timber/connections/cluster_joint.py
+++ b/src/compas_timber/connections/cluster_joint.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .cluster import Cluster
 from .joint import Joint
 from .solver import JointTopology
 
 if TYPE_CHECKING:
     from compas_timber.model import TimberModel
-from compas_timber.errors import BeamJoiningError
 
 
 class ClusterJoint(Joint):

--- a/tests/compas_timber/test_cluster_joint.py
+++ b/tests/compas_timber/test_cluster_joint.py
@@ -1,4 +1,4 @@
-"""Tests for CompositeJoint — a multi-beam joint that delegates to pairwise sub-joints."""
+"""Tests for ClusterJoint — a multi-beam joint that delegates to pairwise sub-joints."""
 
 import pytest
 
@@ -7,7 +7,8 @@ from compas.data import json_loads
 from compas.geometry import Line
 from compas.geometry import Point
 
-from compas_timber.connections import CompositeJoint
+from compas_timber.connections import Cluster
+from compas_timber.connections import ClusterJoint
 from compas_timber.connections import LButtJoint
 from compas_timber.connections import TButtJoint
 from compas_timber.connections.solver import JointTopology
@@ -72,7 +73,7 @@ def sub_joints(beam_a, beam_b, beam_c):
 
 @pytest.fixture
 def composite(model, sub_joints):
-    return CompositeJoint.create(model, joints=sub_joints)
+    return ClusterJoint.create(model, cluster=Cluster(sub_joints))
 
 
 # ---------------------------------------------------------------------------
@@ -81,12 +82,12 @@ def composite(model, sub_joints):
 
 
 def test_create_returns_composite_joint(model, sub_joints):
-    joint = CompositeJoint.create(model, joints=sub_joints)
-    assert isinstance(joint, CompositeJoint)
+    joint = ClusterJoint.create(model, cluster=Cluster(sub_joints))
+    assert isinstance(joint, ClusterJoint)
 
 
 def test_create_registers_in_model(model, sub_joints):
-    CompositeJoint.create(model, joints=sub_joints)
+    ClusterJoint.create(model, cluster=Cluster(sub_joints))
     assert len(list(model.joints)) == 1
 
 
@@ -106,7 +107,7 @@ def test_composite_elements_are_union_of_sub_joint_elements(composite, beam_a, b
 
 def test_repr(composite):
     r = repr(composite)
-    assert "CompositeJoint" in r
+    assert "ClusterJoint" in r
     assert "2" in r  # 2 sub-joints
 
 
@@ -116,15 +117,15 @@ def test_repr(composite):
 
 
 def test_supported_topology():
-    assert CompositeJoint.SUPPORTED_TOPOLOGY == JointTopology.TOPO_UNKNOWN
+    assert ClusterJoint.SUPPORTED_TOPOLOGY == JointTopology.TOPO_UNKNOWN
 
 
 def test_min_element_count():
-    assert CompositeJoint.MIN_ELEMENT_COUNT == 3
+    assert ClusterJoint.MIN_ELEMENT_COUNT == 3
 
 
 def test_max_element_count_is_none():
-    assert CompositeJoint.MAX_ELEMENT_COUNT is None
+    assert ClusterJoint.MAX_ELEMENT_COUNT is None
 
 
 # ---------------------------------------------------------------------------
@@ -133,20 +134,20 @@ def test_max_element_count_is_none():
 
 
 def test_process_joinery_completes_without_error(model, sub_joints):
-    CompositeJoint.create(model, joints=sub_joints)
+    ClusterJoint.create(model, cluster=Cluster(sub_joints))
     errors = model.process_joinery()
     assert errors == []
 
 
 def test_process_joinery_adds_features_to_beams(model, beam_a, beam_b, beam_c, sub_joints):
-    CompositeJoint.create(model, joints=sub_joints)
+    ClusterJoint.create(model, cluster=Cluster(sub_joints))
     model.process_joinery()
     # Each L-butt joint adds at least one feature on the main beam (beam_a)
     assert len(beam_a.features) > 0
 
 
 def test_process_joinery_adds_features_to_cross_beams(model, beam_b, beam_c, sub_joints):
-    CompositeJoint.create(model, joints=sub_joints)
+    ClusterJoint.create(model, cluster=Cluster(sub_joints))
     model.process_joinery()
     assert len(beam_b.features) > 0
     assert len(beam_c.features) > 0
@@ -154,9 +155,9 @@ def test_process_joinery_adds_features_to_cross_beams(model, beam_b, beam_c, sub
 
 def test_process_joinery_does_not_add_sub_joints_to_model(model, sub_joints):
     """Sub-joints must not be independently registered in the model."""
-    CompositeJoint.create(model, joints=sub_joints)
+    ClusterJoint.create(model, cluster=Cluster(sub_joints))
     model.process_joinery()
-    # Only the one CompositeJoint should be in the model
+    # Only the one ClusterJoint should be in the model
     assert len(list(model.joints)) == 1
 
 
@@ -166,11 +167,7 @@ def test_process_joinery_does_not_add_sub_joints_to_model(model, sub_joints):
 
 
 def test_data_contains_joints_key(composite):
-    assert "joints" in composite.__data__
-
-
-def test_data_joints_length(composite):
-    assert len(composite.__data__["joints"]) == 2
+    assert "cluster" in composite.__data__
 
 
 def test_data_contains_element_guids(composite, beam_a, beam_b, beam_c):
@@ -180,24 +177,24 @@ def test_data_contains_element_guids(composite, beam_a, beam_b, beam_c):
 
 
 def test_json_roundtrip_model(model, sub_joints):
-    CompositeJoint.create(model, joints=sub_joints)
+    ClusterJoint.create(model, cluster=Cluster(sub_joints))
     restored = json_loads(json_dumps(model))
 
     joints = list(restored.joints)
     assert len(joints) == 1
     rj = joints[0]
-    assert isinstance(rj, CompositeJoint)
+    assert isinstance(rj, ClusterJoint)
 
 
 def test_json_roundtrip_sub_joint_count(model, sub_joints):
-    CompositeJoint.create(model, joints=sub_joints)
+    ClusterJoint.create(model, cluster=Cluster(sub_joints))
     restored = json_loads(json_dumps(model))
     rj = list(restored.joints)[0]
     assert len(rj.joints) == 2
 
 
 def test_json_roundtrip_sub_joint_types(model, sub_joints):
-    CompositeJoint.create(model, joints=sub_joints)
+    ClusterJoint.create(model, cluster=Cluster(sub_joints))
     restored = json_loads(json_dumps(model))
     rj = list(restored.joints)[0]
     for sub in rj.joints:
@@ -205,7 +202,7 @@ def test_json_roundtrip_sub_joint_types(model, sub_joints):
 
 
 def test_json_roundtrip_elements_restored(model, beam_a, beam_b, beam_c, sub_joints):
-    CompositeJoint.create(model, joints=sub_joints)
+    ClusterJoint.create(model, cluster=Cluster(sub_joints))
     restored = json_loads(json_dumps(model))
     rj = list(restored.joints)[0]
     # All element references must be live objects (not None) after deserialization
@@ -214,7 +211,7 @@ def test_json_roundtrip_elements_restored(model, beam_a, beam_b, beam_c, sub_joi
 
 
 def test_json_roundtrip_sub_joint_elements_restored(model, sub_joints):
-    CompositeJoint.create(model, joints=sub_joints)
+    ClusterJoint.create(model, cluster=Cluster(sub_joints))
     restored = json_loads(json_dumps(model))
     rj = list(restored.joints)[0]
     for sub in rj.joints:
@@ -224,7 +221,7 @@ def test_json_roundtrip_sub_joint_elements_restored(model, sub_joints):
 
 def test_json_roundtrip_process_joinery(model, sub_joints):
     """Deserialized model should still be able to run process_joinery."""
-    CompositeJoint.create(model, joints=sub_joints)
+    ClusterJoint.create(model, cluster=Cluster(sub_joints))
     restored = json_loads(json_dumps(model))
     errors = restored.process_joinery()
     assert errors == []
@@ -232,7 +229,7 @@ def test_json_roundtrip_process_joinery(model, sub_joints):
 
 def test_json_roundtrip_features_generated_after_reload(model, sub_joints):
     """After deserialization and process_joinery, features are added to beams."""
-    CompositeJoint.create(model, joints=sub_joints)
+    ClusterJoint.create(model, cluster=Cluster(sub_joints))
     restored = json_loads(json_dumps(model))
     restored.process_joinery()
     beams = list(restored.beams)
@@ -246,7 +243,7 @@ def test_json_roundtrip_features_generated_after_reload(model, sub_joints):
 
 
 def test_location_delegated_to_first_sub_joint(composite, sub_joints):
-    """CompositeJoint.location falls back to first sub-joint's location when not set."""
+    """ClusterJoint.location falls back to first sub-joint's location when not set."""
     assert composite.location is not None
 
 
@@ -256,7 +253,7 @@ def test_location_delegated_to_first_sub_joint(composite, sub_joints):
 
 
 def test_mixed_sub_joint_types(beam_a, beam_b, beam_c):
-    """CompositeJoint can hold sub-joints of different types."""
+    """ClusterJoint can hold sub-joints of different types."""
     # One L-type and one T-type sub-joint
     j_l = LButtJoint(main_beam=beam_a, cross_beam=beam_b)
     # beam_c crosses beam_a in T topology (approaching from the side)
@@ -264,7 +261,7 @@ def test_mixed_sub_joint_types(beam_a, beam_b, beam_c):
     j_t = TButtJoint(main_beam=beam_a, cross_beam=beam_t)
 
     m = _make_model(beam_a, beam_b, beam_c, beam_t)
-    joint = CompositeJoint.create(m, joints=[j_l, j_t])
+    joint = ClusterJoint.create(m, cluster=Cluster([j_l, j_t]))
 
     assert len(joint.joints) == 2
     assert isinstance(joint.joints[0], LButtJoint)
@@ -329,11 +326,11 @@ def test_mixed_sub_joints_json_roundtrip(beam_a, beam_b, beam_c):
     j_t = TButtJoint(main_beam=beam_a, cross_beam=beam_t)
 
     m = _make_model(beam_a, beam_b, beam_c, beam_t)
-    CompositeJoint.create(m, joints=[j_l, j_t])
+    ClusterJoint.create(m, cluster=Cluster([j_l, j_t]))
 
     restored = json_loads(json_dumps(m))
     rj = list(restored.joints)[0]
-    assert isinstance(rj, CompositeJoint)
+    assert isinstance(rj, ClusterJoint)
     sub_types = {type(s) for s in rj.joints}
     assert LButtJoint in sub_types
     assert TButtJoint in sub_types

--- a/tests/compas_timber/test_cluster_joint.py
+++ b/tests/compas_timber/test_cluster_joint.py
@@ -334,3 +334,71 @@ def test_mixed_sub_joints_json_roundtrip(beam_a, beam_b, beam_c):
     sub_types = {type(s) for s in rj.joints}
     assert LButtJoint in sub_types
     assert TButtJoint in sub_types
+
+
+# ---------------------------------------------------------------------------
+# 8. from_joints — cluster-derived properties
+# ---------------------------------------------------------------------------
+
+
+def test_from_joint_list_returns_cluster_joint(sub_joints):
+    joint = ClusterJoint.from_joints(sub_joints)
+    assert isinstance(joint, ClusterJoint)
+
+
+def test_from_joint_list_builds_cluster_from_joints(sub_joints):
+    joint = ClusterJoint.from_joints(sub_joints)
+    assert isinstance(joint.cluster, Cluster)
+    assert joint.cluster.joints == sub_joints
+
+
+def test_from_joint_list_joints_property_matches_input(sub_joints):
+    joint = ClusterJoint.from_joints(sub_joints)
+    assert list(joint.joints) == sub_joints
+
+
+def test_from_joint_list_elements_are_union_of_sub_joint_elements(sub_joints, beam_a, beam_b, beam_c):
+    joint = ClusterJoint.from_joints(sub_joints)
+    all_elements = set(joint.elements)
+    assert all_elements == {beam_a, beam_b, beam_c}
+
+
+def test_from_joint_list_location_matches_cluster_location(sub_joints):
+    joint = ClusterJoint.from_joints(sub_joints)
+    assert joint.location == joint.cluster.location
+
+
+def test_from_joint_list_topology_matches_cluster_topology(beam_a, beam_b, beam_c):
+    """Two L-topology sub-joints, none T/X, should collapse to TOPO_Y at the cluster level."""
+    j1 = LButtJoint(main_beam=beam_a, cross_beam=beam_b, topology=JointTopology.TOPO_L)
+    j2 = LButtJoint(main_beam=beam_a, cross_beam=beam_c, topology=JointTopology.TOPO_L)
+
+    joint = ClusterJoint.from_joints([j1, j2])
+
+    assert joint.cluster.topology == JointTopology.TOPO_Y
+    assert joint.topology == JointTopology.TOPO_Y
+
+
+def test_from_joint_list_topology_reflects_t_sub_joint(beam_a, beam_b, beam_c):
+    """A T-topology sub-joint in the mix should promote the cluster topology to TOPO_K."""
+    j_l = LButtJoint(main_beam=beam_a, cross_beam=beam_b, topology=JointTopology.TOPO_L)
+    beam_t = Beam.from_centerline(Line(Point(500, -500, 0), Point(500, 500, 0)), width=60, height=100)
+    j_t = TButtJoint(main_beam=beam_a, cross_beam=beam_t, topology=JointTopology.TOPO_T)
+
+    joint = ClusterJoint.from_joints([j_l, j_t])
+
+    assert joint.topology == JointTopology.TOPO_K
+
+
+def test_from_joint_list_not_registered_in_model(sub_joints, model):
+    """from_joints builds the joint standalone; it is not added to any model."""
+    ClusterJoint.from_joints(sub_joints)
+    assert len(list(model.joints)) == 0
+
+
+def test_from_joint_list_features_delegate_to_sub_joints(sub_joints):
+    joint = ClusterJoint.from_joints(sub_joints)
+    for sub in joint.joints:
+        sub.add_extensions()
+        sub.add_features()
+    assert joint.features == [f for sub in sub_joints for f in sub.features]


### PR DESCRIPTION
Rename `CompositeJoint` to `ClusterJoint`, gets a `Cluster` instead of a list of Joints, `Cluster` inherits `Data`, `ClusterJoint` serializes the cluster. 

The proposed `CompositeJoint` just takes a list of joints. a cluster is essentially a list of joints that can do some parsing of those joints. Those parsing functions/cluster properties are 1:1 the properties that this `CompositeJoint` ought to have. I therefore propose renaming this to `ClusterJoint` and making it take a cluster by default. I made the timber_design-side changes [here](https://github.com/gramaziokohler/timber_design/tree/cluster_joint).

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).
