### PR TITLE
Fix stale text in Grasshopper tutorial docs, add Under-the-hood tips, fix contribution-guide anchors

### DIFF
--- a/docs/contribution/BTLx_contribution_guide.md
+++ b/docs/contribution/BTLx_contribution_guide.md
@@ -72,11 +72,11 @@ class NewProcessing(BTLxProcessing):
 
 See also:
 
-- [`JackRafterCut`](../api/compas_timber.fabrication.md#JackRafterCut)
-- [`Lap`](../api/compas_timber.fabrication.md#Lap)
-- [`Drilling`](../api/compas_timber.fabrication.md#Drilling)
-- [`DoubleCut`](../api/compas_timber.fabrication.md#DoubleCut)
-- [`FrenchRidgeLap`](../api/compas_timber.fabrication.md#FrenchRidgeLap)
+- [`JackRafterCut`](../api/compas_timber.fabrication.md#compas_timber.fabrication.JackRafterCut)
+- [`Lap`](../api/compas_timber.fabrication.md#compas_timber.fabrication.Lap)
+- [`Drilling`](../api/compas_timber.fabrication.md#compas_timber.fabrication.Drilling)
+- [`DoubleCut`](../api/compas_timber.fabrication.md#compas_timber.fabrication.DoubleCut)
+- [`FrenchRidgeLap`](../api/compas_timber.fabrication.md#compas_timber.fabrication.FrenchRidgeLap)
 
 ### 3. Add Alternative Constructors in Processing Class
 
@@ -112,11 +112,11 @@ class NewProcessing(BTLxProcessing):
 
 See also:
 
-- [`JackRafterCut.from_plane_and_beam()`](../api/compas_timber.fabrication.md#JackRafterCut.from_plane_and_beam)
-- [`Lap.from_volume_and_beam()`](../api/compas_timber.fabrication.md#Lap.from_volume_and_beam)
-- [`Drilling.from_line_and_element()`](../api/compas_timber.fabrication.md#Drilling.from_line_and_element)
-- [`DoubleCut.from_planes_and_beam()`](../api/compas_timber.fabrication.md#DoubleCut.from_planes_and_beam)
-- [`FrenchRidgeLap.from_beam_beam_and_plane()`](../api/compas_timber.fabrication.md#FrenchRidgeLap.from_beam_beam_and_plane)
+- [`JackRafterCut.from_plane_and_beam()`](../api/compas_timber.fabrication.md#compas_timber.fabrication.JackRafterCut.from_plane_and_beam)
+- [`Lap.from_volume_and_beam()`](../api/compas_timber.fabrication.md#compas_timber.fabrication.Lap.from_volume_and_beam)
+- [`Drilling.from_line_and_element()`](../api/compas_timber.fabrication.md#compas_timber.fabrication.Drilling.from_line_and_element)
+- [`DoubleCut.from_planes_and_beam()`](../api/compas_timber.fabrication.md#compas_timber.fabrication.DoubleCut.from_planes_and_beam)
+- [`FrenchRidgeLap.from_beam_beam_and_plane()`](../api/compas_timber.fabrication.md#compas_timber.fabrication.FrenchRidgeLap.from_beam_beam_and_plane)
 
 ### 4. Add Geometry Generation Method in Processing Class
 
@@ -158,11 +158,11 @@ class NewProcessing(BTLxProcessing):
 
 See also:
 
-- [`JackRafterCut.plane_from_params_and_beam`](../api/compas_timber.fabrication.md#JackRafterCut.plane_from_params_and_beam)
-- [`Lap.volume_from_params_and_beam`](../api/compas_timber.fabrication.md#Lap.volume_from_params_and_beam)
-- [`Drilling.cylinder_from_params_and_element`](../api/compas_timber.fabrication.md#Drilling.cylinder_from_params_and_element)
-- [`DoubleCut.planes_from_params_and_beam`](../api/compas_timber.fabrication.md#DoubleCut.planes_from_params_and_beam)
-- [`FrenchRidgeLap.lap_volume_from_params_and_beam`](../api/compas_timber.fabrication.md#FrenchRidgeLap.lap_volume_from_params_and_beam)
+- [`JackRafterCut.plane_from_params_and_beam`](../api/compas_timber.fabrication.md#compas_timber.fabrication.JackRafterCut.plane_from_params_and_beam)
+- [`Lap.volume_from_params_and_beam`](../api/compas_timber.fabrication.md#compas_timber.fabrication.Lap.volume_from_params_and_beam)
+- [`Drilling.cylinder_from_params_and_element`](../api/compas_timber.fabrication.md#compas_timber.fabrication.Drilling.cylinder_from_params_and_element)
+- [`DoubleCut.planes_from_params_and_beam`](../api/compas_timber.fabrication.md#compas_timber.fabrication.DoubleCut.planes_from_params_and_beam)
+- [`FrenchRidgeLap.lap_volume_from_params_and_beam`](../api/compas_timber.fabrication.md#compas_timber.fabrication.FrenchRidgeLap.lap_volume_from_params_and_beam)
 
 ### 5. Update Module Imports
 

--- a/docs/tutorials/grasshopper/beams.md
+++ b/docs/tutorials/grasshopper/beams.md
@@ -1,6 +1,6 @@
 # Beams
 
-A `compas_timber.parts.Beam` object represents a linear (straight) timber part with a rectangular cross-section - for example as a stud, rafter, beam, joist etc.
+A **Beam** represents a linear (straight) timber part with a rectangular cross-section - for example as a stud, rafter, beam, joist etc.
 It has a local coordinate system, where the X-axis corresponds with the *centerline*, Y-axis with the *width* of the cross-section and Z-axis with the *height* of the cross-section.
 The *origin* is located at the start of the centerline.
 
@@ -43,3 +43,6 @@ Extracts the frame, centreline, box, width and height from a Beam.
 Finds a specific Beam corresponding to a referenced Rhino curve or line.
 
 ![Find Beam](../images/gh_beam_guid.png){ width=40% }
+
+!!! tip "Under the hood"
+    In Python, a beam is a [`compas_timber.elements.Beam`](../../api/compas_timber.elements.md).

--- a/docs/tutorials/grasshopper/design.md
+++ b/docs/tutorials/grasshopper/design.md
@@ -57,3 +57,6 @@ This is a dynamic component. Sets Beam Dimensions for a selected Beam Type in th
 **Outputs:**
 
 *   `Beam Type` : stud, king_stud, jack_stud, edge_stud, plate, header or sill.
+
+!!! tip "Under the hood"
+    The design components are implemented in the [timber_design](https://github.com/gramaziokohler/timber_design) repository, building on [`compas_timber`](../../api/compas_timber.model.md).

--- a/docs/tutorials/grasshopper/fabrication.md
+++ b/docs/tutorials/grasshopper/fabrication.md
@@ -17,3 +17,6 @@ Writes a BTLx File from a Compas Timber Model.
 **Outputs:**
 
 *   `BTLx` : the BTLx Content as xml text.
+
+!!! tip "Under the hood"
+    BTLx export is done by [`compas_timber.fabrication.BTLxWriter`](../../api/compas_timber.fabrication.md).

--- a/docs/tutorials/grasshopper/features.md
+++ b/docs/tutorials/grasshopper/features.md
@@ -38,3 +38,6 @@ Features are additional geometric operations on Beams:
 *   `Diameter` : the diameter of the hole
 
 The output `Feature` is to be used as input for the **Model** component. See [model](model.md).
+
+!!! tip "Under the hood"
+    Each feature is a BTLx processing class in [`compas_timber.fabrication`](../../api/compas_timber.fabrication.md): `JackRafterCut`, `DoubleCut` and `Drilling`.

--- a/docs/tutorials/grasshopper/joint_rules.md
+++ b/docs/tutorials/grasshopper/joint_rules.md
@@ -224,3 +224,6 @@ The following table summarises the joint types that can be applied to the differ
 | Step | | X | |
 | Birdsmouth | | X | |
 | Dovetail | | X | |
+
+!!! tip "Under the hood"
+    The rule components are implemented in the [timber_design](https://github.com/gramaziokohler/timber_design) repository; the joints they produce are `Joint` subclasses from [`compas_timber.connections`](../../api/compas_timber.connections.md).

--- a/docs/tutorials/grasshopper/model.md
+++ b/docs/tutorials/grasshopper/model.md
@@ -22,3 +22,6 @@ To activate it, set `CreateGeometry` to `True`.
 *   `Model` : Model object.
 *   `Geometry` : Geometry of the Beams and Joints.
 *   `DebugInfo` : Debug information object in the case of feature or joining errors.
+
+!!! tip "Under the hood"
+    The **Model** component builds a [`compas_timber.model.TimberModel`](../../api/compas_timber.model.md).

--- a/docs/tutorials/grasshopper/show.md
+++ b/docs/tutorials/grasshopper/show.md
@@ -1,18 +1,18 @@
 # Show
 
-Tools forpreviewing, inspecting and extracting geometry and data from the assembly.
+Tools for previewing, inspecting and extracting geometry and data from the model.
 
 ## Show Beam Face Index
 
 ![Show Beam Face Index](../images/gh_show_beam_face_index.png){ width=20% }
 
-Displays the indexes of the Beams. Based on a global list of the Beams in the assembly.
+Displays the indexes of the Beam faces.
 
 ## Show Beam Index
 
 ![Show Beam Index](../images/gh_show_beam_index.png){ width=20% }
 
-Displays the indexes of the Beam faces.
+Displays the indexes of the Beams. Based on a global list of the Beams in the model.
 
 ## Show Surface Model Beam Types
 
@@ -34,7 +34,7 @@ Shows information useful for debugging errors occured while attempting to join B
 
 ![Show Joint Types](../images/gh_show_joint_types.png){ width=20% }
 
-Displays the type names of each joints in the assembly.
+Displays the type names of each joint in the model.
 
 ## Show Topology Types
 


### PR DESCRIPTION
Text-only cleanup of the docs, three concerns:

**Grasshopper tutorial fixes**
- Removes the pre-2.x `compas_timber.parts.Beam` namespace from `beams.md` — GH users don't need Python paths, a beam is just a Beam.
- `show.md`: fixes a typo, replaces leftover "assembly" wording with "model", and un-swaps the `Show Beam Face Index` / `Show Beam Index` descriptions, which had each other's text.

**"Under the hood" tips**
We decided to remove inline Python paths from the Grasshopper tutorials: GH users don't need them, and for that audience they are more confusing than helpful — a `compas_timber.parts.Beam` is just a beam. For readers who do want to dig deeper, the pages with a Python counterpart now end with a one-line tip linking the GH concept to it (`Beam`, `TimberModel`, the fabrication processings, `BTLxWriter`) — including pointers to [timber_design](https://github.com/gramaziokohler/timber_design) where the components actually live (joint rules, design), complementing #828.

**BTLx contribution guide anchors**
The 15 API deep-links pointed at anchors mkdocstrings never generates (e.g. `#DoubleCut.planes_from_params_and_beam`), so they landed at the top of the API page. Now qualified with the full ID format (`#compas_timber.fabrication.DoubleCut.planes_from_params_and_beam`); all 15 verified against the rendered page.

Note: the GH tutorials also reference component names predating the current `timber_design` set (e.g. `Show Beam Index` vs today's `CT_ShowElementIndex`). This is not yet addressed anywhere — #828 only adds signpost links — so it's left out of this PR — whether the tutorials should be updated here or move next to the components is a question worth settling on #825 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



