### PR TITLE
Link Grasshopper plugin to timber_design repository in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ pip install compas_timber
 ## First Steps
 
 * [Documentation](https://gramaziokohler.github.io/compas_timber/)
+* [COMPAS TIMBER Grasshopper Plugin (timber_design)](https://github.com/gramaziokohler/timber_design)
 * [COMPAS TIMBER Grasshopper Tutorial](https://gramaziokohler.github.io/compas_timber/latest/tutorials.html)
 * [COMPAS TIMBER API Reference](https://gramaziokohler.github.io/compas_timber/latest/api.html)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,10 @@
 COMPAS TIMBER is an open-source package for modeling, designing and fabricating timber frame structures.
 </p>
 
-COMPAS TIMBER is written in Python and and is a part of the [COMPAS](https://compas.dev/index.html) ecosystem.
+COMPAS TIMBER is written in Python and is a part of the [COMPAS](https://compas.dev/index.html) ecosystem.
 It also features an implementation for [Rhinoceros 3D](https://www.rhino3d.com/)
-as a [Grasshopper](https://www.rhino3d.com/features/#grasshopper) plug-in.
+as a [Grasshopper](https://www.rhino3d.com/features/#grasshopper) plug-in,
+which is developed in the separate [timber_design](https://github.com/gramaziokohler/timber_design) repository.
 
 COMPAS TIMBER is an active research project and is being continuously developed at Gramazio Kohler Research at ETH Zurich.
 At the current stage, the library encompasses tools for fast and intuitive design of frame structures with simple joints

--- a/docs/tutorials/grasshopper/development.md
+++ b/docs/tutorials/grasshopper/development.md
@@ -1,0 +1,38 @@
+# Development
+
+The Grasshopper components are not developed in the `compas_timber` repository.
+They live in the separate [timber_design](https://github.com/gramaziokohler/timber_design) repository,
+which builds on `compas_timber` as its Python backend:
+
+- **[timber_design](https://github.com/gramaziokohler/timber_design)** — the Grasshopper components and the Yak package. The components themselves live in [`src/timber_design/ghpython/components`](https://github.com/gramaziokohler/timber_design/tree/main/src/timber_design/ghpython/components). Report plugin issues (components, toolbar, Grasshopper behavior) in the [timber_design issue tracker](https://github.com/gramaziokohler/timber_design/issues).
+- **[compas_timber](https://github.com/gramaziokohler/compas_timber)** — the modeling, joinery and fabrication engine the components call into. Report core issues in the [compas_timber issue tracker](https://github.com/gramaziokohler/compas_timber/issues).
+
+!!! note
+    Although it is built from the `timber_design` repository, the package you install through Rhino's
+    Package Manager is still published under the name `compas_timber`.
+
+## Where timber_design fits in the ecosystem
+
+```mermaid
+flowchart TB
+    subgraph ecosystem["COMPAS ecosystem"]
+        compas["compas"]
+        model["compas_model"]
+        brep["compas_brep"]
+    end
+
+    ct["compas_timber"]
+    td["timber_design"]
+    gh["Compas Timber plugin for Grasshopper"]
+
+    compas -->|supports| ct
+    model -->|supports| ct
+    brep -->|supports| ct
+    ct -->|powers| td
+    td -->|ships| gh
+```
+
+The components themselves are thin: they collect inputs in Grasshopper and call `timber_design` / `compas_timber`
+Python code running in Rhino's CPython environment. This is why changes to the plugin land in the
+`timber_design` repository, while changes to how beams, joints or BTLx processings behave land in
+the `compas_timber` repository.

--- a/docs/tutorials/grasshopper/installation.md
+++ b/docs/tutorials/grasshopper/installation.md
@@ -2,6 +2,9 @@
 
 This guide explains how to install the `compas_timber` package for use in Grasshopper with Rhino 8 and Rhino 7.
 
+!!! note
+    The Grasshopper components are developed in the separate [timber_design](https://github.com/gramaziokohler/timber_design) repository.
+
 ## Rhino 8 Installation
 
 1. **Open Rhino 8.**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,6 +162,7 @@ nav:
   - Grasshopper Plugin:
       - Introduction: tutorials/index.md
       - Installation: tutorials/grasshopper/installation.md
+      - Development: tutorials/grasshopper/development.md
       - Workflow: tutorials/grasshopper/workflow.md
       - Attributes: tutorials/grasshopper/attributes.md
       - Beams: tutorials/grasshopper/beams.md


### PR DESCRIPTION
As discussed in #825: the Grasshopper components now live in the separate [`timber_design`](https://github.com/gramaziokohler/timber_design) package, but the docs never pointed there. This adds the link wherever the Grasshopper plugin is mentioned, plus a dedicated page:

- **New page: *Grasshopper Plugin → Development*** (`docs/tutorials/grasshopper/development.md`) — explains that the components are developed in `timber_design` (with a direct link to the components folder), which issue tracker to use for what, that the Package Manager package is still published under the name `compas_timber`, and a mermaid diagram of how `timber_design` fits in the COMPAS ecosystem
- `docs/index.md` — the landing page sentence advertising the Grasshopper plug-in now links to the `timber_design` repository (also fixes an "and and" typo in the same paragraph)
- `README.md` — new entry under *First Steps* linking to the `timber_design` repository
- `docs/tutorials/grasshopper/installation.md` — note at the top of the installation guide pointing to `timber_design`

Docs-only change, so no CHANGELOG entry.

Closes #825.

🤖 Generated with [Claude Code](https://claude.com/claude-code)