### PR TITLE
Record compas_timber version in BTLx FileHistory ProgramVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added new module `candidate_dispatch` in `compas_timber.connections` with `get_connection_candidate(element_a, element_b, max_distance)`, the entry point used by `TimberModel.compute_topologies()` to build the right kind of joint candidate for a pair of adjacent elements based on their types.
 
 ### Changed
+* Exported BTLx `FileHistory` now records the compas_timber version in `ProgramVersion` (`COMPAS Timber: <version>; COMPAS: <version>`) instead of only the compas version, so the file identifies the program that generated it.
 * Documented in `JackRafterCut.from_plane_and_beam` (and its proxy) that the cut is fully defined by the input plane, so `ref_side_index` only pins which reference side the parameters are expressed on; removed the resolved `TODO` (#824).
 * `TimberElement.add_feature` now delegates to `add_features`, so a list passed by mistake is normalised instead of silently nested (#823). Docstring corrected accordingly.
 * `JointCandidate` no longer subclasses `Joint` (and `PlateJointCandidate` no longer subclasses `PlateJoint`); both are now standalone `compas.data.Data` subclasses with their own `location`/`topology`/`elements` handling. Code relying on `isinstance(candidate, Joint)` must be updated to check `isinstance(candidate, JointCandidate)` instead.

--- a/src/compas_timber/fabrication/btlx.py
+++ b/src/compas_timber/fabrication/btlx.py
@@ -20,6 +20,7 @@ from compas.geometry import Transformation
 from compas.geometry import angle_vectors
 from compas.tolerance import TOL
 
+import compas_timber
 from compas_timber.errors import BTLxProcessingError
 from compas_timber.errors import FeatureApplicationError
 from compas_timber.geometry import brep_from_outlines
@@ -149,8 +150,8 @@ class BTLxWriter(object):
         # create file history element
         file_history = ET.Element("FileHistory")
         # create initial export program element
-        file_history_attibutes = self._get_file_history_attributes()
-        file_history.append(ET.Element("InitialExportProgram", file_history_attibutes))
+        file_history_attributes = self._get_file_history_attributes()
+        file_history.append(ET.Element("InitialExportProgram", file_history_attributes))
         return file_history
 
     def _get_file_history_attributes(self):
@@ -159,7 +160,7 @@ class BTLxWriter(object):
             [
                 ("CompanyName", self.company_name or "Gramazio Kohler Research"),
                 ("ProgramName", "COMPAS_Timber"),
-                ("ProgramVersion", "Compas: {}".format(compas.__version__)),
+                ("ProgramVersion", "COMPAS Timber: {}; COMPAS: {}".format(compas_timber.__version__, compas.__version__)),
                 ("ComputerName", "{}".format(os.getenv("computername"))),
                 ("UserName", "{}".format(os.getenv("USERNAME"))),
                 ("FileName", self.file_name or ""),

--- a/tests/compas_timber/test_btlx.py
+++ b/tests/compas_timber/test_btlx.py
@@ -70,7 +70,7 @@ def test_btlx_file_history(resulting_btlx, namespaces):
     # Validate the attributes of InitialExportProgram
     assert initial_export_program.get("CompanyName") == "Gramazio Kohler Research"
     assert initial_export_program.get("ProgramName") == "COMPAS_Timber"
-    assert initial_export_program.get("ProgramVersion") == "Compas: {}".format(compas.__version__)
+    assert initial_export_program.get("ProgramVersion") == "COMPAS Timber: {}; COMPAS: {}".format(compas_timber.__version__, compas.__version__)
     assert initial_export_program.get("ComputerName") == (os.getenv("computername") or "None")
     assert initial_export_program.get("UserName") == (os.getenv("USERNAME") or "None")
 


### PR DESCRIPTION
Exported BTLx files name `ProgramName="COMPAS_Timber"` but stamp `ProgramVersion` with the version of compas, the geometry kernel — so the fabrication artifact can't identify the version of the program that generated its geometry. The string dates to the initial fabrication PR (#138) and survived the BTLxWriter rewrite (#354) verbatim; it was never a decision. This stamps both, compas_timber first: `COMPAS Timber: 2.2.0; COMPAS: 2.15.1`.

Also updates the `test_btlx_file_history` assertion (verified red without the fix, green with it) and fixes a `file_history_attibutes` typo in the same block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)