### PR TITLE
Fixes Deseiralization/Serialization bug for children elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `BallNodeJoint`, `YButtJoint`, and `TOliGinaJoint` not recording all of the features they apply in `self.features`, which meant `clear_features()` (or the old per-joint clearing logic) could leave some features permanently stuck on the beams.
 * Fixed `PlateJoint.clear_extensions()` resetting *all* of an element's extensions when the joint never set one (e.g. `PlateTButtJoint`'s cross plate), instead of leaving unrelated joints' extensions untouched.
 * Fixed panel `Opening` geometry calculations in standalone environments by swapping `compas.geometry.Brep` for `compas_brep`.
+* Fixed `TimberElement.__data__` (used by `Beam`, `Plate`, and other subclasses that don't override it) serializing the world frame instead of the local/hierarchical transformation, which caused the parent chain's transformation to be applied a second time when a nested element (e.g. a `Beam` inside a `Panel`) was round-tripped through JSON.
 
 ### Removed
 * Removed depricated `features.py` module and related imports.

--- a/src/compas_timber/base.py
+++ b/src/compas_timber/base.py
@@ -66,7 +66,10 @@ class TimberElement(Element, abc.ABC):
     @property
     def __data__(self):
         data = {}
-        data["frame"] = self.frame
+        # NOTE: __init__ interprets `frame` as relative to the parent's local hierarchy
+        # (it's assigned straight to `self.transformation`), not the world frame. Serializing
+        # `self.frame` (world) here would double-apply the parent chain's transformation on reload.
+        data["frame"] = Frame.from_transformation(self.transformation)
         data["length"] = self.length
         data["width"] = self.width
         data["height"] = self.height

--- a/tests/compas_timber/test_panel.py
+++ b/tests/compas_timber/test_panel.py
@@ -110,6 +110,26 @@ def test_add_beam_to_panel(model):
     assert beam.modeltransformation == model.panels[1].transformation, "Expected beam model transformation to match panel transformation"
 
 
+def test_beam_nested_in_panel_roundtrip_preserves_world_position():
+    # regression test: TimberElement.__data__ used to serialize the world frame instead of the
+    # local transformation, causing the parent panel's transformation to be applied twice on reload.
+    new_model = TimberModel()
+    panel = Panel(frame=Frame(Point(10, 0, 0), Vector(1, 0, 0), Vector(0, 1, 0)), length=5, width=3, thickness=0.2)
+    new_model.add_element(panel)
+
+    beam = Beam(Frame(Point(0, 0, 0), Vector(1, 0, 0), Vector(0, 1, 0)), length=2, width=0.1, height=0.1)
+    new_model.add_element(beam, parent=panel)
+
+    expected_centerline = beam.centerline
+
+    model_copy = json_loads(json_dumps(new_model))
+    panel_copy = next(e for e in model_copy.elements() if isinstance(e, Panel))
+    beam_copy = next(iter(panel_copy.children))
+
+    assert TOL.is_allclose(expected_centerline.start, beam_copy.centerline.start)
+    assert TOL.is_allclose(expected_centerline.end, beam_copy.centerline.end)
+
+
 def test_copy_panel_model(model):
     model_copy = json_loads(json_dumps(model))
 


### PR DESCRIPTION
Fixes #809 

This pull request addresses a critical bug in the serialization logic for `TimberElement` and adds a regression test to ensure nested elements (like a `Beam` inside a `Panel`) preserve their world position after a round-trip through JSON. It also updates the changelog to document the fix.

Bug fix for serialization:

* Updated the `TimberElement.__data__` property in `src/compas_timber/base.py` to serialize the local transformation (using `Frame.from_transformation(self.transformation)`) instead of the world frame, preventing parent transformations from being double-applied during deserialization.

Testing improvements:

* Added a regression test `test_beam_nested_in_panel_roundtrip_preserves_world_position` in `tests/compas_timber/test_panel.py` to verify that a nested `Beam` maintains its correct world position after serialization and deserialization.

Documentation:

* Updated `CHANGELOG.md` to describe the fixed bug with `TimberElement.__data__` and its impact on nested element serialization.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_timber.datastructures.Beam`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation, including updating `class_diagrams.rst` (if appropriate).
