### PR TITLE
Fix drifted docstrings: `TimberModel` accessors, joint lifecycle sentence, solver candidate pairs

### DIFF
--- a/src/compas_timber/base.py
+++ b/src/compas_timber/base.py
@@ -194,7 +194,7 @@ class TimberElement(Element, abc.ABC):
     @reset_timber_attrs
     def add_features(self, features):
         # type: (BTLxProcessing | list[BTLxProcessing]) -> None
-        """Adds one or more features to the beam.
+        """Adds one or more features to the element.
 
         Parameters
         ----------
@@ -210,7 +210,7 @@ class TimberElement(Element, abc.ABC):
     @reset_timber_attrs
     def remove_features(self, features=None):
         # type: (None | BTLxProcessing | list[BTLxProcessing]) -> None
-        """Removes a feature from the beam.
+        """Removes one or more features from the element.
 
         Parameters
         ----------

--- a/src/compas_timber/connections/l_french_ridge_lap.py
+++ b/src/compas_timber/connections/l_french_ridge_lap.py
@@ -54,7 +54,7 @@ class LFrenchRidgeLapJoint(LapJoint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -80,7 +80,7 @@ class LFrenchRidgeLapJoint(LapJoint):
     def add_features(self):
         """Adds the necessary features to the beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
         It is executed after the beam extensions have been added via `Joint.add_extensions()`.
 
         """

--- a/src/compas_timber/connections/l_french_ridge_lap.py
+++ b/src/compas_timber/connections/l_french_ridge_lap.py
@@ -54,7 +54,7 @@ class LFrenchRidgeLapJoint(LapJoint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -80,9 +80,8 @@ class LFrenchRidgeLapJoint(LapJoint):
     def add_features(self):
         """Adds the necessary features to the beams.
 
-        This method is called during the `Model.process_joinery()` process after the joint
-        has been instantiated and added to the model. It is executed after the beam extensions
-        have been added via `Joint.add_extensions()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
+        It is executed after the beam extensions have been added via `Joint.add_extensions()`.
 
         """
         assert self.beam_a and self.beam_b

--- a/src/compas_timber/connections/l_miter.py
+++ b/src/compas_timber/connections/l_miter.py
@@ -280,7 +280,7 @@ class LMiterJoint(Joint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -310,7 +310,7 @@ class LMiterJoint(Joint):
     def add_features(self):
         """Adds the required extension and trimming features to both beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         """
         assert self.beam_a and self.beam_b

--- a/src/compas_timber/connections/l_miter.py
+++ b/src/compas_timber/connections/l_miter.py
@@ -280,7 +280,7 @@ class LMiterJoint(Joint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -310,7 +310,7 @@ class LMiterJoint(Joint):
     def add_features(self):
         """Adds the required extension and trimming features to both beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         """
         assert self.beam_a and self.beam_b

--- a/src/compas_timber/connections/l_tenon_mortise.py
+++ b/src/compas_timber/connections/l_tenon_mortise.py
@@ -88,7 +88,7 @@ class LTenonMortiseJoint(MortiseTenonJoint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -116,7 +116,7 @@ class LTenonMortiseJoint(MortiseTenonJoint):
     def add_features(self):
         """Adds the required trimming features to both beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         """
         assert self.main_beam and self.cross_beam  # should never happen

--- a/src/compas_timber/connections/l_tenon_mortise.py
+++ b/src/compas_timber/connections/l_tenon_mortise.py
@@ -88,7 +88,7 @@ class LTenonMortiseJoint(MortiseTenonJoint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -116,7 +116,7 @@ class LTenonMortiseJoint(MortiseTenonJoint):
     def add_features(self):
         """Adds the required trimming features to both beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         """
         assert self.main_beam and self.cross_beam  # should never happen

--- a/src/compas_timber/connections/oligina.py
+++ b/src/compas_timber/connections/oligina.py
@@ -30,7 +30,7 @@ class TOliGinaJoint(MortiseTenonJoint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         Raises
         ------

--- a/src/compas_timber/connections/oligina.py
+++ b/src/compas_timber/connections/oligina.py
@@ -30,7 +30,7 @@ class TOliGinaJoint(MortiseTenonJoint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         Raises
         ------

--- a/src/compas_timber/connections/solver.py
+++ b/src/compas_timber/connections/solver.py
@@ -105,7 +105,11 @@ class ConnectionSolver(object):
 
     @classmethod
     def find_intersecting_pairs(cls, beams, rtree=False, max_distance=0.0):
-        """Finds pairs of intersecting beams in the given list of beams.
+        """Generates candidate pairs of beams for topology checking.
+
+        This method does not test for intersection. When `rtree` is True, candidates are pairs of beams
+        whose axis-aligned bounding boxes overlap; when False, all possible pairs are returned and the
+        geometry is not consulted.
 
         Parameters
         ----------
@@ -114,13 +118,14 @@ class ConnectionSolver(object):
         rtree : bool
             When set to True R-tree will be used to search for neighboring beams.
         max_distance : float, optional
-            When `rtree` is True, an additional distance apart with which
-            non-touching beams are still considered intersecting.
+            When `rtree` is True, beams whose bounding boxes are up to this distance apart are still
+            considered neighboring. Ignored when `rtree` is False.
 
         Returns
         -------
-        list(set(:class:`~compas_timber.elements.Beam`, :class:`~compas_timber.elements.Beam`))
-            List containing sets or neightboring pairs beams.
+        iterable
+            Candidate pairs of beams. A list of sets of two beams when `rtree` is True, an iterator of
+            all possible pairs as tuples otherwise.
 
         """
         return find_neighboring_elements(beams, inflate_by=max_distance) if rtree else itertools.combinations(beams, 2)

--- a/src/compas_timber/connections/t_birdsmouth.py
+++ b/src/compas_timber/connections/t_birdsmouth.py
@@ -69,7 +69,7 @@ class TBirdsmouthJoint(Joint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -95,7 +95,7 @@ class TBirdsmouthJoint(Joint):
     def add_features(self):
         """Adds the required trimming features to both beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         """
 

--- a/src/compas_timber/connections/t_birdsmouth.py
+++ b/src/compas_timber/connections/t_birdsmouth.py
@@ -69,7 +69,7 @@ class TBirdsmouthJoint(Joint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -95,7 +95,7 @@ class TBirdsmouthJoint(Joint):
     def add_features(self):
         """Adds the required trimming features to both beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         """
 

--- a/src/compas_timber/connections/t_dovetail.py
+++ b/src/compas_timber/connections/t_dovetail.py
@@ -179,7 +179,7 @@ class TDovetailJoint(Joint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -206,7 +206,7 @@ class TDovetailJoint(Joint):
     def add_features(self):
         """Adds the required trimming features to both beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         """
         assert self.main_beam and self.cross_beam  # should never happen

--- a/src/compas_timber/connections/t_dovetail.py
+++ b/src/compas_timber/connections/t_dovetail.py
@@ -179,7 +179,7 @@ class TDovetailJoint(Joint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -206,7 +206,7 @@ class TDovetailJoint(Joint):
     def add_features(self):
         """Adds the required trimming features to both beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         """
         assert self.main_beam and self.cross_beam  # should never happen

--- a/src/compas_timber/connections/t_lap.py
+++ b/src/compas_timber/connections/t_lap.py
@@ -53,7 +53,7 @@ class TLapJoint(LapJoint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -83,7 +83,7 @@ class TLapJoint(LapJoint):
     def add_features(self):
         """Adds the required extension and trimming features to both beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         """
         assert self.main_beam and self.cross_beam

--- a/src/compas_timber/connections/t_lap.py
+++ b/src/compas_timber/connections/t_lap.py
@@ -53,7 +53,7 @@ class TLapJoint(LapJoint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -83,7 +83,7 @@ class TLapJoint(LapJoint):
     def add_features(self):
         """Adds the required extension and trimming features to both beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         """
         assert self.main_beam and self.cross_beam

--- a/src/compas_timber/connections/t_step_joint.py
+++ b/src/compas_timber/connections/t_step_joint.py
@@ -160,7 +160,7 @@ class TStepJoint(Joint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -184,7 +184,7 @@ class TStepJoint(Joint):
     def add_features(self):
         """Adds the required trimming features to both beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         """
         assert self.main_beam and self.cross_beam  # should never happen

--- a/src/compas_timber/connections/t_step_joint.py
+++ b/src/compas_timber/connections/t_step_joint.py
@@ -160,7 +160,7 @@ class TStepJoint(Joint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -184,7 +184,7 @@ class TStepJoint(Joint):
     def add_features(self):
         """Adds the required trimming features to both beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         """
         assert self.main_beam and self.cross_beam  # should never happen

--- a/src/compas_timber/connections/t_tenon_mortise.py
+++ b/src/compas_timber/connections/t_tenon_mortise.py
@@ -71,7 +71,7 @@ class TTenonMortiseJoint(MortiseTenonJoint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -92,7 +92,7 @@ class TTenonMortiseJoint(MortiseTenonJoint):
     def add_features(self):
         """Adds the required trimming features to both beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         """
         assert self.main_beam and self.cross_beam  # should never happen

--- a/src/compas_timber/connections/t_tenon_mortise.py
+++ b/src/compas_timber/connections/t_tenon_mortise.py
@@ -71,7 +71,7 @@ class TTenonMortiseJoint(MortiseTenonJoint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -92,7 +92,7 @@ class TTenonMortiseJoint(MortiseTenonJoint):
     def add_features(self):
         """Adds the required trimming features to both beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         """
         assert self.main_beam and self.cross_beam  # should never happen

--- a/src/compas_timber/connections/x_lap.py
+++ b/src/compas_timber/connections/x_lap.py
@@ -39,7 +39,7 @@ class XLapJoint(LapJoint):
     def add_features(self):
         """Adds the required extension and trimming features to both beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         """
         assert self.beam_a and self.beam_b

--- a/src/compas_timber/connections/x_lap.py
+++ b/src/compas_timber/connections/x_lap.py
@@ -39,7 +39,7 @@ class XLapJoint(LapJoint):
     def add_features(self):
         """Adds the required extension and trimming features to both beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         """
         assert self.beam_a and self.beam_b

--- a/src/compas_timber/connections/x_notch.py
+++ b/src/compas_timber/connections/x_notch.py
@@ -101,7 +101,7 @@ class XNotchJoint(Joint):
     def add_features(self):
         """Adds the required extension and trimming features to both beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         """
         assert self.notch_beam and self.solid_beam

--- a/src/compas_timber/connections/x_notch.py
+++ b/src/compas_timber/connections/x_notch.py
@@ -101,7 +101,7 @@ class XNotchJoint(Joint):
     def add_features(self):
         """Adds the required extension and trimming features to both beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         """
         assert self.notch_beam and self.solid_beam

--- a/src/compas_timber/connections/y_butt.py
+++ b/src/compas_timber/connections/y_butt.py
@@ -125,7 +125,7 @@ class YButtJoint(Joint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -171,7 +171,7 @@ class YButtJoint(Joint):
     def add_features(self):
         """Adds the required extension and trimming features to both beams.
 
-        This method is automatically called when joint is created by the call to `Joint.create()`.
+        This method is called during `Model.process_joinery()`, not when the joint is created.
 
         """
 

--- a/src/compas_timber/connections/y_butt.py
+++ b/src/compas_timber/connections/y_butt.py
@@ -125,7 +125,7 @@ class YButtJoint(Joint):
     def add_extensions(self):
         """Calculates and adds the necessary extensions to the beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         Raises
         ------
@@ -171,7 +171,7 @@ class YButtJoint(Joint):
     def add_features(self):
         """Adds the required extension and trimming features to both beams.
 
-        This method is called during `Model.process_joinery()`, not when the joint is created.
+        This method is called during `TimberModel.process_joinery()`, not when the joint is created.
 
         """
 

--- a/src/compas_timber/errors.py
+++ b/src/compas_timber/errors.py
@@ -94,11 +94,13 @@ class FastenerApplicationError(Exception):
 
 
 class BTLxProcessingError(Exception):
-    """Exception raised when an error occurs while writing a Processing to BTLx file.
+    """Error which occurred while writing a Processing to a BTLx file.
+
+    This error is not raised but rather collected by ``BTLxWriter`` and exposed via its ``errors`` property.
 
     TODO: some work here to figure out the different types of feature/processing related errors.
     TODO: this one is somewhat similar to FeatureApplicationError, but only relevant when processing is created from its proxy.
-    TOOD: also BTLxProcessingError is never throws but rather collected to form some sort of a report for the user.
+    TODO: also BTLxProcessingError is never throws but rather collected to form some sort of a report for the user.
 
     Parameters
     ----------

--- a/src/compas_timber/fabrication/btlx.py
+++ b/src/compas_timber/fabrication/btlx.py
@@ -342,10 +342,10 @@ class BTLxWriter(object):
 
         Parameters
         ----------
-        type_ : type
-            The type to be serialized.
+        type_ : str
+            The name of the type to be serialized, i.e. its ``__name__`` attribute.
         serializer : callable
-            The serializer function. Takes an instance of `type_` and returns an XML element which correspondes with it.
+            The serializer function. Takes an instance of the named type and returns an XML element which corresponds with it.
 
         """
         cls.SERIALIZERS[type_] = serializer

--- a/src/compas_timber/model.py
+++ b/src/compas_timber/model.py
@@ -32,18 +32,22 @@ class TimberModel(Model):
 
     Attributes
     ----------
-    beams : Generator[:class:`~compas_timber.elements.Beam`]
-        A Generator object of all beams assigned to this model.
-    plates : Generator[:class:`~compas_timber.elements.Plate`]
-        A Generator object of all plates assigned to this model.
-    joints : set[:class:`~compas_timber.connections.Joint`]
-        A set of all actual joints assigned to this model.
+    beams : list[:class:`~compas_timber.elements.Beam`]
+        A list of all beams assigned to this model.
+    plates : list[:class:`~compas_timber.elements.Plate`]
+        A list of all plates assigned to this model.
+    joints : Iterable[:class:`~compas_timber.connections.Joint`]
+        A view of all actual joints assigned to this model.
     joint_candidates : set[:class:`~compas_timber.connections.JointCandidate`]
         A set of all joint candidates in the model.
-    panels : Generator[:class:`~compas_timber.elements.Panel`]
-        A Generator object of all panels assigned to this model.
+    unpromoted_joint_candidates : set[:class:`~compas_timber.connections.JointCandidate`]
+        A set of all joint candidates in the model which have not been promoted to joints.
+    panels : list[:class:`~compas_timber.elements.Panel`]
+        A list of all panels assigned to this model.
     layers : list[:class:`~compas_timber.elements.Layer`]
-        A Generator object of all layers assigned to this model.
+        A list of all layers assigned to this model.
+    fasteners : list[:class:`~compas_timber.elements.Fastener`]
+        A list of all fasteners assigned to this model.
 
     center_of_mass : :class:`~compas.geometry.Point`
         The calculated center of mass of the model.

--- a/src/compas_timber/rhino/__init__.py
+++ b/src/compas_timber/rhino/__init__.py
@@ -15,7 +15,7 @@ def find_neighboring_elements(elements, inflate_by=0.0):
     Returns
     -------
     list(set(:class:`compas_timber.elements.Beam`))
-        List containing sets or neightboring pairs beams.
+        List containing sets of neighboring beam pairs.
 
     """
     import Rhino

--- a/src/compas_timber/utils/r_tree.py
+++ b/src/compas_timber/utils/r_tree.py
@@ -21,7 +21,7 @@ def find_neighboring_elements(elements, inflate_by=0.0):
     Returns
     -------
     list(set(:class:`~compas_timber.parts.Beam`, :class:`~compas_timber.parts.Beam`))
-        List containing sets of two neightboring beams each.
+        List containing sets of two neighboring beams each.
 
     """
     # insert and search three dimensional data (bounding boxes).


### PR DESCRIPTION
Doc-only sweep, no behavior change.

- `TimberModel` attributes block: the element accessors have returned lists since the `find_all_elements_of_type` refactor, but the class docstring still said Generators (the inline `# type:` comments were already updated). Also adds the missing `fasteners` and `unpromoted_joint_candidates` entries.
- The sentence "This method is automatically called when joint is created by the call to `Joint.create()`" predates `process_joinery()` and survived in 20 docstrings across 12 connections files; replaced with "called during `TimberModel.process_joinery()`, not when the joint is created" — phrased so it stays true for `CompositeJoint` sub-joints, which are never added to the model.
- `find_intersecting_pairs`: the docstring half of #821 (the rename stays off the table) — it generates candidate pairs rather than testing intersection, and `max_distance` is silently ignored when `rtree=False`. Also fixes the "neightboring" typo here and in the two `find_neighboring_elements` plugins.
- `BTLxProcessingError` is collected by `BTLxWriter` and exposed via its `errors` property, never raised — the summary line said otherwise (the class's own third TODO knew this, with a `TOOD` typo, now fixed).
- `register_type_serializer` takes a type *name* string, not a type — both in-repo registrations pass `__name__`, and this matches its sibling `register_type_deserializer`.
- `add_features`/`remove_features`: "beam" → "element", follow-up to #836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
