### PR TITLE
Delegate `TimberElement.add_feature` to `add_features`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * Documented in `JackRafterCut.from_plane_and_beam` (and its proxy) that the cut is fully defined by the input plane, so `ref_side_index` only pins which reference side the parameters are expressed on; removed the resolved `TODO` (#824).
+* `TimberElement.add_feature` now delegates to `add_features`, so a list passed by mistake is normalised instead of silently nested (#823). Docstring corrected accordingly.
 * `FeatureApplicationError` raised from `BTLxProcessing.apply()` now carries geometry in the model's global coordinate system (previously local/element space), matching errors raised elsewhere. 
 * Fixed a live crash (`TypeError`) and two other constructor-argument bugs on `BeamJoiningError` call sites.
 * Fixed wrong `RefPosition` assigned to one beam in `LFrenchRidgeLapJoint` for 90° configurations where floating-point drift caused `_calculate_ref_position` to miss the orthogonal-connection branch (`angle == 90.0` replaced with `TOL.is_close(angle, 90.0)`). Also removed a stray `print(90)` debug statement.

--- a/src/compas_timber/base.py
+++ b/src/compas_timber/base.py
@@ -178,19 +178,17 @@ class TimberElement(Element, abc.ABC):
         self.remove_blank_extension()
         self.debug_info = []
 
-    @reset_computed
-    @reset_timber_attrs
     def add_feature(self, feature):
         # type: (BTLxProcessing) -> None
-        """Adds one or more features to the beam.
+        """Adds a feature to the element.
 
         Parameters
         ----------
-        feature : :class:`~compas_timber.fabrication.BTLxProcessing`)
+        feature : :class:`~compas_timber.fabrication.BTLxProcessing`
             The feature to be added.
 
         """
-        self._features.append(feature)  # type: ignore
+        self.add_features(feature)
 
     @reset_computed
     @reset_timber_attrs

--- a/tests/compas_timber/test_beam.py
+++ b/tests/compas_timber/test_beam.py
@@ -445,6 +445,15 @@ def test_geometry_with_features(beam, mocker):
     mock_feature.apply.assert_called()
 
 
+def test_add_feature_with_list_does_not_nest(beam):
+    """A list passed to the singular add_feature is normalised, not stored as a nested list (#823)."""
+    cut = JackRafterCut(is_joinery=False)
+
+    beam.add_feature([cut])
+
+    assert beam.features == [cut]
+
+
 def test_reset_timber_attrs_decorator_clears_cached_attributes(beam):
     """Test that the reset_timber_attrs decorator resets cached attributes when decorated methods are called."""
     # Force computation of cached attributes by accessing them


### PR DESCRIPTION
Fixes #823 — `add_feature` appended its argument unchecked, so a list would nest inside `_features` and only fail later, in geometry computation. It now delegates to `add_features`, which normalises single-or-list input. Docstring corrected (it was copied from `add_features`), and the cache-reset decorators dropped since the delegated call carries the same stack. Repro and full context on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)