### PR TITLE
Replace deprecated `element_by_guid` call in `Joint.restore_elements_from_keys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added new module `candidate_dispatch` in `compas_timber.connections` with `get_connection_candidate(element_a, element_b, max_distance)`, the entry point used by `TimberModel.compute_topologies()` to build the right kind of joint candidate for a pair of adjacent elements based on their types.
 
 ### Changed
+* `Joint.restore_elements_from_keys()` now uses `model[guid]` instead of the deprecated `element_by_guid()`, so deserializing a jointed model no longer emits a `DeprecationWarning` from inside the library.
 * Documented in `JackRafterCut.from_plane_and_beam` (and its proxy) that the cut is fully defined by the input plane, so `ref_side_index` only pins which reference side the parameters are expressed on; removed the resolved `TODO` (#824).
 * `TimberElement.add_feature` now delegates to `add_features`, so a list passed by mistake is normalised instead of silently nested (#823). Docstring corrected accordingly.
 * `JointCandidate` no longer subclasses `Joint` (and `PlateJointCandidate` no longer subclasses `PlateJoint`); both are now standalone `compas.data.Data` subclasses with their own `location`/`topology`/`elements` handling. Code relying on `isinstance(candidate, Joint)` must be updated to check `isinstance(candidate, JointCandidate)` instead.

--- a/src/compas_timber/connections/joint.py
+++ b/src/compas_timber/connections/joint.py
@@ -252,7 +252,7 @@ class Joint(Data):
         See :class:`compas_timber.connections.TButtJoint`.
 
         """
-        self._elements = tuple(model.element_by_guid(guid) for guid in self.element_guids)
+        self._elements = tuple(model[guid] for guid in self.element_guids)
         self._set_unset_attributes()
 
         # TODO add fasteners to this as well? should we have a separate self.fastener_guids property?

--- a/tests/compas_timber/test_model.py
+++ b/tests/compas_timber/test_model.py
@@ -572,15 +572,32 @@ def test_getitem_returns_correct_element():
     assert result is beam
 
 
-def test_element_by_guid_deprecated_warning(mocker):
+def test_element_by_guid_deprecated_warning():
     model = TimberModel()
     beam = Beam(Frame.worldXY(), width=0.1, height=0.1, length=1.0)
     model.add_element(beam)
 
-    warn_spy = mocker.spy(model, "element_by_guid")
+    with pytest.warns(DeprecationWarning):
+        result = model.element_by_guid(str(beam.guid))
 
-    _ = model.element_by_guid(str(beam.guid))
-    warn_spy.assert_called_once()
+    assert result is beam
+
+
+@pytest.mark.filterwarnings("error::DeprecationWarning")
+def test_serialization_jointed_model_no_deprecation_warning(mocker):
+    mocker.patch("compas_timber.connections.LButtJoint.add_features")
+    F1 = Frame(Point(0, 0, 0), Vector(1, 0, 0), Vector(0, 1, 0))
+    F2 = Frame(Point(0, 0, 0), Vector(0, 0, 1), Vector(0, 1, 0))
+    B1 = Beam(F1, length=1.0, width=0.1, height=0.12)
+    B2 = Beam(F2, length=1.0, width=0.1, height=0.12)
+    A = TimberModel()
+    A.add_element(B1)
+    A.add_element(B2)
+    _ = LButtJoint.create(A, B1, B2)
+
+    A = json_loads(json_dumps(A))
+
+    assert len(list(A.joints)) == 1
 
 
 def test_compute_topologies_mixed_beams_and_plates():


### PR DESCRIPTION
`Joint.restore_elements_from_keys` still calls the deprecated `element_by_guid`, so deserializing any jointed model emits a `DeprecationWarning` from inside the library. #661 converted all internal callers to `model[guid]`; the base-class implementation landed two days later from a parallel branch and reintroduced the call. This applies the same conversion — pure passthrough, no behaviour change.

Tests: `test_element_by_guid_deprecated_warning` now actually asserts the warning via `pytest.warns` (the spy only checked the call happened), and a new round-trip test under `error::DeprecationWarning` guards against reintroduction — verified red without the fix, green with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)