### PR TITLE
Fix panel geometry computation in non-Rhino environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `Beam.remove_blank_extension()` raising `KeyError` when called for a joint/element pair that was never extended (e.g. `ButtJoint` only extends its `main_beam`, never `cross_beam`).
 * Fixed `BallNodeJoint`, `YButtJoint`, and `TOliGinaJoint` not recording all of the features they apply in `self.features`, which meant `clear_features()` (or the old per-joint clearing logic) could leave some features permanently stuck on the beams.
 * Fixed `PlateJoint.clear_extensions()` resetting *all* of an element's extensions when the joint never set one (e.g. `PlateTButtJoint`'s cross plate), instead of leaving unrelated joints' extensions untouched.
+* Fixed panel `Opening` geometry calculations in standalone environments by swapping `compas.geometry.Brep` for `compas_brep`.
 
 ### Removed
 * Removed depricated `features.py` module and related imports.

--- a/src/compas_timber/panel_features/opening.py
+++ b/src/compas_timber/panel_features/opening.py
@@ -80,7 +80,6 @@ class Opening(PanelFeature):
         """
         try:
             panel_geometry = Brep.from_boolean_difference(panel_geometry, self.shape.transformed(self.transformation))
-            # panel_geometry -= self.shape.transformed(self.transformation)
             return panel_geometry
         except Exception as e:
             raise FeatureApplicationError(panel_geometry, self.shape, f"Failed to apply opening to panel geometry: {e}")

--- a/src/compas_timber/panel_features/opening.py
+++ b/src/compas_timber/panel_features/opening.py
@@ -3,7 +3,6 @@ from enum import auto
 from compas.geometry import Box
 from compas.geometry import Frame
 from compas.geometry import Line
-from compas.geometry import NurbsCurve
 from compas.geometry import Plane
 from compas.geometry import Point
 from compas.geometry import Polyline
@@ -11,6 +10,7 @@ from compas.geometry import Transformation
 from compas.geometry import Vector
 from compas.geometry import intersection_line_plane
 from compas_brep import Brep
+from compas_brep import NurbsCurve
 
 from compas_timber.errors import FeatureApplicationError
 from compas_timber.utils import StrEnum
@@ -79,7 +79,8 @@ class Opening(PanelFeature):
 
         """
         try:
-            panel_geometry -= self.shape.transformed(self.transformation)
+            panel_geometry = Brep.from_boolean_difference(panel_geometry, self.shape.transformed(self.transformation))
+            # panel_geometry -= self.shape.transformed(self.transformation)
             return panel_geometry
         except Exception as e:
             raise FeatureApplicationError(panel_geometry, self.shape, f"Failed to apply opening to panel geometry: {e}")


### PR DESCRIPTION
Fixes a small bug occurring outside of the Rhino/Grasshopper environment where the geometry of panels with `Opening` features could not be computed.

`NurbsCurve` and the boolean subtraction were still relying on `compas.geometry.Brep` instead of `compas_brep`.

This PR imports `NurbsCurve` and executes the boolean operation with `compas_brep`.


### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).
