### PR TITLE
Resolve TODO in JackRafterCut.from_plane_and_beam: any ref side yields an equivalent cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added new `compas_timber.fabrication.BirdsMouth`.
 
 ### Changed
+* Documented in `JackRafterCut.from_plane_and_beam` (and its proxy) that the cut is fully defined by the input plane, so `ref_side_index` only pins which reference side the parameters are expressed on; removed the resolved `TODO` (#824).
 * `FeatureApplicationError` raised from `BTLxProcessing.apply()` now carries geometry in the model's global coordinate system (previously local/element space), matching errors raised elsewhere. 
 * Fixed a live crash (`TypeError`) and two other constructor-argument bugs on `BeamJoiningError` call sites.
 * Fixed wrong `RefPosition` assigned to one beam in `LFrenchRidgeLapJoint` for 90° configurations where floating-point drift caused `_calculate_ref_position` to miss the orthogonal-connection branch (`angle == 90.0` replaced with `TOL.is_close(angle, 90.0)`). Also removed a stray `print(90)` debug statement.

--- a/src/compas_timber/fabrication/jack_cut.py
+++ b/src/compas_timber/fabrication/jack_cut.py
@@ -156,6 +156,9 @@ class JackRafterCut(BTLxProcessing):
             The beam that is cut by this instance.
         ref_side_index : int, optional
             The reference side index of the beam to be cut. Default is 0 (i.e. RS1).
+            The cut is fully defined by ``plane``, so any reference side yields an
+            equivalent processing; pass an index to pin the resulting parameters
+            to a specific side (e.g. for post-processing on a chosen face).
 
         Returns
         -------
@@ -167,7 +170,7 @@ class JackRafterCut(BTLxProcessing):
             plane = Plane.from_frame(plane)
         start_y = 0.0
         start_depth = 0.0
-        ref_side = beam.ref_sides[ref_side_index]  # TODO: is this arbitrary?
+        ref_side = beam.ref_sides[ref_side_index]
         ref_edge = Line.from_point_and_vector(ref_side.point, ref_side.xaxis)
         orientation = cls._calculate_orientation(beam, plane)
         point_start_x = intersection_line_plane(ref_edge, plane)
@@ -378,6 +381,9 @@ class JackRafterCutProxy(object):
             The beam that is cut by this instance.
         ref_side_index : int, optional
             The reference side index of the beam to be cut. Default is 0 (i.e. RS1).
+            The cut is fully defined by ``plane``, so any reference side yields an
+            equivalent processing; pass an index to pin the resulting parameters
+            to a specific side (e.g. for post-processing on a chosen face).
 
         Returns
         -------


### PR DESCRIPTION
Resolves the `TODO: is this arbitrary?` on the `ref_side_index` default (discussed in #824). The answer has two halves: the default *is* an unprincipled pick — but a harmless one, because `JackRafterCut` is plane-defined: parameters computed on any reference side describe the same cut, and the index only pins which side they're expressed on. That fact now lives in the `ref_side_index` docstring (constructor and proxy) instead of the comment. Doc-only change (plus a changelog line).

The discussion also surfaced the real gap: in the joint-driven flow there's no way to pass a *preferred* ref side (needed e.g. when post-processing reads the BTLx off a chosen face). That follow-up is now tracked in #829.

Fixes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)
