### PR TITLE
Fix README: logo alignment, DOI badge, broken links, uv install, authors

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,20 @@
+# Authors
+
+`compas_timber` is developed by Gramazio Kohler Research and contributors:
+
+* Aleksandra Anna Apolinarska <<apolinarska@arch.ethz.ch>>
+* Chen Kasirer <<kasirer@arch.ethz.ch>>
+* Gonzalo Casas <<casas@arch.ethz.ch>>
+* Jonas Haldemann <<haldemann@arch.ethz.ch>>
+* Oliver Appling Bucklin <<bucklin@arch.ethz.ch>>
+* Aurèle L. Gheyselinck <<gheyselinck@arch.ethz.ch>>
+* Panayiotis Papacharalambous <<papacharalambous@arch.ethz.ch>>
+* Anastasiia Stryzhevska <<astryzhevska@arch.ethz.ch>>
+* Jelle Feringa <<jelleferinga@gmail.com>>
+* Joseph Kenny <<jk6372@princeton.edu>>
+* Beverly Lytle <<lytle@arch.ethz.ch>>
+* Eric Gozzi <<eric.gozzi@arch.ethz.ch>>
+* Rodrigo Arca Zimmermann <<rodrigo.arca@gmail.com>>
+* Nicolas Benjamin Boscoboinik <<boscoboinik@arch.ethz.ch>>
+* Paul Jaeggi <<jaeggipa@ethz.ch>>
+* Daniel Nunes Locatelli <<daniel.nlocatelli@gmail.com>>

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ uv run pytest
 
 * [Documentation](https://gramaziokohler.github.io/compas_timber/)
 * [COMPAS TIMBER Grasshopper Plugin (timber_design)](https://github.com/gramaziokohler/timber_design)
-* [COMPAS TIMBER Grasshopper Tutorial](https://gramaziokohler.github.io/compas_timber/latest/tutorials/)
+* [COMPAS TIMBER Grasshopper Tutorial](https://gramaziokohler.github.io/timber_design/)
 * [COMPAS TIMBER API Reference](https://gramaziokohler.github.io/compas_timber/latest/api/compas_timber.model/)
 
 ## Questions and feedback

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ pip install compas_timber
 ## First Steps
 
 * [Documentation](https://gramaziokohler.github.io/compas_timber/)
+* [COMPAS TIMBER Grasshopper Plugin (timber_design)](https://github.com/gramaziokohler/timber_design)
 * [COMPAS TIMBER Grasshopper Tutorial](https://gramaziokohler.github.io/compas_timber/latest/tutorials.html)
 * [COMPAS TIMBER API Reference](https://gramaziokohler.github.io/compas_timber/latest/api.html)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <h1>
-  <img src="docs\_logo\PNG_tranparent-background.png" alt="Logo" width="70" height="70" style="vertical-align:middle"> 
-      COMPAS Timber
+  <img src="docs/_logo/PNG_tranparent-background.png" alt="COMPAS Timber logo" width="70" height="70" align="absmiddle"> COMPAS Timber
 </h1>
 
 
@@ -10,27 +9,38 @@
 [![pip downloads](https://img.shields.io/pypi/dm/compas_timber)](https://pypi.python.org/project/compas_timber)
 [![PyPI Package latest release](https://img.shields.io/pypi/v/compas_timber.svg)](https://pypi.python.org/pypi/compas_timber)
 [![Supported implementations](https://img.shields.io/pypi/implementation/compas_timber.svg)](https://pypi.python.org/pypi/compas_timber)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7934266.svg)](https://doi.org/10.5281/zenodo.7934266)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.7934266-blue)](https://doi.org/10.5281/zenodo.7934266)
 [![Twitter Follow](https://img.shields.io/twitter/follow/compas_dev?style=social)](https://twitter.com/compas_dev)
 [![Made with COMPAS](https://compas.dev/badge.svg)](https://compas.dev/#/)
 ![COMPAS Timber](https://raw.githubusercontent.com/gramaziokohler/compas_timber/main/docs/_images/compas_timber.jpg)
 
-`compas_timber` is a user-friendly open-source software toolkit to streamline the design of timber frame structures. Despite its advances in digitalization compared to other building techniques, timber construction is often perceived as a challenging field, involving intricate processes in design, planning, coordination, and fabrication. We aim to increase the use of timber in architecture by lowering the threshold of creating versatile and resource-aware designs.
+`compas_timber` is a user-friendly open-source software toolkit that streamlines the design-to-fabrication workflow of timber frame structures. A project is designed and refined in a single digital model that also produces the manufacturing data, so it can go from first concept to fabrication without re-modeling or back-and-forth rework along the way. By lowering the threshold for creating versatile and resource-aware timber designs, we aim to increase the use of timber in architecture.
 
 ## Installation
 
-> It is recomended you install `compas_timber` inside a virtual environment.
+We recommend managing environments and dependencies with [uv](https://docs.astral.sh/uv/), but a plain `pip install compas_timber` works just as well.
+
+Add `compas_timber` to your project:
 
 ```bash
-pip install compas_timber
+uv add compas_timber
+```
+
+For a development setup, clone the repository and sync the environment:
+
+```bash
+git clone https://github.com/gramaziokohler/compas_timber.git
+cd compas_timber
+uv sync --extra dev
+uv run pytest
 ```
 
 ## First Steps
 
 * [Documentation](https://gramaziokohler.github.io/compas_timber/)
 * [COMPAS TIMBER Grasshopper Plugin (timber_design)](https://github.com/gramaziokohler/timber_design)
-* [COMPAS TIMBER Grasshopper Tutorial](https://gramaziokohler.github.io/compas_timber/latest/tutorials.html)
-* [COMPAS TIMBER API Reference](https://gramaziokohler.github.io/compas_timber/latest/api.html)
+* [COMPAS TIMBER Grasshopper Tutorial](https://gramaziokohler.github.io/compas_timber/latest/tutorials/)
+* [COMPAS TIMBER API Reference](https://gramaziokohler.github.io/compas_timber/latest/api/compas_timber.model/)
 
 ## Questions and feedback
 
@@ -45,9 +55,9 @@ If you found an issue or have a suggestion for a dandy new feature, please file 
 
 We love contributions!
 
-Check the [Contributor's Guide](https://github.com/gramaziokohler/compas_timber/blob/main/CONTRIBUTING.md)
+Check the [Contributor's Guide](CONTRIBUTING.md)
 for more details.
 
 ## Credits
 
-`compas_timber` is currently developed by Gramazio Kohler Research. See the [list of authors](https://github.com/gramaziokohler/compas_timber/blob/main/AUTHORS.md) for a complete overview.
+`compas_timber` is currently developed by Gramazio Kohler Research. See the [list of authors](AUTHORS.md) for a complete overview.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,10 @@
 COMPAS TIMBER is an open-source package for modeling, designing and fabricating timber frame structures.
 </p>
 
-COMPAS TIMBER is written in Python and and is a part of the [COMPAS](https://compas.dev/index.html) ecosystem.
+COMPAS TIMBER is written in Python and is a part of the [COMPAS](https://compas.dev/index.html) ecosystem.
 It also features an implementation for [Rhinoceros 3D](https://www.rhino3d.com/)
-as a [Grasshopper](https://www.rhino3d.com/features/#grasshopper) plug-in.
+as a [Grasshopper](https://www.rhino3d.com/features/#grasshopper) plug-in,
+which is developed in the separate [timber_design](https://github.com/gramaziokohler/timber_design) repository.
 
 COMPAS TIMBER is an active research project and is being continuously developed at Gramazio Kohler Research at ETH Zurich.
 At the current stage, the library encompasses tools for fast and intuitive design of frame structures with simple joints

--- a/docs/tutorials/grasshopper/development.md
+++ b/docs/tutorials/grasshopper/development.md
@@ -1,0 +1,38 @@
+# Development
+
+The Grasshopper components are not developed in the `compas_timber` repository.
+They live in the separate [timber_design](https://github.com/gramaziokohler/timber_design) repository,
+which builds on `compas_timber` as its Python backend:
+
+- **[timber_design](https://github.com/gramaziokohler/timber_design)** — the Grasshopper components and the Yak package. The components themselves live in [`src/timber_design/ghpython/components`](https://github.com/gramaziokohler/timber_design/tree/main/src/timber_design/ghpython/components). Report plugin issues (components, toolbar, Grasshopper behavior) in the [timber_design issue tracker](https://github.com/gramaziokohler/timber_design/issues).
+- **[compas_timber](https://github.com/gramaziokohler/compas_timber)** — the modeling, joinery and fabrication engine the components call into. Report core issues in the [compas_timber issue tracker](https://github.com/gramaziokohler/compas_timber/issues).
+
+!!! note
+    Although it is built from the `timber_design` repository, the package you install through Rhino's
+    Package Manager is still published under the name `compas_timber`.
+
+## Where timber_design fits in the ecosystem
+
+```mermaid
+flowchart TB
+    subgraph ecosystem["COMPAS ecosystem"]
+        compas["compas"]
+        model["compas_model"]
+        brep["compas_brep"]
+    end
+
+    ct["compas_timber"]
+    td["timber_design"]
+    gh["Compas Timber plugin for Grasshopper"]
+
+    compas -->|supports| ct
+    model -->|supports| ct
+    brep -->|supports| ct
+    ct -->|powers| td
+    td -->|ships| gh
+```
+
+The components themselves are thin: they collect inputs in Grasshopper and call `timber_design` / `compas_timber`
+Python code running in Rhino's CPython environment. This is why changes to the plugin land in the
+`timber_design` repository, while changes to how beams, joints or BTLx processings behave land in
+the `compas_timber` repository.

--- a/docs/tutorials/grasshopper/installation.md
+++ b/docs/tutorials/grasshopper/installation.md
@@ -2,6 +2,9 @@
 
 This guide explains how to install the `compas_timber` package for use in Grasshopper with Rhino 8 and Rhino 7.
 
+!!! note
+    The Grasshopper components are developed in the separate [timber_design](https://github.com/gramaziokohler/timber_design) repository.
+
 ## Rhino 8 Installation
 
 1. **Open Rhino 8.**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,6 +162,7 @@ nav:
   - Grasshopper Plugin:
       - Introduction: tutorials/index.md
       - Installation: tutorials/grasshopper/installation.md
+      - Development: tutorials/grasshopper/development.md
       - Workflow: tutorials/grasshopper/workflow.md
       - Attributes: tutorials/grasshopper/attributes.md
       - Beams: tutorials/grasshopper/beams.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ authors = [
     { name = "Eric Gozzi", email = "eric.gozzi@arch.ethz.ch" },
     { name = "Rodrigo Arca Zimmermann", email = "rodrigo.arca@gmail.com" },
     { name = "Nicolas Benjamin Boscoboinik", email = "boscoboinik@arch.ethz.ch" },
-    { name = "Paul Jaeggi", email = "jaeggipa@ethz.ch" }
+    { name = "Paul Jaeggi", email = "jaeggipa@ethz.ch" },
+    { name = "Daniel Nunes Locatelli", email = "daniel.nlocatelli@gmail.com" }
 ]
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
### What type of change is this?

- [x] Documentation update

Fixes several broken things in the README and modernizes it:

- **Logo/title alignment** — the title sat at the bottom of the logo because GitHub's HTML sanitizer strips `style` attributes. Switched to the sanitizer-allowed `align="absmiddle"`, which vertically centers the title on the logo (verified in a browser against GitHub's markdown CSS). Also fixed the backslash image path.
- **DOI badge** — the Zenodo badge rendered as a broken image (Zenodo serves it with no-cache headers that GitHub's image proxy chokes on). Replaced with a shields.io DOI badge pointing to the same DOI.
- **Intro** — reworded around the design-to-fabrication workflow: a single digital model carries a project from first concept to manufacturing data, without re-modeling or rework.
- **Installation** — updated to `uv` (with a one-line pip note), including the dev setup, matching the [onboarding](https://github.com/gramaziokohler/gramazio-kohler-onboarding).
- **Broken links** — the tutorial and API reference links pointed at the old Sphinx-style `.html` pages (404 since the mkdocs migration); now point to the current mkdocs URLs. Authors and Contributor's Guide links are now relative.
- **Authors** — the "list of authors" link pointed at a non-existent `AUTHORS.md`. Added it, generated from the `pyproject.toml` authors list, and added Daniel Nunes Locatelli to both.

> Stacked on #828 — its two commits appear here until it merges, after which this PR's diff slims down to the README/authors changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)